### PR TITLE
MSC2746: Improved VoIP Signalling

### DIFF
--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -18,7 +18,7 @@ Matrix has basic support for signalling 1:1 WebRTC calls, but has a number of sh
 ### Change the `version` field in all VoIP events to `1`
 This will be used to determine whether determine whether devices support this new version of the protocol.
 If clients see events with `version` other than `0` or `1`, they should treat these the same as if they had
-`version` == `1`. In addition, clients must accept either a number or a string for the value of the `version`
+`version` == `1`. In addition, clients must accept either the number `0` or a string for the value of the `version`
 field, in order to allow for namespaced versions in the future.
 
 ### Define the configurations of WebRTC streams and tracks in each call type

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -18,7 +18,8 @@ Matrix has basic support for signalling 1:1 WebRTC calls, but has a number of sh
 ### Change the `version` field in all VoIP events to `1`
 This will be used to determine whether determine whether devices support this new version of the protocol.
 If clients see events with `version` other than `0` or `1`, they should treat these the same as if they had
-`version` == `1`.
+`version` == `1`. In addition, clients must accept either a number or a string for the value of the `version`
+field, in order to allow for namespaced versions in the future.
 
 ### Add `invitee` field to `m.call.invite`
 This allows for the following use cases:

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -76,8 +76,8 @@ Example:
 ### Introduce `m.call.reject`
 
  * If the `m.call.invite` event has `version` `1`, a client wishing to reject the call
-   sends an `m.call.reject` event. This rejects the call on all devices, but if another device
-   has already sent an accept, it disregards the reject and carries on. The reject has a
+   sends an `m.call.reject` event. This rejects the call on all devices, but if the calling
+   device sees an accept, it disregards the reject event and carries on. The reject has a
    `party_id` just like an answer, and the caller sends a `select_answer` for it just like an
    answer. If the other client that had already sent an answer sees the caller select the
    reject response instead of its answer, it ends the call.

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -234,7 +234,15 @@ from the set of `A-Z` `a-z` `0-9` `.-_`.
    callers could be identified by the lack of an `answer_id`. An explicit field on every event may be
    easier to comprehend, less error-prone and clearer in the backwards-compatibility scenario.
  * We could make `party_id`s more prescriptive, eg. the caller could always have a `party_id` of the
-  empty string, the word `caller` or equal to the `call_id`, which may make debugging simpler.
+   empty string, the word `caller` or equal to the `call_id`, which may make debugging simpler.
+ * To allow for bridging into protocols that don't support trickle ICE, this proposal requires that
+   clients send an empty candidate to signal the end of candidates. This means it will be up to bridges
+   to buffer the invite and edit the SDP to add the candidates once they arrive, adding complexity to
+   bridges. The alternative would be a discovery mechanism so clients could know whether a callee supports
+   trickle ICE before calling, and disable it if so. This would add complexity to every Matrix client as
+   well as having to assume that all current clients did not, disabling trickle ICE everywhere until clients
+   support the discovery mechanism. The mechanism would also have to be per-user which would make sense for
+   bridged users, but not where some of a users devices support trickle ICE and some do not.
 
 ## Security considerations
  * IP addresses remain in the room in candidates, as they did in the previous version of the spec.

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -236,6 +236,11 @@ The same behaviour applies when a client is looking at historic calls.
    had categorised it as a junk call and not the other would be confusing for the user.
 
 ## Alternatives
+ * This MSC does not allow for ICE negotiation before the user chooses to answer the call. This can
+   make call setup faster by allowing connectivity to be established whilst the call is ringing. This
+   is problematic with Matrix since any device or user could answer the call, so it is not known which
+   device is going to answer before the user chooses to answer. It would also leak information on which
+   of a user's devices were online.
  * We could define that the ID of a call is implcitly the event IDs of the invite event rather than
    having a specific `call_id` field. This would mean that a client would be unable to know the ID of
    a call before the remote echo of the invite came back, which could complicate implementations.

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -185,6 +185,16 @@ Clients should aim to send a small number of candidate events, with guidelines:
    invite or 500ms after sending the answer is suggested as starting point (since a delay is natural
    anyway after the invite whilst the client waits for the user to accept it).
 
+### Mandate the end-of-candidates candidate
+Mandate that an ICE candidate whose value is the empty string must be sent in an m.call.candidates
+message to signal that no more ICE candidates will be sent. The WebRTC spec requires browsers to
+generate such a candidate, however note that at time of writing, not all browsers do (Chrome does
+not). The client should send any remaining candidates once candidate generation finishes, ignoring
+timeouts above.
+
+This allows bridges to batch the candidates together when bridging to protocols that don't support
+trickle ICE.
+
 ### Add DTMF
 Add that Matrix clients can send DTMF as specified by WebRTC. The WebRTC standard as of August
 2020 does not support receiving DTMF but a Matrix client can receive and interpret the DTMF sent

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -231,7 +231,7 @@ in the RTP payload.
 `call_id`s and the newly introduced `party_id` are explicitly defined to be up to 32 characters
 from the set of `A-Z` `a-z` `0-9` `.-_`.
 
-### Specify behhaviour on room leave
+### Specify behaviour on room leave
 If the client sees the party it is in a call with leave the room, the client should treat this
 as a hangup event for any calls that are in progress. No specific requirement is given for the
 situation where a client has sent an invite and the invitee leaves the room, but the client may

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -291,7 +291,7 @@ The same behaviour applies when a client is looking at historic calls.
 
 ## Unstable prefix
 Since VoIP events already have a 'version' field, we would ideally use a string, namespaced version during
-development, but this field is defined to be a string in version 0. This MSC proposes changing the version
+development, but this field is defined to be an int in version 0. This MSC proposes changing the version
 field to a string so that this namespacing can be used for future changes. Since there is no other easy way
 to namespace events whilst in development and ensure interoperability, we have chosen not to use an unstable
 prefix for this change, on the understanding that in future we will be able to use the string `version` field

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -240,6 +240,13 @@ wish to treat it as a rejection if there are no more users in the room who could
 
 The same behaviour applies when a client is looking at historic calls.
 
+### Clarify that supported codecs should follow the WebRTC spec
+The Matrix spec does not mandate particular audio or video codecs, but instead defers to the
+WebRTC spec. A compliant matrix VoIP client will behave in the same wau as a supported 'browser'
+in terms of what codecs it supports and what variants thereof. The latest WebRTC specification
+applies, so clients should keeps up to date with new versions of the WebRTC specification whether
+or not there have been any changes to the Matrix spec.
+
 ## Potential issues
  * The ability to call yourself makes the protocol a little more complex for clients to implement,
    and is somewhat of a special case. However, some of the necessary additions are also required for

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -252,3 +252,11 @@ from the set of `A-Z` `a-z` `0-9` `.-_`.
    candidates) or redacting them afterwards (the volume of events sent during calls can already
    cause rate limiting issues and this would exacerbate this).
  * Clients must take care to not ring for any call, as per the 'alternatives' section.
+
+## Unstable prefix
+Since VoIP events already have a 'version' field, we would ideally use a string, namespaced version during
+development, but this field is defined to be a string in version 0. This MSC proposes changing the version
+field to a string so that this namespacing can be used for future changes. Since there is no other easy way
+to namespace events whilst in development and ensure interoperability, we have chosen not to use an unstable
+prefix for this change, on the understanding that in future we will be able to use the string `version` field
+for the unstable prefix.

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -230,6 +230,11 @@ Add that Matrix clients can send DTMF as specified by WebRTC. The WebRTC standar
 2020 does not support receiving DTMF but a Matrix client can receive and interpret the DTMF sent
 in the RTP payload.
 
+We also add a capability to the `capabilities` section of invites and answers (detailed in
+[MSC2747](https://github.com/matrix-org/matrix-doc/pull/2747) called `m.call.dtmf`. Clients
+should only display UI for sending DTMF during a call if the other party advertises this
+capability (boolean value `true`).
+
 ### Specify exact grammar for VoIP IDs
 `call_id`s and the newly introduced `party_id` are explicitly defined to be up to 32 characters
 from the set of `A-Z` `a-z` `0-9` `.-_`.

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -158,9 +158,10 @@ party whose invite had the lexicographically greater call ID becomes the polite 
 
 ### Add explicit recommendations for call event liveness.
 `m.call.invite` contains a `lifetime` field that indicates how long the offer is valid for. When
-a client receives an invite, it should use the `age` field of the event plus the time since it
-received the event from the homeserver to determine whether the invite is still valid. If the
-invite is still valid *and will remain valid for long enough for the user to accept the call*,
+a client receives an invite, it should use the event's `age` field in the sync response plus the
+time since it received the event from the homeserver to determine whether the invite is still valid.
+The use of the `age` field ensures that incorrect clocks on client devices don't break calls.
+If the invite is still valid *and will remain valid for long enough for the user to accept the call*,
 it should signal an incoming call. The amount of time allowed for the user to accept the call may
 vary between clients, for example, it may be longer on a locked mobile device than on an unlocked
 desktop device.

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -46,7 +46,10 @@ call. Clients use this to identify remote echo of their own events, since a user
 they can no longer ignore events from their own user. This field also identifies different answers sent
 by different clients to an invite, and matches `m.call.candidate` events to their respective answer/invite.
 
-A client implementation may choose to use the device ID used in end-to-end cryptography for this purpose.
+A client implementation may choose to use the device ID used in end-to-end cryptography for this purpose,
+or it may choose, for example, to use a different one for each call to avoid lekaing information on which
+devices were used in a call (in an unencrypted room) or if a single device (ie. access token were used to
+send signalling for more than one call party.
 
 ### Introduce `m.call.select_answer`
 This event is sent by the caller's client once it has chosen an answer. Its

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -209,6 +209,15 @@ them to be present on events they receive.
 `call_id`s and the newly introduced `party_id` are explicitly defined to be up to 32 characters
 from the set of `A-Z` `a-z` `0-9` `.-_`.
 
+### Specify behhaviour on room leave
+If the client sees the party it is in a call with leave the room, the client should treat this
+as a hangup event for any calls that are in progress. No specific requirement is given for the
+situation where a client has sent an invite and the invitee leaves the room, but the client may
+wish to treat it as a rejection if there are no more users in the room who could answer the call
+(eg. the user is now alone or the `invitee` field was set on the invite).
+
+The same behaviour applies when a client is looking at historic calls.
+
 ## Potential issues
  * The ability to call yourself makes the protocol a little more complex for clients to implement,
    and is somewhat of a special case. However, some of the necessary additions are also required for

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -21,6 +21,19 @@ If clients see events with `version` other than `0` or `1`, they should treat th
 `version` == `1`. In addition, clients must accept either a number or a string for the value of the `version`
 field, in order to allow for namespaced versions in the future.
 
+### Define the configurations of WebRTC streams and tracks in each call type
+We define that:
+ * A voice call has at least one track of kind 'audio' in the first stream
+ * A video call has at least one track of kind 'video' and at least one track of kind 'audio' in the first stream
+Clients implementing this specification use the first stream and will ignore any streamless tracks. Note that
+in the Javascript WebRTC API, this means `addTrack()` must be passed two parameters: a track and a stream,
+not just a track, and in a video call the stream must be the same for both audio and video track.
+
+A client may send other streams and tracks but the behaviour of the other party with respect to presenting
+such streams and tracks is undefined.
+
+This follows the existing known implementations of v0 VoIP.
+
 ### Add `invitee` field to `m.call.invite`
 This allows for the following use cases:
  * Placing a call to a specifc user in a room where other users are also present.

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -189,8 +189,8 @@ Clients should aim to send a small number of candidate events, with guidelines:
 Mandate that an ICE candidate whose value is the empty string must be sent in an m.call.candidates
 message to signal that no more ICE candidates will be sent. The WebRTC spec requires browsers to
 generate such a candidate, however note that at time of writing, not all browsers do (Chrome does
-not). The client should send any remaining candidates once candidate generation finishes, ignoring
-timeouts above.
+not, but does generate an `icegatheringstatechange` event). The client should send any remaining
+candidates once candidate generation finishes, ignoring timeouts above.
 
 This allows bridges to batch the candidates together when bridging to protocols that don't support
 trickle ICE.

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -1,6 +1,6 @@
 # MSC2746: Improved Signalling for 1:1 VoIP
 
-Matrix has basic support for signalling 1:1 WebRTC calls, but has a number of shortcomings:
+Historically, Matrix has basic support for signalling 1:1 WebRTC calls which suffer a number of shortcomings:
 
  * If several devices try to answer the same call, there is no way for them to determine clearly
    that the caller has set up the call with a different device, and no way for the caller to

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -129,7 +129,7 @@ recommendation: https://www.w3.org/TR/webrtc/#hold-functionality
 If both the invite event and the accepted answer event have `version` equal to `1`, either party may
 send `m.call.negotiate` with an `sdp` field to offer new SDP to the other party. This event has
 `call_id` with the ID of the call and `party_id` equal to the client's party ID for that call.
-The caller ignores any negotiate events with `party_id` not equal to the `party_id` of the
+The caller ignores any negotiate events with `party_id` + `user_id` tuple not equal to that of the
 answer it accepted. Clients should use the `party_id` field to ignore the remote echo of their
 own negotiate events.
 

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -164,10 +164,10 @@ with the WebRTC API).
 
 ### Designate one party as 'polite'
 In line with WebRTC perfect negotiation (https://w3c.github.io/webrtc-pc/#perfect-negotiation-example)
-we introduce rules to establish which party is polite. By default, the callee is the polite party.
-In a glare situation, if the client receives an invite whilst preparing to send one, it becomes the callee
-and therefore becomes the polite party. If an invite is received after the client has sent one, the
-party whose invite had the lexicographically greater call ID becomes the polite party.
+we introduce rules to establish which party is polite. The callee is always the polite party. In a
+glare situation, the politenes of a party is therefore determined by whether the inbound or outbound
+call is used: if a client discards its outbound call in favour of an inbound call, it becomes the polite
+party.
 
 ### Add explicit recommendations for call event liveness.
 `m.call.invite` contains a `lifetime` field that indicates how long the offer is valid for. When

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -190,6 +190,10 @@ in the RTP payload.
 These are redundant: clients should continue to send them but must not require
 them to be present on events they receive.
 
+### Specify exact grammar for VoIP IDs
+`call_id`s and the newly introduced `party_id` are explicitly defined to be up to 32 characters
+from the set of `A-Z` `a-z` `0-9` `.-_`.
+
 ## Potential issues
  * The ability to call yourself makes the protocol a little more complex for clients to implement,
    and is somewhat of a special case. However, some of the necessary additions are also required for

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -133,6 +133,9 @@ The client may:
    `user_hangup`.
  * `user_media_failed`: The client was unable to start capturing media in such a way as it is unable
    to continue the call.
+ * `user_busy`: The user is busy. Note that this exists primarily for bridging to other networks such
+   as the PSTN. A Matrix client that receives a call whilst already in a call would not generally reject
+   the new call unless the user had specifically chosen to do so.
  * `unknown_error`: Some other failure occurred that meant the client was unable to continue the call
    rather than the user choosing to end it.
 

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -242,9 +242,9 @@ The same behaviour applies when a client is looking at historic calls.
 
 ### Clarify that supported codecs should follow the WebRTC spec
 The Matrix spec does not mandate particular audio or video codecs, but instead defers to the
-WebRTC spec. A compliant matrix VoIP client will behave in the same wau as a supported 'browser'
+WebRTC spec. A compliant matrix VoIP client will behave in the same way as a supported 'browser'
 in terms of what codecs it supports and what variants thereof. The latest WebRTC specification
-applies, so clients should keeps up to date with new versions of the WebRTC specification whether
+applies, so clients should keep up to date with new versions of the WebRTC specification whether
 or not there have been any changes to the Matrix spec.
 
 ## Potential issues

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -80,6 +80,7 @@ Example:
 {
     "type": "m.call.select_answer",
     "content": {
+        "version": 1,
         "call_id": "12345",
         "party_id": "67890",
         "selected_party_id": "111213",

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -317,4 +317,4 @@ prefix for this change, on the understanding that in future we will be able to u
 for the unstable prefix.
 
 For backwards compatibility, strongly typed implementations should allow for
-`version` to be both integer and string.
+`version` to either be a string or the integer `0`.

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -36,7 +36,9 @@ be for it to simply use a separate set of event types.
 
 ### Define the configurations of WebRTC streams and tracks
 
-Clients are expected to send one stream with one track of kind `audio` (creating
+The [spec](https://spec.matrix.org/v1.5/client-server-api/#voice-over-ip) does not currently define
+the WebRTC streams and tracks that should be sent. Under this proposal,
+clients are expected to send one stream with one track of kind `audio` (creating a
 voice call). They can optionally send a second track in the same stream of kind
 `video` (creating a video call).
 

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -56,9 +56,11 @@ This allows for the following use cases:
  * Placing a call to a specifc user in a room where other users are also present.
  * Placing a call to oneself.
 
-The field should be added for all invites where the target is a specific user. Invites without an `invitee`
-field are defined to be intended for any member of the room other than the sender of the event. Clients
-should consider an incoming call if they see a non-expired invite event where the `invitee` field is either
+The field should be added for all invites where the target is a specific user, and should be set
+to the Matrix user ID of that user. Invites without an `invitee`
+field are defined to be intended for any member of the room other than the sender of the event. 
+
+Clients should consider an incoming call if they see a non-expired invite event where the `invitee` field is either
 absent or equal to their user's Matrix ID, however they should evaluate whether or not to ring based on their
 user's trust relationship with the callers and/or where the call was placed. As a starting point, it is
 suggested that clients ignore call invites from users in public rooms. It is strongly recommended that
@@ -82,6 +84,8 @@ A client implementation may choose to use the device ID used in end-to-end crypt
 or it may choose, for example, to use a different one for each call to avoid leaking information on which
 devices were used in a call (in an unencrypted room) or if a single device (ie. access token were used to
 send signalling for more than one call party.
+
+A grammar for `party_id` is defined [below](#specify-exact-grammar-for-voip-ids).
 
 ### Introduce `m.call.select_answer`
 This event is sent by the caller's client once it has chosen an answer. Its

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -106,7 +106,7 @@ Example:
         "call_id": "12345",
         "party_id": "67890",
         "selected_party_id": "111213",
-    },
+    }
 }
 ```
 
@@ -114,9 +114,9 @@ Example:
 
  * If the `m.call.invite` event has `version` `"1"`, a client wishing to reject the call
    sends an `m.call.reject` event. This rejects the call on all devices, but if the calling
-   device sees an accept, it disregards the reject event and carries on. The reject has a
+   device sees an `answer` before the `reject`, it disregards the reject event and carries on. The reject has a
    `party_id` just like an answer, and the caller sends a `select_answer` for it just like an
-   answer. If the other client that had already sent an answer sees the caller select the
+   answer. If another client had already sent an answer and sees the caller select the
    reject response instead of its answer, it ends the call.
  * If the `m.call.invite` event has `version` `0`, the callee sends an `m.call.hangup` event
    as in spec version 0.

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -25,8 +25,8 @@ This will be used to determine whether devices support this new version of the p
 
 This will be used to determine whether devices support this new version of the protocol. For example,
 clients can use this field to know whether to expect an `m.call.select_answer` event from their
-opponent. If clients see events with `version` other than `0` or `"1"`, they should treat these the
-same as if they had `version` == `"1"` (including the numeric value `1`). In addition, clients must
+opponent. If clients see events with `version` other than `0` or `"1"` (including, for example, the numeric
+value `1`), they should treat these the same as if they had `version` == `"1"`. In addition, clients must
 accept either the number `0` or a string for the value of the `version` field, in order to allow for
 namespaced versions in the future.
 

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -163,6 +163,7 @@ Example:
 {
     "type": "m.call.negotiate",
     "content": {
+        "version": "1",
         "call_id": "12345",
         "party_id": "67890",
         "lifetime": 10000,

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -184,8 +184,8 @@ Example:
 }
 ```
 
-Once an `m.call.negotiate` event is received, the client must respond with an
-event of the same type with type with the SDP answer (`type: "answer"`).
+Once an `m.call.negotiate` event is received, the client must respond with another `m.call.negotiate`
+event, with the SDP answer (with `"type"`: `"answer"`) in the description property.
 
 This MSC also proposes clarifying the `m.call.invite` and `m.call.answer` events to state that
 the `offer` and `answer` fields respectively are objects of type `RTCSessionDescriptionInit`

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -210,6 +210,9 @@ indicate the call has been hung up, rejected, or answered elsewhere, the client 
 If on startup, after processing locally stored events, the client determines that there is an invite
 that is still valid, it should still signal it but only after it has completed a sync from the homeserver.
 
+The minimal recommended lifetime is 90 seconds - this should give the user
+enough time to actually pick up the call.
+
 ### Introduce recommendations for batching of ICE candidates
 Clients should aim to send a small number of candidate events, with guidelines:
  * ICE candidates which can be discovered immediately or almost immediately in the invite/answer

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -26,9 +26,7 @@ This will be used to determine whether devices support this new version of the p
 This will be used to determine whether devices support this new version of the protocol. For example,
 clients can use this field to know whether to expect an `m.call.select_answer` event from their
 opponent. If clients see events with `version` other than `0` or `"1"` (including, for example, the numeric
-value `1`), they should treat these the same as if they had `version` == `"1"`. In addition, clients must
-accept either the number `0` or a string for the value of the `version` field, in order to allow for
-namespaced versions in the future.
+value `1`), they should treat these the same as if they had `version` == `"1"`.
 
 Note that this implies any and all future versions of VoIP events should be backwards-compatible.
 If it does become necessary to introduce a non backwards-compatible VoIP spec, the intention would

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -76,7 +76,7 @@ lowercase alphanumeric characters is recommended. Parties in the call are identi
 
 The client  adds a `party_id` field containing this ID to the top-level of the content of all VoIP events
 it sends on the call, including `m.call.invite`. Clients use this to identify remote echo of their own
-events, since a user may now call themselves, they can no longer ignore events from their own user. This
+events: since a user may now call themselves, they can no longer ignore events from their own user. This
 field also identifies different answers sent by different clients to an invite, and matches `m.call.candidates`
 events to their respective answer/invite.
 

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -286,10 +286,10 @@ or not there have been any changes to the Matrix spec.
    is problematic with Matrix since any device or user could answer the call, so it is not known which
    device is going to answer before the user chooses to answer. It would also leak information on which
    of a user's devices were online.
- * We could define that the ID of a call is implcitly the event IDs of the invite event rather than
+ * We could define that the ID of a call is implcitly the event ID of the invite event rather than
    having a specific `call_id` field. This would mean that a client would be unable to know the ID of
-   a call before the remote echo of the invite came back, which could complicate implementations.
-   There is probably no compelling reason to change this.
+   a call before the it received the response from sending the invite event, which could complicate
+   implementations. There is probably no compelling reason to change this.
  * `m.call.select_answer` was chosen such that its name reflect the intention of the event. `m.call.ack`
    is more succinct and mirrors SIP, but this MSC opts for the more descriptive name.
  * This MSC elects to allow invites without an `invitee` field to mean a call for anyone in the room.

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -138,15 +138,15 @@ as previously.
 
 ### Clarify what actions a client may take in response to an invite
 The client may:
- * Attempt to accept the call by sending an answer
- * Actively reject the call everywhere: reject the call as per above, which will stop the call from
+ * Attempt to accept the call by sending an `m.call.answer`.
+ * Actively reject the call everywhere: send an `m.call.reject` as per above, which will stop the call from
    ringing on all the user's devices and the caller's client will inform them that the user has
    rejected their call.
  * Ignore the call: send no events, but stop alerting the user about the call. The user's other
    devices will continue to ring, and the caller's device will continue to indicate that the call
    is ringing, and will time the call out in the normal way if no other device responds.
 
-### Introduce more reason codes to `m.call.hangup`
+### Introduce more reason codes to [`m.call.hangup`](https://spec.matrix.org/v1.5/client-server-api/#mcallhangup)
  * `ice_timeout`: The connection failed after some media was exchanged (as opposed to current
    `ice_failed` which means no media connection could be established). Note that, in the case of
    an ICE renegotiation, a client should be sure to send `ice_timeout` rather than `ice_failed` if
@@ -154,7 +154,7 @@ The client may:
  * `user_hangup`: Clients must now send this code when the user chooses to end the call, although
    for backwards compatability with version 0, a clients should treat an absence of the `reason`
    field as `user_hangup`.
- * `user_media_failed`: The client was unable to start capturing media in such a way as it is unable
+ * `user_media_failed`: The client was unable to start capturing media in such a way that it is unable
    to continue the call.
  * `user_busy`: The user is busy. Note that this exists primarily for bridging to other networks such
    as the PSTN. A Matrix client that receives a call whilst already in a call would not generally reject
@@ -220,7 +220,7 @@ time since it received the event from the homeserver to determine whether the in
 The use of the `age` field ensures that incorrect clocks on client devices don't break calls.
 If the invite is still valid *and will remain valid for long enough for the user to accept the call*,
 it should signal an incoming call. The amount of time allowed for the user to accept the call may
-vary between clients, for example, it may be longer on a locked mobile device than on an unlocked
+vary between clients. For example, it may be longer on a locked mobile device than on an unlocked
 desktop device.
 
 The client should only signal an incoming call in a given room once it has completed processing the
@@ -261,7 +261,7 @@ Add that Matrix clients can send DTMF as specified by WebRTC. The WebRTC standar
 in the RTP payload.
 
 We also add a capability to the `capabilities` section of invites and answers (detailed in
-[MSC2747](https://github.com/matrix-org/matrix-doc/pull/2747) called `m.call.dtmf`. Clients
+[MSC2747](https://github.com/matrix-org/matrix-doc/pull/2747)) called `m.call.dtmf`. Clients
 should only display UI for sending DTMF during a call if the other party advertises this
 capability (boolean value `true`).
 
@@ -270,7 +270,7 @@ capability (boolean value `true`).
 'opaque IDs' from [MSC1597](https://github.com/matrix-org/matrix-spec-proposals/blob/rav/proposals/id_grammar/proposals/1597-id-grammar.md#opaque-ids).
 
 ### Specify behaviour on room leave
-If the client sees the party it is in a call with leave the room, the client should treat this
+If the client sees the user it is in a call with leave the room, the client should treat this
 as a hangup event for any calls that are in progress. No specific requirement is given for the
 situation where a client has sent an invite and the invitee leaves the room, but the client may
 wish to treat it as a rejection if there are no more users in the room who could answer the call

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -246,7 +246,7 @@ Clients should aim to send a small number of candidate events, with guidelines:
    anyway after the invite whilst the client waits for the user to accept it).
 
 ### Mandate the end-of-candidates candidate
-Mandate that an ICE candidate whose value is the empty string must be sent in an m.call.candidates
+Define that an ICE candidate whose value is the empty string must be sent in an m.call.candidates
 message to signal that no more ICE candidates will be sent. The WebRTC spec requires browsers to
 generate such a candidate, however note that at time of writing, not all browsers do (Chrome does
 not, but does generate an `icegatheringstatechange` event). The client should send any remaining

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -51,7 +51,7 @@ such streams and tracks is undefined.
 
 This follows the existing known implementations of v0 VoIP.
 
-### Add `invitee` field to `m.call.invite`
+### Add `invitee` field to [`m.call.invite`](https://spec.matrix.org/v1.5/client-server-api/#mcallinvite)
 This allows for the following use cases:
  * Placing a call to a specifc user in a room where other users are also present.
  * Placing a call to oneself.

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -64,7 +64,7 @@ Clients should consider an incoming call if they see a non-expired invite event 
 absent or equal to their user's Matrix ID, however they should evaluate whether or not to ring based on their
 user's trust relationship with the callers and/or where the call was placed. As a starting point, it is
 suggested that clients ignore call invites from users in public rooms. It is strongly recommended that
-when clients do not ring for an incoming call invite, they still display the invite in the room and
+when clients do not ring for an incoming call invite, they still display the call invite in the room and
 annotate that it was ignored.
 
 ### Add `party_id` to all VoIP events

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -260,11 +260,6 @@ Add that Matrix clients can send DTMF as specified by WebRTC. The WebRTC standar
 2020 does not support receiving DTMF but a Matrix client can receive and interpret the DTMF sent
 in the RTP payload.
 
-We also add a capability to the `capabilities` section of invites and answers (detailed in
-[MSC2747](https://github.com/matrix-org/matrix-doc/pull/2747)) called `m.call.dtmf`. Clients
-should only display UI for sending DTMF during a call if the other party advertises this
-capability (boolean value `true`).
-
 ### Specify exact grammar for VoIP IDs
 `call_id`s and the newly introduced `party_id` are explicitly defined to be between 1 
 and 255 characters long, consisting of the characters `[0-9a-zA-Z._~-]`. 

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -62,8 +62,8 @@ both generating an answer at the same time generating the same party ID is vanis
 lowercase alphanumeric characters is recommended. Parties in the call are identified by the tuple of
 `(user_id, party_id)`.
 
-The client  adds a `party_id` field containing this ID alongside the `user_id` field to all VoIP events
-it sends on the call, including `m.call.inbite`. . Clients use this to identify remote echo of their own
+The client  adds a `party_id` field containing this ID to the top-level of the content of all VoIP events
+it sends on the call, including `m.call.invite`. Clients use this to identify remote echo of their own
 events, since a user may now call themselves, they can no longer ignore events from their own user. This
 field also identifies different answers sent by different clients to an invite, and matches `m.call.candidate`
 events to their respective answer/invite.

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -77,7 +77,7 @@ lowercase alphanumeric characters is recommended. Parties in the call are identi
 The client  adds a `party_id` field containing this ID to the top-level of the content of all VoIP events
 it sends on the call, including `m.call.invite`. Clients use this to identify remote echo of their own
 events, since a user may now call themselves, they can no longer ignore events from their own user. This
-field also identifies different answers sent by different clients to an invite, and matches `m.call.candidate`
+field also identifies different answers sent by different clients to an invite, and matches `m.call.candidates`
 events to their respective answer/invite.
 
 A client implementation may choose to use the device ID used in end-to-end cryptography for this purpose,

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -21,10 +21,12 @@ If clients see events with `version` other than `0` or `"1"`, they should treat 
 `version` == `"1"`. In addition, clients must accept either the number `0` or a string for the value of the `version`
 field, in order to allow for namespaced versions in the future.
 
-### Define the configurations of WebRTC streams and tracks in each call type
-We define that:
- * A voice call has at least one track of kind 'audio' in the first stream
- * A video call has at least one track of kind 'video' and at least one track of kind 'audio' in the first stream
+### Define the configurations of WebRTC streams and tracks
+
+Clients are expected to send one stream with one track of kind `audio` (creating
+voice call). They can optionally send a second track in the same stream of kind
+`video` (creating a video call).
+
 Clients implementing this specification use the first stream and will ignore any streamless tracks. Note that
 in the Javascript WebRTC API, this means `addTrack()` must be passed two parameters: a track and a stream,
 not just a track, and in a video call the stream must be the same for both audio and video track.

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -16,7 +16,7 @@ Historically, Matrix has basic support for signalling 1:1 WebRTC calls which suf
 
 ## Proposal
 ### Change the `version` field in all VoIP events to `"1"`
-The version property is changed to `"`1`" in all existing VoIP events
+The version property is changed to `"1"` in all existing VoIP events
 ([`m.call.answer`](https://spec.matrix.org/v1.5/client-server-api/#mcallanswer),
 [`m.call.candidates`](https://spec.matrix.org/v1.5/client-server-api/#mcallcandidates),
 [`m.call.hangup`](https://spec.matrix.org/v1.5/client-server-api/#mcallhangup)

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -16,6 +16,13 @@ Historically, Matrix has basic support for signalling 1:1 WebRTC calls which suf
 
 ## Proposal
 ### Change the `version` field in all VoIP events to `"1"`
+The version property is changed to `"`1`" in all existing VoIP events
+([`m.call.answer`](https://spec.matrix.org/v1.5/client-server-api/#mcallanswer),
+[`m.call.candidates`](https://spec.matrix.org/v1.5/client-server-api/#mcallcandidates),
+[`m.call.hangup`](https://spec.matrix.org/v1.5/client-server-api/#mcallhangup)
+[`m.call.invite`](https://spec.matrix.org/v1.5/client-server-api/#mcallinvite)).
+This will be used to determine whether devices support this new version of the protocol.
+
 This will be used to determine whether devices support this new version of the protocol. For example,
 clients can use this field to know whether to expect an `m.call.select_answer` event from their
 opponent. If clients see events with `version` other than `0` or `"1"`, they should treat these the

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -266,8 +266,13 @@ should only display UI for sending DTMF during a call if the other party adverti
 capability (boolean value `true`).
 
 ### Specify exact grammar for VoIP IDs
-`call_id`s and the newly introduced `party_id` are explicitly defined to be in the grammar of
-'opaque IDs' from [MSC1597](https://github.com/matrix-org/matrix-spec-proposals/blob/rav/proposals/id_grammar/proposals/1597-id-grammar.md#opaque-ids).
+`call_id`s and the newly introduced `party_id` are explicitly defined to be between 1 
+and 255 characters long, consisting of the characters `[0-9a-zA-Z._~-]`. 
+
+(Note that this matches the grammar of 'opaque IDs' from  
+[MSC1597](https://github.com/matrix-org/matrix-spec-proposals/blob/rav/proposals/id_grammar/proposals/1597-id-grammar.md#opaque-ids),
+and that of the `id` property of the
+ [`m.login.sso` flow schema](https://spec.matrix.org/v1.5/client-server-api/#definition-mloginsso-flow-schema).)
 
 ### Specify behaviour on room leave
 If the client sees the user it is in a call with leave the room, the client should treat this

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -200,9 +200,10 @@ Once an `m.call.negotiate` event is received, the client must respond with anoth
 event, with the SDP answer (with `"type": "answer"`) in the `description` property.
 
 This MSC also proposes clarifying the `m.call.invite` and `m.call.answer` events to state that
-the `offer` and `answer` fields respectively are objects of type `RTCSessionDescriptionInit`
-(and hence the `type` field, whilst redundant in these events, is included for ease of working
-with the WebRTC API).
+the `offer` and `answer` fields respectively are objects of type `RTCSessionDescriptionInit`.
+Hence the `type` field, whilst redundant in these events, is included for ease of working
+with the WebRTC API and is mandatory. Receiving clients should not attempt to validate the `type` field,
+but simply pass the object into the WebRTC API.
 
 ### Designate one party as 'polite'
 In line with WebRTC perfect negotiation (https://w3c.github.io/webrtc-pc/#perfect-negotiation-example)

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -103,7 +103,8 @@ Example:
    `party_id` just like an answer, and the caller sends a `select_answer` for it just like an
    answer. If the other client that had already sent an answer sees the caller select the
    reject response instead of its answer, it ends the call.
- * If the `m.call.invite` event has `version` `0`, the callee sends an `m.call.hangup` event before.
+ * If the `m.call.invite` event has `version` `0`, the callee sends an `m.call.hangup` event
+   as in spec version 0.
 
 Example:
 ```

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -62,10 +62,11 @@ both generating an answer at the same time generating the same party ID is vanis
 lowercase alphanumeric characters is recommended. Parties in the call are identified by the tuple of
 `(user_id, party_id)`.
 
-The client  adds a `party_id` field containing this ID alongside the `user_id` field to all VoIP events it sends on the
-call. Clients use this to identify remote echo of their own events, since a user may now call themselves,
-they can no longer ignore events from their own user. This field also identifies different answers sent
-by different clients to an invite, and matches `m.call.candidate` events to their respective answer/invite.
+The client  adds a `party_id` field containing this ID alongside the `user_id` field to all VoIP events
+it sends on the call, including `m.call.inbite`. . Clients use this to identify remote echo of their own
+events, since a user may now call themselves, they can no longer ignore events from their own user. This
+field also identifies different answers sent by different clients to an invite, and matches `m.call.candidate`
+events to their respective answer/invite.
 
 A client implementation may choose to use the device ID used in end-to-end cryptography for this purpose,
 or it may choose, for example, to use a different one for each call to avoid leaking information on which

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -16,7 +16,7 @@ Historically, Matrix has basic support for signalling 1:1 WebRTC calls which suf
 
 ## Proposal
 ### Change the `version` field in all VoIP events to `"1"`
-This will be used to determine whether determine whether devices support this new version of the protocol.
+This will be used to determine whether devices support this new version of the protocol.
 If clients see events with `version` other than `0` or `"1"`, they should treat these the same as if they had
 `version` == `"1"`. In addition, clients must accept either the number `0` or a string for the value of the `version`
 field, in order to allow for namespaced versions in the future.

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -208,10 +208,10 @@ with the WebRTC API).
 
 ### Designate one party as 'polite'
 In line with WebRTC perfect negotiation (https://w3c.github.io/webrtc-pc/#perfect-negotiation-example)
-we introduce rules to establish which party is polite. The callee is always the polite party. In a
-glare situation, the politenes of a party is therefore determined by whether the inbound or outbound
-call is used: if a client discards its outbound call in favour of an inbound call, it becomes the polite
-party.
+we introduce rules to establish which party is polite in the process of renegotiation. The callee is
+always the polite party. In a glare situation, the politenes of a party is therefore determined by
+whether the inbound or outbound call is used: if a client discards its outbound call in favour of
+an inbound call, it becomes the polite party.
 
 ### Add explicit recommendations for call event liveness.
 `m.call.invite` contains a `lifetime` field that indicates how long the offer is valid for. When

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -50,10 +50,10 @@ The field should be added for all invites where the target is a specific user. I
 field are defined to be intended for any member of the room other than the sender of the event. Clients
 should consider an incoming call if they see a non-expired invite event where the `invitee` field is either
 absent or equal to their user's Matrix ID, however they should evaluate whether or not to ring based on their
-user's trust relationship with the caller, eg. ignoring call invites from users in public rooms that they have
-no other connection with. As a starting point, it is suggested that clients ring for any call invite from a user
-that they have a direct message room with. It is strongly recommended that when clients do not ring for an
-incoming call invite, they still display the invite in the room and annotate that it was ignored.
+user's trust relationship with the callers and/or where the call was placed. As a starting point, it is
+suggested that clients ignore call invites from users in public rooms. It is strongly recommended that
+when clients do not ring for an incoming call invite, they still display the invite in the room and
+annotate that it was ignored.
 
 ### Add `party_id` to all VoIP events
 Whenever a client first participates in a new call, it generates a `party_id` for itself to use for the

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -199,7 +199,7 @@ Example:
 ```
 
 Once an `m.call.negotiate` event is received, the client must respond with another `m.call.negotiate`
-event, with the SDP answer (with `"type"`: `"answer"`) in the description property.
+event, with the SDP answer (with `"type": "answer"`) in the `description` property.
 
 This MSC also proposes clarifying the `m.call.invite` and `m.call.answer` events to state that
 the `offer` and `answer` fields respectively are objects of type `RTCSessionDescriptionInit`

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -15,10 +15,10 @@ Historically, Matrix has basic support for signalling 1:1 WebRTC calls which suf
    on a different device to be hung up.
 
 ## Proposal
-### Change the `version` field in all VoIP events to `1`
+### Change the `version` field in all VoIP events to `"1"`
 This will be used to determine whether determine whether devices support this new version of the protocol.
-If clients see events with `version` other than `0` or `1`, they should treat these the same as if they had
-`version` == `1`. In addition, clients must accept either the number `0` or a string for the value of the `version`
+If clients see events with `version` other than `0` or `"1"`, they should treat these the same as if they had
+`version` == `"1"`. In addition, clients must accept either the number `0` or a string for the value of the `version`
 field, in order to allow for namespaced versions in the future.
 
 ### Define the configurations of WebRTC streams and tracks in each call type
@@ -80,7 +80,7 @@ Example:
 {
     "type": "m.call.select_answer",
     "content": {
-        "version": 1,
+        "version": "1",
         "call_id": "12345",
         "party_id": "67890",
         "selected_party_id": "111213",
@@ -90,7 +90,7 @@ Example:
 
 ### Introduce `m.call.reject`
 
- * If the `m.call.invite` event has `version` `1`, a client wishing to reject the call
+ * If the `m.call.invite` event has `version` `"1"`, a client wishing to reject the call
    sends an `m.call.reject` event. This rejects the call on all devices, but if the calling
    device sees an accept, it disregards the reject event and carries on. The reject has a
    `party_id` just like an answer, and the caller sends a `select_answer` for it just like an
@@ -103,7 +103,7 @@ Example:
 {
     "type": "m.call.reject",
     "content" : {
-        "version": 1,
+        "version": "1",
         "call_id": "12345",
         "party_id": "67890",
     }
@@ -144,7 +144,7 @@ This introduces SDP negotiation semantics for media pause, hold/resume, ICE rest
 call up/downgrading. Clients should implement & honour hold functionality as per WebRTC's
 recommendation: https://www.w3.org/TR/webrtc/#hold-functionality
 
-If both the invite event and the accepted answer event have `version` equal to `1`, either party may
+If both the invite event and the accepted answer event have `version` equal to `"1"`, either party may
 send `m.call.negotiate` with a `description` field to offer new SDP to the other party. This event has
 `call_id` with the ID of the call and `party_id` equal to the client's party ID for that call.
 The caller ignores any negotiate events with `party_id` + `user_id` tuple not equal to that of the
@@ -311,3 +311,6 @@ field to a string so that this namespacing can be used for future changes. Since
 to namespace events whilst in development and ensure interoperability, we have chosen not to use an unstable
 prefix for this change, on the understanding that in future we will be able to use the string `version` field
 for the unstable prefix.
+
+For backwards compatibility, strongly typed implementations should allow for
+`version` to be both integer and string.

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -245,12 +245,11 @@ Clients should aim to send a small number of candidate events, with guidelines:
    anyway after the invite whilst the client waits for the user to accept it).
 
 ### Mandate the end-of-candidates candidate
-Define that an ICE candidate whose value is the empty string must be sent in an m.call.candidates
-message to signal that no more ICE candidates will be sent. The WebRTC spec requires browsers to
-generate such a candidate, however note that at time of writing, not all browsers do (Chrome does
-not, but does generate an `icegatheringstatechange` event). The client should send any remaining
-candidates once candidate generation finishes, ignoring timeouts above.
-
+Define that an ICE candidate whose value is the empty string means that no more ICE candidates will
+be sent and mandate that clients must send such a candidate in an `m.call.candidates` message.
+The WebRTC spec requires browsers to generate such a candidate, however note that at time of writing,
+not all browsers do (Chrome does not, but does generate an `icegatheringstatechange` event). The
+client should send any remaining candidates once candidate generation finishes, ignoring timeouts above.
 This allows bridges to batch the candidates together when bridging to protocols that don't support
 trickle ICE.
 

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -166,13 +166,16 @@ Example:
         "call_id": "12345",
         "party_id": "67890",
         "lifetime": 10000,
-	"description": {
+        "description": {
             "sdp": "[some sdp]",
             "type": "offer",
 	},
     }
 }
 ```
+
+Once an `m.call.negotiate` event is received, the client must respond with an
+event of the same type with type with the SDP answer (`type: "answer"`).
 
 This MSC also proposes clarifying the `m.call.invite` and `m.call.answer` events to state that
 the `offer` and `answer` fields respectively are objects of type `RTCSessionDescriptionInit`

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -157,7 +157,7 @@ If both the invite event and the accepted answer event have `version` equal to `
 send `m.call.negotiate` with a `description` field to offer new SDP to the other party. This event has
 `call_id` with the ID of the call and `party_id` equal to the client's party ID for that call.
 The caller ignores any negotiate events with `party_id` + `user_id` tuple not equal to that of the
-answer it accepted. Clients should use the `party_id` field to ignore the remote echo of their
+answer it accepted and the callee ignores any negotiate events with `party_id` + `user_id` tuple not equal to that of the caller. Clients should use the `party_id` field to ignore the remote echo of their
 own negotiate events.
 
 This has a `lifetime` field as in `m.call.invite`, after which the sender of the negotiate event

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -26,8 +26,9 @@ This will be used to determine whether devices support this new version of the p
 This will be used to determine whether devices support this new version of the protocol. For example,
 clients can use this field to know whether to expect an `m.call.select_answer` event from their
 opponent. If clients see events with `version` other than `0` or `"1"`, they should treat these the
-same as if they had `version` == `"1"`. In addition, clients must accept either the number `0` or a
-string for the value of the `version` field, in order to allow for namespaced versions in the future.
+same as if they had `version` == `"1"` (including the numeric value `1`). In addition, clients must
+accept either the number `0` or a string for the value of the `version` field, in order to allow for
+namespaced versions in the future.
 
 Note that this implies any and all future versions of VoIP events should be backwards-compatible.
 If it does become necessary to introduce a non backwards-compatible VoIP spec, the intention would

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -300,7 +300,7 @@ or not there have been any changes to the Matrix spec.
    is problematic with Matrix since any device or user could answer the call, so it is not known which
    device is going to answer before the user chooses to answer. It would also leak information on which
    of a user's devices were online.
- * We could define that the ID of a call is implcitly the event ID of the invite event rather than
+ * We could define that the ID of a call is implicitly the event ID of the invite event rather than
    having a specific `call_id` field. This would mean that a client would be unable to know the ID of
    a call before the it received the response from sending the invite event, which could complicate
    implementations. There is probably no compelling reason to change this.

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -246,7 +246,7 @@ Clients should aim to send a small number of candidate events, with guidelines:
 
 ### Mandate the end-of-candidates candidate
 Define that an ICE candidate whose value is the empty string means that no more ICE candidates will
-be sent and mandate that clients must send such a candidate in an `m.call.candidates` message.
+be sent, and mandate that clients must send such a candidate in an `m.call.candidates` message.
 The WebRTC spec requires browsers to generate such a candidate, however note that at time of writing,
 not all browsers do (Chrome does not, but does generate an `icegatheringstatechange` event). The
 client should send any remaining candidates once candidate generation finishes, ignoring timeouts above.

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -137,8 +137,8 @@ The client may:
    an ICE renegotiation, a client should be sure to send `ice_timeout` rather than `ice_failed` if
    media had previously been received successfully, even if the ICE renegotiation itself failed.
  * `user_hangup`: Clients must now send this code when the user chooses to end the call, although
-   for backwards compatability, a clients should treat an absence of the `reason` field as
-   `user_hangup`.
+   for backwards compatability with version 0, a clients should treat an absence of the `reason`
+   field as `user_hangup`.
  * `user_media_failed`: The client was unable to start capturing media in such a way as it is unable
    to continue the call.
  * `user_busy`: The user is busy. Note that this exists primarily for bridging to other networks such

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -16,10 +16,15 @@ Historically, Matrix has basic support for signalling 1:1 WebRTC calls which suf
 
 ## Proposal
 ### Change the `version` field in all VoIP events to `"1"`
-This will be used to determine whether devices support this new version of the protocol.
-If clients see events with `version` other than `0` or `"1"`, they should treat these the same as if they had
-`version` == `"1"`. In addition, clients must accept either the number `0` or a string for the value of the `version`
-field, in order to allow for namespaced versions in the future.
+This will be used to determine whether devices support this new version of the protocol. For example,
+clients can use this field to know whether to expect an `m.call.select_answer` event from their
+opponent. If clients see events with `version` other than `0` or `"1"`, they should treat these the
+same as if they had `version` == `"1"`. In addition, clients must accept either the number `0` or a
+string for the value of the `version` field, in order to allow for namespaced versions in the future.
+
+Note that this implies any and all future versions of VoIP events should be backwards-compatible.
+If it does become necessary to introduce a non backwards-compatible VoIP spec, the intention would
+be for it to simply use a separate set of event types.
 
 ### Define the configurations of WebRTC streams and tracks
 

--- a/proposals/2746-reliable-voip.md
+++ b/proposals/2746-reliable-voip.md
@@ -245,8 +245,8 @@ should only display UI for sending DTMF during a call if the other party adverti
 capability (boolean value `true`).
 
 ### Specify exact grammar for VoIP IDs
-`call_id`s and the newly introduced `party_id` are explicitly defined to be up to 32 characters
-from the set of `A-Z` `a-z` `0-9` `.-_`.
+`call_id`s and the newly introduced `party_id` are explicitly defined to be in the grammar of
+'opaque IDs' from [MSC1597](https://github.com/matrix-org/matrix-spec-proposals/blob/rav/proposals/id_grammar/proposals/1597-id-grammar.md#opaque-ids).
 
 ### Specify behaviour on room leave
 If the client sees the party it is in a call with leave the room, the client should treat this


### PR DESCRIPTION
A proposal introducing a number of mechanisms to 1:1 VoIP calls, adding:
 * Better reliability, especially in the presence of multiple devices
 * Renegotiation (ICE restarts, hold/resume, voice/video upgrade)
 * DTMF

<hr>

Implementation: https://github.com/matrix-org/matrix-js-sdk/tree/develop/src/webrtc

<hr>

[Rendered](https://github.com/matrix-org/matrix-doc/blob/dbkr/msc2746/proposals/2746-reliable-voip.md)

[FCP tickyboxes](https://github.com/matrix-org/matrix-spec-proposals/pull/2746#issuecomment-1348766607)