### PR TITLE
MSC2781: Remove the reply fallbacks from the specification

### DIFF
--- a/proposals/2781-down-with-the-fallbacks.md
+++ b/proposals/2781-down-with-the-fallbacks.md
@@ -1,0 +1,151 @@
+# MSC2781: Deprecate fallbacks in the specification
+
+Currently replies require clients to send and parse a fallback representation of
+the replied to message. Something similar is planned for edits. While at least
+in theory fallbacks should make it simpler to start supporting replies in a new
+client, they actually introduce a lot of complexity and implementation issues
+and block a few valuable features. This MSC proposes to deprecate and eventually
+remove those fallbacks. It is an alternative to
+[MSC2589](https://github.com/matrix-org/matrix-doc/pull/2589), which intends to
+double down on fallbacks.
+
+### Issues with the current fallbacks
+
+#### Stripping the fallback
+
+To reply to a reply, a client needs to strip the existing fallback of the first
+reply. Otherwise replies will just infinitely nest replies. [While the spec doesn't necessarily require that](https://github.com/matrix-org/matrix-doc/issues/1541),
+not doing so risks running into the event size limit, but more importantly, it
+just leads to a bad experience for clients actually relying on the fallback.
+
+Stripping the fallback sadly is not trivial. Most clients did that wrong at some
+point. At the point of writing this, FluffyChat seems to fail stripping the
+fallback, while Riot/Element did fail to do so in the past, when `<mx-reply>`
+tags were not evenly matched. Since clients can send arbitrary byte sequences,
+every client needs to basically parse untrusted input and sanitize it. A normal
+html parser will fail stripping a `</mx-reply><mx-reply></mx-reply>` sequence in
+some cases. If you use a regex to strip the fallback, you may be able to be
+attacked using regex DOS attacks (although that is somewhat mitigated by the
+maximum event size). In the end there are quite a few edge cases, that are not
+covered in the existing specification, since it doesn't specify the exact rules
+to strip a fallback at all.
+
+Stripping the fallback from body is even more complicated, since there is no way
+to distinguish a quote from a reply reliably.
+
+#### Creating a new fallback
+
+To create a new fallback, a client needs to add untrusted html to its own
+events. This is an easy attack vector to inject your own content into someone
+elses reply. While this can be prevented with enough care, since Riot basically
+had to fix this issue twice, it can be expected that other clients can also be
+affected by this.
+
+#### Requirement of html for replies
+
+The spec requires rich replies to have a fallback using html:
+
+> Rich replies MUST have a format of org.matrix.custom.html and therefore a formatted_body alongside the body and appropriate msgtype.
+
+This means you can't reply using only a `body` and you can't reply with an
+image, since those don't have a `formatted_body` property currently. This means
+a text only client, that doesn't want to display html, still needs to support
+html anyway and that new features are blocked, because of fallbacks.
+
+This is also an issue with edits, where the combination of edit fallback and
+reply fallback is somewhat interesting: You need to send a fallback, since the
+event is still a reply, but you can't send a reply relation, since this is an
+edit. So for clients relying on the edit fallback, you send a broken reply
+fallback, that doesn't get stripped, even when the client supports rich replies.
+
+#### Replies leak history
+
+A reply includes the `body` of another event. This means a reply to an event can
+leak data to users, that joined this room at a later point, but shouldn't be
+able to see the event because of visibility rules or encryption. While this
+isn't a big issue, there is still an issue about it: https://github.com/matrix-org/matrix-doc/issues/1654
+
+Replies are also sometimes localized. In those cases they leak the users
+language selection for their client, which may be personal information.
+
+#### Low value of fallbacks
+
+The above issues would be somewhat acceptable, if reply fallbacks would provide
+some value to clients. Generally they don't though. The Qt html renderer breaks
+on `<mx-reply>` tags, so you need to strip them anyway to render replies.
+Bridges usually try to bridge to native replies, so they need to strip the reply
+part (https://github.com/matrix-org/matrix-doc/issues/1541). Even the IRC bridge
+seems to send a custom fallback, because the default fallback is not that
+welcome to the IRC crowd.
+
+Clients that actually use the fallback (original Riot/Android for example) tend
+to do so for quite some while, because the fallbacks are "good enough", but in
+the end that provides a worse experience for everyone involved. For example you
+couldn't see what image was replied to for the longest time. Just "X replied to
+an image with: I like this one" is not valuable, when 3 images were sent.
+
+Only replies to actual text messages have a somewhat reasonable fallback. The
+other ones do not provide any more value than a plain "this is a reply" tag,
+unless the client also already supports event links.
+
+## Proposal
+
+Deprecate the rich reply fallback. Clients should stop sending them and should
+consider treating `<mx-reply>` parts as either something to be unconditionally
+stripped or as something to be escaped as invalid html. In the future the
+fallback should be removed from the spec completely with only a note left, that
+it may exist in old events.
+
+Furthermore, no fallback should be used for edits, since just adding an asterisk
+before the same message does not provide much value to users and it complicates
+the implementation of edits for no tangible benefit.
+
+The fallback for more niche features, like in room verification can stay, since
+that feature is actually somewhat hard to implement and some clients may never
+support encryption.
+
+As a result of this, you would be able to reply with an image or edit a video.
+New clients would also be able to implement edits and replies more easily, as
+they can sidestep a lot of pitfalls.
+
+## Potential issues
+
+Obviously you can't remove the fallback from old events. As such clients would
+still need to do something with them in the near future. I'd say just not
+handling them in a special way should be okay after some unspecified period of
+time.
+
+Clients not implementing rich replies or edits may show some slightly more
+confusing messages to users as well. I'd argue though that in most cases, the
+reply is close enough to the replied to message, that you would be able to guess
+the correct context. Replies would also be somewhat easier to implement and
+worst case, a client could very easily implement a little "this is a reply"
+marker to at least mark replies visually.
+
+Same applies to edits. If 2 very similar messages appear after one another,
+someone new to online messaging would assume, this is a correction to the
+previous message. That may even be more obvious to them than if the message was
+prefixed with a `*`, since that has been confusing to users in the past. Since
+edits would now look exactly like a normal message, they would also be
+considerably easier to implement, since you jus need to replace the former
+message now, similar to a redaction, and not merge `content` and `new_content`.
+
+## Alternatives
+
+[MSC2589](https://github.com/matrix-org/matrix-doc/pull/2589): This adds the
+reply text as an addional key. While this solves the parsing issues, it
+doesn't address the other issues with fallbacks.
+
+One could also just stick with the current fallbacks and make all clients pay
+the cost for a small number of clients actually benefitting from them.
+
+## Security considerations
+
+Removing the fallback from the spec may lead to issues, when clients experience
+the fallback in old events. This should not add any security issues the
+client didn't already have from interpreting untrusted html, though. In all
+other cases this should **reduce** security issues.
+
+## Unstable prefix
+
+Seems unnecessary, since this only removes stuff.

--- a/proposals/2781-down-with-the-fallbacks.md
+++ b/proposals/2781-down-with-the-fallbacks.md
@@ -149,4 +149,6 @@ other cases this should **reduce** security issues.
 
 ## Unstable prefix
 
-Seems unnecessary, since this only removes stuff.
+Clients should use the prefix `im.nheko.msc2781.` for all their event types, if
+they implement this MSC in a publicly available release or events may otherwise
+bleed into public rooms.

--- a/proposals/2781-down-with-the-fallbacks.md
+++ b/proposals/2781-down-with-the-fallbacks.md
@@ -94,7 +94,8 @@ Deprecate the rich reply fallback. Clients should stop sending them and should
 consider treating `<mx-reply>` parts as either something to be unconditionally
 stripped or as something to be escaped as invalid html. In the future the
 fallback should be removed from the spec completely with only a note left, that
-it may exist in old events.
+it may exist in old events. Clients may send replies without a formatted_body
+now.
 
 Furthermore, no fallback should be used for edits, since just adding an asterisk
 before the same message does not provide much value to users and it complicates

--- a/proposals/2781-down-with-the-fallbacks.md
+++ b/proposals/2781-down-with-the-fallbacks.md
@@ -164,7 +164,7 @@ other cases this should **reduce** security issues.
 Of the 18 clients listed in the [matrix client matrix](https://matrix.org/client-matrix)
 10 are listed as not supporting replies:
 
-- weechat-matrix: Actually has an [implementation](https://github.com/poljar/weechat-matrix/issues/86) although it may be [broken](https://github.com/poljar/weechat-matrix/issues/233).
+- weechat-matrix: Actually has an [implementation](https://github.com/poljar/weechat-matrix/issues/86) to send replies although it may be [broken](https://github.com/poljar/weechat-matrix/issues/233). Doesn't render rich replies. Hard to implement because of the single socket implementation, but may be easier in the Rust version.
 - Quaternion: [Blocked because of fallbacks](https://github.com/quotient-im/libQuotient/issues/245).
 - matrixcli: [Doesn't support formatted messages](https://github.com/ahmedsaadxyzz/matrixcli/issues/10).
 - Ditto Chat: [Doesn't support replying?](https://gitlab.com/ditto-chat/ditto-mobile/-/issues/83), but [does some special stuff for rendering?](https://gitlab.com/ditto-chat/ditto-mobile/-/issues/8)

--- a/proposals/2781-down-with-the-fallbacks.md
+++ b/proposals/2781-down-with-the-fallbacks.md
@@ -140,7 +140,7 @@ someone new to online messaging would assume, this is a correction to the
 previous message. That may even be more obvious to them than if the message was
 prefixed with a `*`, since that has been confusing to users in the past. Since
 edits would now look exactly like a normal message, they would also be
-considerably easier to implement, since you jus need to replace the former
+considerably easier to implement, since you just need to replace the former
 message now, similar to a redaction, and not merge `content` and `new_content`.
 
 ## Alternatives
@@ -158,6 +158,32 @@ Removing the fallback from the spec may lead to issues, when clients experience
 the fallback in old events. This should not add any security issues the
 client didn't already have from interpreting untrusted html, though. In all
 other cases this should **reduce** security issues.
+
+## Appendix A: Clients not supporting rich replies
+
+Of the 18 clients listed in the [matrix client matrix](https://matrix.org/client-matrix)
+10 are listed as not supporting replies:
+
+- weechat-matrix: Actually has an [implementation](https://github.com/poljar/weechat-matrix/issues/86) although it may be [broken](https://github.com/poljar/weechat-matrix/issues/233).
+- Quaternion: [Blocked because of fallbacks](https://github.com/quotient-im/libQuotient/issues/245).
+- matrixcli: [Doesn't support formatted messages](https://github.com/ahmedsaadxyzz/matrixcli/issues/10).
+- Ditto Chat: [Doesn't support replying?](https://gitlab.com/ditto-chat/ditto-mobile/-/issues/83), but [does some special stuff for rendering?](https://gitlab.com/ditto-chat/ditto-mobile/-/issues/8)
+- Mirage: Supports rich replies, but has [doesn't strip the fallback correctly](https://github.com/mirukana/mirage/issues/89) and uses the fallback to render them.
+- Fractal: [Unsupported](https://gitlab.gnome.org/GNOME/fractal/-/issues/194). Has some reports, that the fallback doesn't look nice though.
+- Nio: [Unsupported](https://github.com/niochat/nio/issues/85).
+- Pattle: Client is not being developed anymore.
+- Seaglass: Doesn't support rich replies, but is [unhappy with how the fallback looks](https://github.com/neilalexander/seaglass/issues/51)?
+- Miitrix: Somewhat unlikely to support it, I guess?
+- matrix-commander: No idea.
+
+So in summary, half of the listed clients don't support replies. At least one
+client doesn't support it because of the fallback (Quaternion). 3 of the command
+line clients probably won't support replies, since they don't support formatted
+messages and replies require html support for at least sending. Fractal and Nio
+don't seem to use html for rendering either. It would be interesting to hear the
+opionion of the developers of those clients, if dropping the fallback would
+negatively impact them or if they would be fine with implementing proper
+replies.
 
 ## Unstable prefix
 

--- a/proposals/2781-down-with-the-fallbacks.md
+++ b/proposals/2781-down-with-the-fallbacks.md
@@ -58,6 +58,18 @@ event is still a reply, but you can't send a reply relation, since this is an
 edit. So for clients relying on the edit fallback, you send a broken reply
 fallback, that doesn't get stripped, even when the client supports rich replies.
 
+#### Format is somewhat badly specified
+
+Further complicating the stripping and creation portion of fallbacks is, that
+they are somewhat badly specified. While the fallback and html use are required,
+the spec only says how a fallback "should" look, not how it "must" look. In
+practice there are various variations of the fallback floating around, where the
+tame ones are just localized, but others are just straight up missing suggested
+links or tags.
+
+Basically a client can't rely on the fallback being present currently or it
+folllowing any kind of shape or form.
+
 #### Replies leak history
 
 A reply includes the `body` of another event. This means a reply to an event can

--- a/proposals/2781-down-with-the-fallbacks.md
+++ b/proposals/2781-down-with-the-fallbacks.md
@@ -100,6 +100,26 @@ Only replies to actual text messages have a somewhat reasonable fallback. The
 other ones do not provide any more value than a plain "this is a reply" tag,
 unless the client also already supports event links.
 
+#### Fallback discussion blocks new features
+
+On any proposal that wants to enable replies to other events or replies with
+other events, the discussion around "how to handle the fallback" happens. Any
+such MSC needs to specify, how the fallback should look like and the events need
+to support the `formatted_body` field. This blocks a lot of improvements, that
+could be done to replies as a whole. Often commentors even ask for the issues
+with fallbacks to be fixed on that MSC.
+
+#### Localization
+
+Since the fallback is added as normal text into the message, it needs to be
+localized for the receiving party to understand it. This however proves to be a
+challenge, since users may switch languages freely in a room and it is not easy
+to guess, which language was used in a short message. One could also use the
+client's language, but that leaks the user's localization settings, which can be a
+privacy concern and the other party may not speak that language. Alternatively a
+client can just send english fallbacks, but that significantly worsens the
+experience for casual users in non-english speaking countries.
+
 ## Proposal
 
 Deprecate the rich reply fallback. Clients should stop sending them and should

--- a/proposals/2781-down-with-the-fallbacks.md
+++ b/proposals/2781-down-with-the-fallbacks.md
@@ -152,6 +152,14 @@ doesn't address the other issues with fallbacks.
 One could also just stick with the current fallbacks and make all clients pay
 the cost for a small number of clients actually benefitting from them.
 
+Lastly one could introduce an alternative relation type for replies without
+fallback and deprecate the current relation type (since it does not fit the new
+format for relations anyway). We could specify, that the server is supposed to
+send the replied_to event in unsigned to the client, so that clients just need
+to stitch those two events together, but don't need to fetch the replied_to
+event from the server. It would make replies slightly harder to implement for
+clients, but it would be simpler than what this MSC proposes.
+
 ## Security considerations
 
 Removing the fallback from the spec may lead to issues, when clients experience

--- a/proposals/2781-down-with-the-fallbacks.md
+++ b/proposals/2781-down-with-the-fallbacks.md
@@ -26,8 +26,7 @@ provided for convenience and aren't necessary to understand this proposal.
 Remove the [rich reply fallback from the
 specification](https://spec.matrix.org/v1.10/client-server-api/#fallbacks-for-rich-replies).
 Clients should stop sending them and should consider treating `<mx-reply>` parts
-as either something to be unconditionally stripped or as something to be escaped
-as invalid html.
+as they treat other invalid html tags.
 
 Clients are not required to include a fallback in a reply since version 1.3 of
 the
@@ -53,11 +52,11 @@ Old events and events sent by clients implementing an older version of the
 Matrix specification might still contain a reply fallback. So for at least some
 period of time clients will still need to strip reply fallbacks from messages.
 
-Clients which don't implement rich replies or edits may see messages
-without context, confusing users. However, most replies and edits are
-in close proximity to the original message, making context likely to be
-nearby. Clients should also have enough information in the event to
-render helpful indications to users while they work on full support.
+Clients which don't implement rich replies may see messages without context,
+confusing users. However, most replies are in close proximity to the original
+message, making context likely to be nearby. Clients should also have enough
+information in the event to render helpful indications to users while they work
+on full support.
 
 Clients which aren't using
 [intentional mentions](https://spec.matrix.org/v1.7/client-server-api/#mentioning-the-replied-to-user)

--- a/proposals/2781-down-with-the-fallbacks.md
+++ b/proposals/2781-down-with-the-fallbacks.md
@@ -193,13 +193,13 @@ html anyway and that new features are blocked, because of fallbacks.
 ### Format is unreliable
 
 While the spec says how a fallback "should" look, there are variations in use
-which further complicates stripping the fallback.  Some variations include
-localizing the fallback, missing suggested links or tags, using the body in
-replies to files or images or using the display name instead of the matrix id.
+which further complicates stripping the fallback or are common mistakes, when
+emitting the fallback. Some variations include localizing the fallback,
+missing suggested links or tags, using the body in replies to files or images
+or using the display name instead of the matrix id.
 
-Basically a client can't rely on the fallback being present currently or it
-following any kind of shape or form and stripping is done on a best effort
-basis, especially for the fallback in `body`.
+As a result the experience in clients relying on the fallback or stripping the
+fallback varies depending on the sending client.
 
 ### Replies leak history
 
@@ -208,8 +208,9 @@ leak data to users, that joined this room at a later point, but shouldn't be
 able to see the event because of visibility rules or encryption. While this
 isn't a big issue, there is still an issue about it: https://github.com/matrix-org/matrix-doc/issues/1654
 
-Replies are also sometimes localized. In those cases they leak the users
-language selection for their client, which may be personal information.
+Historically clients have also sometimes localized the fallbacks. In those cases
+they leak the users language selection for their client, which may be personal
+information.
 
 ### Using the unmodified fallback in clients and bridges
 

--- a/proposals/2781-down-with-the-fallbacks.md
+++ b/proposals/2781-down-with-the-fallbacks.md
@@ -61,7 +61,7 @@ Clients which aren't using
 [intentional mentions](https://spec.matrix.org/v1.7/client-server-api/#mentioning-the-replied-to-user)
 may cause some missed notifications on the receiving side.
 [MSC3664](https://github.com/matrix-org/matrix-doc/pull/3664) and similar aim to
-address this issue, as
+address this issue, and
 [MSC4142](https://github.com/matrix-org/matrix-spec-proposals/pull/4142) tries
 to improve the intentional mentions experience for replies generally.
 Because intentional mentions are already part of the Matrix specification since

--- a/proposals/2781-down-with-the-fallbacks.md
+++ b/proposals/2781-down-with-the-fallbacks.md
@@ -6,7 +6,7 @@ of a replied to message. The fallback representation was meant to simplify
 supporting replies in a new client, but in practice they add complexity, are
 often implemented incorrectly and block new features.
 
-This MSC proposes to deprecate and eventually remove those fallbacks.
+This MSC proposes to **remove** those fallbacks from the specification.
 
 Some of the known issues include:
 * The content of reply fallback is [untrusted](https://spec.matrix.org/v1.10/client-server-api/#stripping-the-fallback).

--- a/proposals/2781-down-with-the-fallbacks.md
+++ b/proposals/2781-down-with-the-fallbacks.md
@@ -22,7 +22,7 @@ would also be able to implement edits and replies more easily, as they can
 sidestep a lot of pitfalls. This should improve the look and feel of replies in
 Matrix across all clients in the long term.
 
-An extended motivation is provided at [the end of this document](user-content-appendix-b-issues-with-the-current-fallbacks).
+An extended motivation is provided at [the end of this document](#user-content-appendix-b-issues-with-the-current-fallbacks).
 
 There are similar benefit for not adding a fallback to edits. This proposal
 focuses on replies for simplicity, but encourages

--- a/proposals/2781-down-with-the-fallbacks.md
+++ b/proposals/2781-down-with-the-fallbacks.md
@@ -19,9 +19,10 @@ events (not state events).
 
 As a result of this, you would be able to reply with an image.  New clients
 would also be able to implement edits and replies more easily, as they can
-sidestep a lot of pitfalls.
+sidestep a lot of pitfalls. This should improve the look and feel of replies in
+Matrix across all clients in the long term.
 
-An extended motivation is provided at [the end of this document](Appendix-B:-Issues-with-the-current-fallbacks).
+An extended motivation is provided at [the end of this document](user-content-appendix-b-issues-with-the-current-fallbacks).
 
 There are similar benefit for not adding a fallback to edits. This proposal
 focuses on replies for simplicity, but encourages

--- a/proposals/2781-down-with-the-fallbacks.md
+++ b/proposals/2781-down-with-the-fallbacks.md
@@ -88,12 +88,9 @@ simpler than what this MSC proposes.
 
 ## Security considerations
 
-Removing the fallback from the spec may lead to issues, when clients experience
-the fallback in old events. This should not add any security issues the
-client didn't already have from interpreting untrusted html, though. In all
-other cases this should **reduce** security issues (see
-https://github.com/vector-im/element-web/releases/tag/v1.7.3 or the appendix for
-examples).
+Overall this should **reduce** security issues as the handling of untrusted
+HTML is simplified. For an example security issue that could be avoided, see
+https://github.com/vector-im/element-web/releases/tag/v1.7.3 and the appendix.
 
 ## Unstable prefix
 

--- a/proposals/2781-down-with-the-fallbacks.md
+++ b/proposals/2781-down-with-the-fallbacks.md
@@ -24,7 +24,7 @@ Matrix across all clients in the long term.
 
 An extended motivation is provided at [the end of this document](#user-content-appendix-b-issues-with-the-current-fallbacks).
 
-There are similar benefit for not adding a fallback to edits. This proposal
+There are similar benefits to not adding a fallback to edits. This proposal
 focuses on replies for simplicity, but encourages
 [MSC2676](https://github.com/matrix-org/matrix-doc/pull/2676) to drop the edit
 fallback or remove it [when moving to extensible

--- a/proposals/2781-down-with-the-fallbacks.md
+++ b/proposals/2781-down-with-the-fallbacks.md
@@ -203,9 +203,8 @@ language selection for their client, which may be personal information.
 ### Using the unmodified fallback in clients and bridges
 
 The above issues are minor, if reply fallbacks would sufficiend value to
-clients. However at least the Qt html renderer breaks on `<mx-reply>` tags, so
-you need to strip them anyway to render replies.  Bridges usually try to bridge
-to native replies, so they need to strip the reply fallback
+clients.  Bridges usually try to bridge to native replies, so they need to
+strip the reply fallback
 (https://github.com/matrix-org/matrix-doc/issues/1541). Even the IRC bridge
 seems to send a custom fallback, because the default fallback is not that
 welcome to the IRC crowd.

--- a/proposals/2781-down-with-the-fallbacks.md
+++ b/proposals/2781-down-with-the-fallbacks.md
@@ -1,4 +1,4 @@
-# MSC2781: Deprecate fallbacks in the specification
+# MSC2781: Remove reply fallbacks from the specification
 
 Currently replies require clients to send and parse a fallback representation of
 the replied to message. Something similar is planned for edits. While at least
@@ -9,137 +9,25 @@ remove those fallbacks. It is an alternative to
 [MSC2589](https://github.com/matrix-org/matrix-doc/pull/2589), which intends to
 double down on fallbacks.
 
-### Issues with the current fallbacks
-
-#### Stripping the fallback
-
-To reply to a reply, a client needs to strip the existing fallback of the first
-reply. Otherwise replies will just infinitely nest replies. [While the spec doesn't necessarily require that](https://github.com/matrix-org/matrix-doc/issues/1541),
-not doing so risks running into the event size limit, but more importantly, it
-just leads to a bad experience for clients actually relying on the fallback.
-
-Stripping the fallback sadly is not trivial. Most clients did that wrong at some
-point. At the point of writing this, FluffyChat seems to fail stripping the
-fallback, while Riot/Element did fail to do so in the past, when `<mx-reply>`
-tags were not evenly matched. Since clients can send arbitrary byte sequences,
-every client needs to basically parse untrusted input and sanitize it. A normal
-html parser will fail stripping a `</mx-reply><mx-reply></mx-reply>` sequence in
-some cases. If you use a regex to strip the fallback, you may be able to be
-attacked using regex DOS attacks (although that is somewhat mitigated by the
-maximum event size). In the end there are quite a few edge cases, that are not
-covered in the existing specification, since it doesn't specify the exact rules
-to strip a fallback at all.
-
-Stripping the fallback from body is even more complicated, since there is no way
-to distinguish a quote from a reply reliably.
-
-#### Creating a new fallback
-
-To create a new fallback, a client needs to add untrusted html to its own
-events. This is an easy attack vector to inject your own content into someone
-elses reply. While this can be prevented with enough care, since Riot basically
-had to fix this issue twice, it can be expected that other clients can also be
-affected by this.
-
-#### Requirement of html for replies
-
-The spec requires rich replies to have a fallback using html:
-
-> Rich replies MUST have a format of org.matrix.custom.html and therefore a formatted_body alongside the body and appropriate msgtype.
-
-This means you can't reply using only a `body` and you can't reply with an
-image, since those don't have a `formatted_body` property currently. This means
-a text only client, that doesn't want to display html, still needs to support
-html anyway and that new features are blocked, because of fallbacks.
-
-This is also an issue with edits, where the combination of edit fallback and
-reply fallback is somewhat interesting: You need to send a fallback, since the
-event is still a reply, but you can't send a reply relation, since this is an
-edit. So for clients relying on the edit fallback, you send a broken reply
-fallback, that doesn't get stripped, even when the client supports rich replies.
-
-#### Format is somewhat badly specified
-
-Further complicating the stripping and creation portion of fallbacks is, that
-they are somewhat badly specified. While the fallback and html use are required,
-the spec only says how a fallback "should" look, not how it "must" look. In
-practice there are various variations of the fallback floating around, where the
-tame ones are just localized, but others are just straight up missing suggested
-links or tags.
-
-Basically a client can't rely on the fallback being present currently or it
-folllowing any kind of shape or form.
-
-#### Replies leak history
-
-A reply includes the `body` of another event. This means a reply to an event can
-leak data to users, that joined this room at a later point, but shouldn't be
-able to see the event because of visibility rules or encryption. While this
-isn't a big issue, there is still an issue about it: https://github.com/matrix-org/matrix-doc/issues/1654
-
-Replies are also sometimes localized. In those cases they leak the users
-language selection for their client, which may be personal information.
-
-#### Low value of fallbacks
-
-The above issues would be somewhat acceptable, if reply fallbacks would provide
-some value to clients. Generally they don't though. The Qt html renderer breaks
-on `<mx-reply>` tags, so you need to strip them anyway to render replies.
-Bridges usually try to bridge to native replies, so they need to strip the reply
-part (https://github.com/matrix-org/matrix-doc/issues/1541). Even the IRC bridge
-seems to send a custom fallback, because the default fallback is not that
-welcome to the IRC crowd.
-
-Clients that actually use the fallback (original Riot/Android for example) tend
-to do so for quite some while, because the fallbacks are "good enough", but in
-the end that provides a worse experience for everyone involved. For example you
-couldn't see what image was replied to for the longest time. Just "X replied to
-an image with: I like this one" is not valuable, when 3 images were sent.
-
-Only replies to actual text messages have a somewhat reasonable fallback. The
-other ones do not provide any more value than a plain "this is a reply" tag,
-unless the client also already supports event links.
-
-#### Fallback discussion blocks new features
-
-On any proposal that wants to enable replies to other events or replies with
-other events, the discussion around "how to handle the fallback" happens. Any
-such MSC needs to specify, how the fallback should look like and the events need
-to support the `formatted_body` field. This blocks a lot of improvements, that
-could be done to replies as a whole. Often commentors even ask for the issues
-with fallbacks to be fixed on that MSC.
-
-#### Localization
-
-Since the fallback is added as normal text into the message, it needs to be
-localized for the receiving party to understand it. This however proves to be a
-challenge, since users may switch languages freely in a room and it is not easy
-to guess, which language was used in a short message. One could also use the
-client's language, but that leaks the user's localization settings, which can be a
-privacy concern and the other party may not speak that language. Alternatively a
-client can just send english fallbacks, but that significantly worsens the
-experience for casual users in non-english speaking countries.
-
 ## Proposal
 
-Deprecate the rich reply fallback. Clients should stop sending them and should
-consider treating `<mx-reply>` parts as either something to be unconditionally
-stripped or as something to be escaped as invalid html. In the future the
-fallback should be removed from the spec completely with only a note left, that
-it may exist in old events. Clients may send replies without a formatted_body
-now.
+Remove the rich reply fallback from the specification. Clients should stop
+sending them and should consider treating `<mx-reply>` parts as either something
+to be unconditionally stripped or as something to be escaped as invalid html.
+Clients may send replies without a formatted_body now using arbitrary message
+events (not state events).
 
-Furthermore, no fallback should be used for edits, since just adding an asterisk
-before the same message does not provide much value to users and it complicates
-the implementation of edits for no tangible benefit.
+As a result of this, you would be able to reply with an image.  New clients
+would also be able to implement edits and replies more easily, as they can
+sidestep a lot of pitfalls.
 
-The fallback for more niche features, like in room verification can stay, since
-that feature is actually somewhat hard to implement and some clients may never
-support encryption.
+An extended motivation is provided at [the end of this document](Appendix-B:-Issues-with-the-current-fallbacks).
 
-As a result of this, you would be able to reply with an image or edit a video.
-New clients would also be able to implement edits and replies more easily, as
-they can sidestep a lot of pitfalls.
+There are similar benefit for not adding a fallback to edits. This proposal
+focuses on replies for simplicity, but encourages
+[MSC2676](https://github.com/matrix-org/matrix-doc/pull/2676) to drop the edit
+fallback or remove it [when moving to extensible
+events](https://github.com/matrix-org/matrix-doc/pull/3644).
 
 ## Potential issues
 
@@ -189,29 +77,164 @@ other cases this should **reduce** security issues.
 
 ## Appendix A: Clients not supporting rich replies
 
-Of the 18 clients listed in the [matrix client matrix](https://matrix.org/client-matrix)
-10 are listed as not supporting replies:
+Of the 23 clients listed in the [matrix client matrix](https://matrix.org/clients-matrix)
+16 are listed as not supporting replies:
 
-- weechat-matrix: Actually has an [implementation](https://github.com/poljar/weechat-matrix/issues/86) to send replies although it may be [broken](https://github.com/poljar/weechat-matrix/issues/233). Doesn't render rich replies. Hard to implement because of the single socket implementation, but may be easier in the Rust version.
+- Element Android: Relies on the reply fallback.
+- Element iOS: [Does not support rich replies](https://github.com/vector-im/element-ios/issues/3517)
+- weechat-matrix: Actually has an [implementation](https://github.com/poljar/weechat-matrix/issues/86) to send replies although it seems to be [broken](https://github.com/poljar/weechat-matrix/issues/233). Doesn't render rich replies. Hard to implement because of the single socket implementation, but may be easier in the Rust version.
 - Quaternion: [Blocked because of fallbacks](https://github.com/quotient-im/libQuotient/issues/245).
 - matrixcli: [Doesn't support formatted messages](https://github.com/ahmedsaadxyzz/matrixcli/issues/10).
-- Ditto Chat: [Doesn't support replying?](https://gitlab.com/ditto-chat/ditto-mobile/-/issues/83), but [does some special stuff for rendering?](https://gitlab.com/ditto-chat/ditto-mobile/-/issues/8)
-- Mirage: Supports rich replies, but has [doesn't strip the fallback correctly](https://github.com/mirukana/mirage/issues/89) and uses the fallback to render them.
-- Fractal: [Unsupported](https://gitlab.gnome.org/GNOME/fractal/-/issues/194). Has some reports, that the fallback doesn't look nice though.
+- Ditto Chat: [Seems to rely on the fallback](https://gitlab.com/ditto-chat/ditto/-/blob/main/mobile/scenes/chat/components/Html.tsx#L38)
+- Mirage: Supports rich replies, but [doesn't strip the fallback correctly](https://github.com/mirukana/mirage/issues/89) and uses the fallback to render them.
 - Nio: [Unsupported](https://github.com/niochat/nio/issues/85).
 - Pattle: Client is not being developed anymore.
 - Seaglass: Doesn't support rich replies, but is [unhappy with how the fallback looks](https://github.com/neilalexander/seaglass/issues/51)?
 - Miitrix: Somewhat unlikely to support it, I guess?
-- matrix-commander: No idea.
+- matrix-commander: No idea, but doesn't look like it.
+- gotktrix: [Seems to rely on the reply fallback](https://github.com/diamondburned/gotktrix/blob/5f2783d633560421746a82aab71d4f7421e4b99c/internal/app/messageview/message/mcontent/text/html.go#L437)
+- Hydrogen: [Seems to use the reply fallback](https://github.com/vector-im/hydrogen-web/blob/c3177b06bf9f760aac2bfd5039342422b7ec8bb4/doc/impl-thoughts/PENDING_REPLIES.md)
+- kazv: Doesn't seem to support replies at all
+- Syphon: [Uses the reply fallback in body](https://github.com/syphon-org/syphon/blob/fa44c5abe37bdd256a9cb61cbc8552e0e539cdce/lib/views/widgets/messages/message.dart#L368)
 
-So in summary, half of the listed clients don't support replies. At least one
+So in summary, 3/4 of the listed clients don't support replies. At least one
 client doesn't support it because of the fallback (Quaternion). 3 of the command
 line clients probably won't support replies, since they don't support formatted
-messages and replies require html support for at least sending. Fractal and Nio
-don't seem to use html for rendering either. It would be interesting to hear the
-opionion of the developers of those clients, if dropping the fallback would
-negatively impact them or if they would be fine with implementing proper
-replies.
+messages and replies require html support for at least sending.
+
+Only one client implemented rich replies in the last 1.5 years. Other clients
+are either new in my list or didn't change their reply rendering. I would
+appreciate to hear, why those client developers decided not to support rich
+reply rendering and if dropping the reply fallback would be an issue for them.
+
+Changes from 1.5 years ago:
+
+- Fractal: [Seems to support replies now!](https://gitlab.gnome.org/GNOME/fractal/-/merge_requests/941)
+- Commune: Seems to support rich reply rendering and style them very nicely.
+- NeoChat: [Supports rich replies](https://invent.kde.org/network/neochat/-/blob/master/src/utils.h#L21)
+- Cinny: [Seems to support rich replies](https://github.com/ajbura/cinny/blob/6ff339b552e242f6233abd86768bb2373b150f77/src/app/molecules/message/Message.jsx#L111)
+- gomuks: [Strips the reply fallback](https://github.com/tulir/gomuks/blob/3510d223b2d765572bf2e97222f2f55d099119f0/ui/messages/html/parser.go#L361)
+- Lots of other new clients!
+
+
+## Appendix B: Issues with the current fallbacks
+
+This section was moved to the back of this MSC, because it is fairly long and
+exhaustive. It lists all the issues the proposal author personally experienced
+with fallbacks in their client and its interactions with the ecosystem.
+
+### Stripping the fallback
+
+To reply to a reply, a client needs to strip the existing fallback of the first
+reply. Otherwise replies will just infinitely nest replies. [While the spec doesn't necessarily require that](https://github.com/matrix-org/matrix-doc/issues/1541),
+not doing so risks running into the event size limit, but more importantly, it
+just leads to a bad experience for clients actually relying on the fallback.
+
+Stripping the fallback is not trivial. Multiple implementations had bugs in
+their fallback stripping logic. The edge cases are not covered in the
+specification in detail and some clients have interpreted them differently.
+Common mistakes include:
+
+- Not stripping the fallback in body, which leads to a very long nested chain.
+- Not dealing with mismatched `<mx-reply>` tags, which can look like you were
+    impersonating someone.
+
+Stripping the fallback from body is even more complicated, since there is no way
+to distinguish a quote from a reply reliably.
+
+### Creating a new fallback
+
+To create a new fallback, a client needs to add untrusted html to its own
+events. This is an easy attack vector to inject your own content into someone
+elses reply. While this can be prevented with enough care, since Riot basically
+had to fix this issue twice, it can be expected that other clients can also be
+affected by this.
+
+### Requirement of html for replies
+
+The spec requires rich replies to have a fallback using html:
+
+> Rich replies MUST have a format of org.matrix.custom.html and therefore a formatted_body alongside the body and appropriate msgtype.
+
+This means you can't reply using only a `body` and you can't reply with an
+image, since those don't have a `formatted_body` property currently. This means
+a text only client, that doesn't want to display html, still needs to support
+html anyway and that new features are blocked, because of fallbacks.
+
+This is also an issue with edits, where the combination of edit fallback and
+reply fallback is somewhat interesting: You need to send a fallback, since the
+event is still a reply, but you can't send a reply relation, since this is an
+edit. Currently this is solved by not sending a reply fallback in edits, so
+clients can't rely on a reply fallback in all cases.
+
+We currently can see 2 behaviours in practice:
+
+Client A supports rich reply rendering, Client B does not.
+
+- A sends an edit. This according to MSC2676 does not include a reply fallback.
+    A properly sees the edit still as a reply. B does not.
+- B sends an edit but includes a reply fallback in the body. It can still see
+    that the message is a reply. A needs to strip the invalid reply fallback, or
+    it will see the reply content twice.
+
+### Format is unreliable
+
+Further complicating the stripping and creation portion of fallbacks is, that
+they are somewhat badly specified. While the fallback and html use are required,
+the spec only says how a fallback "should" look, not how it "must" look. In
+practice there are various variations of the fallback floating around, where the
+tame ones are just localized, but others are just straight up missing suggested
+links or tags.
+
+Basically a client can't rely on the fallback being present currently or it
+following any kind of shape or form and stripping is done on a best effort
+basis, especially for the fallback in `body`.
+
+### Replies leak history
+
+A reply includes the `body` of another event. This means a reply to an event can
+leak data to users, that joined this room at a later point, but shouldn't be
+able to see the event because of visibility rules or encryption. While this
+isn't a big issue, there is still an issue about it: https://github.com/matrix-org/matrix-doc/issues/1654
+
+Replies are also sometimes localized. In those cases they leak the users
+language selection for their client, which may be personal information.
+
+### Using the unmodified fallback in clients and bridges
+
+The above issues are minor, if reply fallbacks would sufficiend value to
+clients. However at least the Qt html renderer breaks on `<mx-reply>` tags, so
+you need to strip them anyway to render replies.  Bridges usually try to bridge
+to native replies, so they need to strip the reply fallback
+(https://github.com/matrix-org/matrix-doc/issues/1541). Even the IRC bridge
+seems to send a custom fallback, because the default fallback is not that
+welcome to the IRC crowd.
+
+Some clients do choose not to implement rich reply rendering, but the experience
+tends to not be ideal, especially in cases where you reply to an image and now
+the user needs to guess, what image was being replied to.
+
+As a result the fallbacks provide value to only a subset of the Matrix
+ecosystem.
+
+### Fallback increase integration work with new features
+
+- [Edits explicitly mention](https://github.com/matrix-org/matrix-doc/pull/2676)
+    that a reply fallback should not be sent in the `m.new_content`.
+- [Extensible events](https://github.com/matrix-org/matrix-doc/pull/1767) would
+    need to specify how the fallback should look like. [Alternatively they could
+    also drop it](https://github.com/matrix-org/matrix-doc/pull/3644).
+
+### Localization
+
+Since the fallback is added as normal text into the message, it needs to be
+localized for the receiving party to understand it. This however proves to be a
+challenge, since users may switch languages freely in a room and it is not easy
+to guess, which language was used in a short message. One could also use the
+client's language, but that leaks the user's localization settings, which can be a
+privacy concern and the other party may not speak that language. Alternatively a
+client can just send english fallbacks, but that significantly worsens the
+experience for casual users in non-english speaking countries.
 
 ## Unstable prefix
 

--- a/proposals/2781-down-with-the-fallbacks.md
+++ b/proposals/2781-down-with-the-fallbacks.md
@@ -50,7 +50,7 @@ experience with replies to images was not acceptable. Motivating clients to
 implement rich replies is a good thing in the long run and will improve the
 Matrix experience overall.
 
-You might not get notifications anymore for replies to your messages. This was
+You might not get notifications any more for replies to your messages. This was
 a feature of the reply fallback, because it included the username, but users had
 no control over it. A follow-up MSC will propose a push rule for related events,
 which will allow users control over getting notified by replies (and other
@@ -127,7 +127,7 @@ Changes from 1.5 years ago:
 - Lots of other new clients!
 
 
-### Testresults without fallback
+### Results of testing replies without fallback
 
 So far I haven't found a client that completely breaks without the fallback.
 All clients that support rendering rich replies don't break, when there is no
@@ -231,7 +231,7 @@ the user needs to guess, what image was being replied to.
 As a result the fallbacks provide value to only a subset of the Matrix
 ecosystem.
 
-### Fallback increase integration work with new features
+### Fallbacks increase integration work with new features
 
 - [Edits explicitly mention](https://github.com/matrix-org/matrix-doc/pull/2676)
     that a reply fallback should not be sent in the `m.new_content`. This causes

--- a/proposals/2781-down-with-the-fallbacks.md
+++ b/proposals/2781-down-with-the-fallbacks.md
@@ -52,9 +52,10 @@ Matrix experience overall.
 
 You might not get notifications any more for replies to your messages. This was
 a feature of the reply fallback, because it included the username, but users had
-no control over it. A follow-up MSC will propose a push rule for related events,
-which will allow users control over getting notified by replies (and other
-relations) or not.
+no control over it. Notifications can be added back by an MSC like
+[MSC3664](https://github.com/matrix-org/matrix-doc/pull/3664) or a similar
+proposal and give the user more control over the notifications while also being
+an explicit solution.
 
 ## Alternatives
 

--- a/proposals/2781-down-with-the-fallbacks.md
+++ b/proposals/2781-down-with-the-fallbacks.md
@@ -59,7 +59,7 @@ relations) or not.
 ## Alternatives
 
 [MSC2589](https://github.com/matrix-org/matrix-doc/pull/2589): This adds the
-reply text as an addional key. While this solves the parsing issues, it
+reply text as an additional key. While this solves the parsing issues, it
 doesn't address the other issues with fallbacks.
 
 One could also just stick with the current fallbacks and make all clients pay
@@ -88,7 +88,7 @@ examples).
 ### Clients without rendering support for rich replies
 
 Of the 23 clients listed in the [matrix client matrix](https://matrix.org/clients-matrix)
-16 are listed as not supporting replies:
+16 are listed as not supporting replies (updated January 2022):
 
 - Element Android: Relies on the reply fallback.
 - Element iOS: [Does not support rich replies](https://github.com/vector-im/element-ios/issues/3517)
@@ -112,12 +112,13 @@ client doesn't support it because of the fallback (Quaternion). 3 of the command
 line clients probably won't support replies, since they don't support formatted
 messages and replies require html support for at least sending.
 
-Only one client implemented rich replies in the last 1.5 years. Other clients
-are either new in my list or didn't change their reply rendering. I would
-appreciate to hear, why those client developers decided not to support rich
-reply rendering and if dropping the reply fallback would be an issue for them.
+Only one client implemented rich replies in the last 1.5 years after the
+original list was done in October 2020. Other clients are either new in my list
+or didn't change their reply rendering. I would appreciate to hear, why those
+client developers decided not to support rich reply rendering and if dropping
+the reply fallback would be an issue for them.
 
-Changes from 1.5 years ago:
+Changes from 1.5 years ago as of January 2022:
 
 - Fractal: [Seems to support replies now!](https://gitlab.gnome.org/GNOME/fractal/-/merge_requests/941)
 - Commune: Seems to support rich reply rendering and style them very nicely.

--- a/proposals/2781-down-with-the-fallbacks.md
+++ b/proposals/2781-down-with-the-fallbacks.md
@@ -14,7 +14,8 @@ Some of the known issues include:
 * Parsing reply fallbacks can be tricky. ([#350](https://github.com/matrix-org/matrix-spec/issues/350))
 * It is unclear how to handle a reply to a reply. ([#372](https://github.com/matrix-org/matrix-spec/issues/372))
 * Localization of replies is not possible when the content is embedded into the event.
-* It is not possible to fully redact an event once it is replied to. This causes both trust & safety and right to be forgotten issues.
+* It is not possible to fully redact an event once it is replied to. This causes issues with Trust & Safety where
+  spam or other removed content remains visible, and may cause issues with the GDPR Right to be Forgotten.
 * There are a variety of implementation bugs related to reply fallback handling.
 
 More details and considerations are provided in the appendices, but these are
@@ -34,9 +35,10 @@ the
 For this reason the reply fallback can be removed from the specification without
 any additional deprecation period.
 
-An info box should be included to mention the historical use of the reply
-fallback, suggesting that clients may encounter such events sent by other
-clients and that clients may need to strip out such fallbacks.
+A suggestion for the spec PR: An info box could be included to mention
+the historical use of the reply fallback, suggesting that clients may encounter
+such events sent by other clients and that clients may need to strip out such
+fallbacks.
 
 Given clients have had enough time to implement replies completely, the
 overall look & feel of replies should be unchanged or even improved by this

--- a/proposals/2781-down-with-the-fallbacks.md
+++ b/proposals/2781-down-with-the-fallbacks.md
@@ -44,13 +44,13 @@ the correct context. Replies would also be somewhat easier to implement and
 worst case, a client could very easily implement a little "this is a reply"
 marker to at least mark replies visually.
 
-Same applies to edits. If 2 very similar messages appear after one another,
+~~Same applies to edits. If 2 very similar messages appear after one another,
 someone new to online messaging would assume, this is a correction to the
 previous message. That may even be more obvious to them than if the message was
 prefixed with a `*`, since that has been confusing to users in the past. Since
 edits would now look exactly like a normal message, they would also be
 considerably easier to implement, since you just need to replace the former
-message now, similar to a redaction, and not merge `content` and `new_content`.
+message now, similar to a redaction, and not merge `content` and `new_content`.~~
 
 ## Alternatives
 

--- a/proposals/2781-down-with-the-fallbacks.md
+++ b/proposals/2781-down-with-the-fallbacks.md
@@ -1,6 +1,6 @@
 # MSC2781: Remove reply fallbacks from the specification
 
-Currently the specification suggest clients should send and strip a
+Currently the specification suggests clients should send and strip a
 [fallback representation](https://spec.matrix.org/v1.10/client-server-api/#fallbacks-for-rich-replies)
 of a replied to message. The fallback representation was meant to simplify
 supporting replies in a new client, but in practice they add complexity, are
@@ -14,7 +14,7 @@ Some of the known issues include:
 * Parsing reply fallbacks can be tricky. ([#350](https://github.com/matrix-org/matrix-spec/issues/350))
 * It is unclear how to handle a reply to a reply. ([#372](https://github.com/matrix-org/matrix-spec/issues/372))
 * Localization of replies is not possible when the content is embedded into the event.
-* It is not possible to fully redact an event once it is replied to, this causes both trust & safety and right to be forgotten issues.
+* It is not possible to fully redact an event once it is replied to. This causes both trust & safety and right to be forgotten issues.
 * There are a variety of implementation bugs related to reply fallback handling.
 
 More details and considerations are provided in the appendices, but these are
@@ -31,7 +31,7 @@ as invalid html.
 Clients are not required to include a fallback in a reply since version 1.3 of
 the
 [specification](https://spec.matrix.org/v1.10/client-server-api/#rich-replies).
-For this reason the reply fallbck can be removed from the specification without
+For this reason the reply fallback can be removed from the specification without
 any additional deprecation period.
 
 An info box should be included to mention the historical use of the reply
@@ -105,7 +105,7 @@ changed the wording from "MUST" to "SHOULD".
 
 ### Clients without rendering support for rich replies
 
-Of the 23 clients listed in the [matrix client matrix](https://matrix.org/clients-matrix)
+Of the 23 clients listed in the [Matrix client matrix](https://matrix.org/clients-matrix)
 16 are listed as not supporting replies (updated January 2022):
 
 - Element Android: Relies on the reply fallback.


### PR DESCRIPTION
Since I hit another fallback bug today, I thought I should finally propose this. Let's see, how this goes.

[Rendered](https://github.com/deepbluev7/matrix-doc/blob/drop-the-fallbacks/proposals/2781-down-with-the-fallbacks.md)

Implementations:
* [react-sdk](https://github.com/matrix-org/matrix-react-sdk/pull/6964)

See also:
* matrix-org/matrix-spec-proposals#3644 

fixes matrix-org/matrix-spec#368

fixes matrix-org/matrix-spec#350 ?

Signed-off-by: Nicolas Werner <nicolas.werner@hotmail.de>

---

[FCP tickyboxes](https://github.com/matrix-org/matrix-spec-proposals/pull/2781#issuecomment-2108904800)
