### PR TITLE
MSC2832: HS -> AS authorization header

### DIFF
--- a/proposals/2832-appservice-auth-fix.md
+++ b/proposals/2832-appservice-auth-fix.md
@@ -1,0 +1,37 @@
+# HS -> AS authorization header
+Most of the auth tokens in the spec are passed in the `Authorization` header,
+with the `access_token` query parameter supported for backwards-compatibility.
+For some reason, the application service spec was not updated in the same way
+and it still requires using the archaic query parameter when the homeserver
+pushes transactions to the appservice.
+
+## Proposal
+The `access_token` query parameter is deprecated and homeservers are encouraged
+to use the `Authorization` header with `Bearer <token>` as the value when
+sending transactions or other requests to application services.
+
+Application services MUST support checking the access token from the header.
+Appservices SHOULD still support the old query param auth, but it is not
+required, as there are no cases where a homeserver is unable to set HTTP
+request headers.
+
+### Transition to auth header
+Similarly to how [legacy routes](https://matrix.org/docs/spec/application_service/r0.1.2#legacy-routes)
+work in the appservice spec, homeservers should prefer using the authorization
+header, but fall back to the query parameter if the appservice returns a status
+code indicating invalid auth (401 or 403).
+
+## Security considerations
+Not fixing this causes access tokens to be logged in many bridges.
+
+## Alternatives
+The transition could be done differently, e.g. with an appservice registration
+field or homeserver config. Some sort of version identifier in appservice
+registrations would be the optimal solution (define that after vX, auth always
+uses the header), but such an identifier does not currently exist.
+
+## Unstable prefix
+The authorization header is already used in the client-server spec, and an
+unstable prefix would just unnecessarily complicate things. If the transition
+is decided to be done with an appservice registration field, then that field
+could have an unstable prefix.

--- a/proposals/2832-appservice-auth-fix.md
+++ b/proposals/2832-appservice-auth-fix.md
@@ -6,32 +6,23 @@ and it still requires using the archaic query parameter when the homeserver
 pushes transactions to the appservice.
 
 ## Proposal
-The `access_token` query parameter is deprecated and homeservers are encouraged
-to use the `Authorization` header with `Bearer <token>` as the value when
-sending transactions or other requests to application services.
+The `access_token` query parameter is removed from all requests made by the
+homeserver to appservice and is replaced with the `Authorization` header with
+`Bearer <token>` as the value.
 
-Application services MUST support checking the access token from the header.
-Appservices SHOULD still support the old query param auth, but it is not
-required, as there are no cases where a homeserver is unable to set HTTP
-request headers.
-
-### Transition to auth header
-Similarly to how [legacy routes](https://matrix.org/docs/spec/application_service/r0.1.2#legacy-routes)
-work in the appservice spec, homeservers should prefer using the authorization
-header, but fall back to the query parameter if the appservice returns a status
-code indicating invalid auth (401 or 403).
+### Backwards-compatibility
+Homeservers which want to support old spec versions in the appservice API may
+send both the query parameter and header. Similarly, appservices may accept the
+token from either source.
 
 ## Security considerations
 Not fixing this causes access tokens to be logged in many bridges.
 
 ## Alternatives
-The transition could be done differently, e.g. with an appservice registration
-field or homeserver config. Some sort of version identifier in appservice
-registrations would be the optimal solution (define that after vX, auth always
-uses the header), but such an identifier does not currently exist.
+We could add a way for appservices to explicitly specify which spec version
+they want in order to implement backwards-compatibility without sending both
+tokens.
 
 ## Unstable prefix
 The authorization header is already used in the client-server spec, and an
-unstable prefix would just unnecessarily complicate things. If the transition
-is decided to be done with an appservice registration field, then that field
-could have an unstable prefix.
+unstable prefix would just unnecessarily complicate things.

--- a/proposals/2832-appservice-auth-fix.md
+++ b/proposals/2832-appservice-auth-fix.md
@@ -1,4 +1,4 @@
-# HS -> AS authorization header
+# MSC2832: Homeserver -> Application Service authorization header
 Most of the auth tokens in the spec are passed in the `Authorization` header,
 with the `access_token` query parameter supported for backwards-compatibility.
 For some reason, the application service spec was not updated in the same way


### PR DESCRIPTION
[Rendered](https://github.com/tulir/matrix-doc/blob/appservice-auth-fix/proposals/2832-appservice-auth-fix.md)

Fixes matrix-org/matrix-spec#679 

This has been implemented by mautrix-python for a long time already, as I had mistakenly thought the spec was fixed long ago.

Signed-off-by: Tulir Asokan &lt;tulir@maunium.net&gt;

----

[FCP Checkboxes](https://github.com/matrix-org/matrix-spec-proposals/pull/2832#issuecomment-1151403491)