### PR TITLE
MSC3030: Jump to date API endpoint

### DIFF
--- a/proposals/3030-jump-to-date.md
+++ b/proposals/3030-jump-to-date.md
@@ -19,7 +19,7 @@ These types of use cases are not supported by the current Matrix API because it 
 ## Proposal
 
 
-Add new client API endpoint `GET /_matrix/client/r0/rooms/{roomId}/timestamp_to_event?ts=<timestamp>?dir=[f|b]` which fetches the closest `event_id` to the given timestamp `ts` query parameter in the direction specified by the `dir` query parameter.
+Add new client API endpoint `GET /_matrix/client/r0/rooms/{roomId}/timestamp_to_event?ts=<timestamp>?dir=[f|b]` which fetches the closest `event_id` to the given timestamp `ts` query parameter in the direction specified by the `dir` query parameter. This endpoint also returns `origin_server_ts` to make it easy to do a quick comparison to see if the `event_id` fetched is too far out of range to be useful for your use case.
 
 In order to solve the problem where a remote federated homeserver does not have all of the history in a room and no suitably close event, we also add a server API endpoint `GET /_matrix/federation/v1/timestamp_to_event/{roomId}?ts=<timestamp>?dir=[f|b]` which other homeservers can use to ask about their closest `event_id` to the timestamp. This endpoint also returns `origin_server_ts` to make it easy to do a quick comparison to see if the remote `event_id` fetched is closer than the local one.
 
@@ -29,6 +29,7 @@ The heuristics for deciding when to ask another homeserver for a closer event if
 GET /_matrix/client/unstable/org.matrix.msc3030/rooms/<roomID>/timestamp_to_event?ts=<timestamp>&dir=<direction>
 {
     "event_id": ...
+    "origin_server_ts": ...
 }
 ```
 

--- a/proposals/3030-jump-to-date.md
+++ b/proposals/3030-jump-to-date.md
@@ -169,3 +169,7 @@ GET /_matrix/federation/unstable/org.matrix.msc3030/timestamp_to_event/<roomID>?
     "origin_server_ts": ...
 }
 ```
+
+Servers will indicate support for the new endpoint via a non-empty value for feature flag
+`org.matrix.msc3030` in `unstable_features` in the response to `GET
+/_matrix/client/versions`.

--- a/proposals/3030-jump-to-date.md
+++ b/proposals/3030-jump-to-date.md
@@ -36,7 +36,7 @@ get a message from 3 years ago 😫
 
 
 Add new client API endpoint `GET
-/_matrix/client/r0/rooms/{roomId}/timestamp_to_event?ts=<timestamp>?dir=[f|b]`
+/_matrix/client/v1/rooms/{roomId}/timestamp_to_event?ts=<timestamp>?dir=[f|b]`
 which fetches the closest `event_id` to the given timestamp `ts` query parameter
 in the direction specified by the `dir` query parameter. This endpoint also
 returns `origin_server_ts` to make it easy to do a quick comparison to see if
@@ -58,7 +58,7 @@ closest event is a forward/backward extremity indicating it's next to a gap of
 events which are potentially closer.
 
 ```
-GET /_matrix/client/unstable/org.matrix.msc3030/rooms/<roomID>/timestamp_to_event?ts=<timestamp>&dir=<direction>
+GET /_matrix/client/v1/rooms/<roomID>/timestamp_to_event?ts=<timestamp>&dir=<direction>
 {
     "event_id": ...
     "origin_server_ts": ...
@@ -67,7 +67,7 @@ GET /_matrix/client/unstable/org.matrix.msc3030/rooms/<roomID>/timestamp_to_even
 
 Federation API endpoint:
 ```
-GET /_matrix/federation/unstable/org.matrix.msc3030/timestamp_to_event/<roomID>?ts=<timestamp>&dir=<direction>
+GET /_matrix/federation/v1/timestamp_to_event/<roomID>?ts=<timestamp>&dir=<direction>
 {
     "event_id": ...
     "origin_server_ts": ...
@@ -150,10 +150,20 @@ just a new way to sort through it all.
 
 ## Unstable prefix
 
-*If a proposal is implemented before it is included in the spec, then implementers must ensure that the
-implementation is compatible with the final version that lands in the spec. This generally means that
-experimental implementations should use `/unstable` endpoints, and use vendor prefixes where necessary.
-For more information, see [MSC2324](https://github.com/matrix-org/matrix-doc/pull/2324). This section
-should be used to document things such as what endpoints and names are being used while the feature is
-in development, the name of the unstable feature flag to use to detect support for the feature, or what
-migration steps are needed to switch to newer versions of the proposal.*
+While this MSC is not considered stable, the endpoints are available at `/unstable/org.matrix.msc3030` instead of their `/v1` description from above.
+
+```
+GET /_matrix/client/unstable/org.matrix.msc3030/rooms/<roomID>/timestamp_to_event?ts=<timestamp>&dir=<direction>
+{
+    "event_id": ...
+    "origin_server_ts": ...
+}
+```
+
+```
+GET /_matrix/federation/unstable/org.matrix.msc3030/timestamp_to_event/<roomID>?ts=<timestamp>&dir=<direction>
+{
+    "event_id": ...
+    "origin_server_ts": ...
+}
+```

--- a/proposals/3030-jump-to-date.md
+++ b/proposals/3030-jump-to-date.md
@@ -19,15 +19,31 @@ These types of use cases are not supported by the current Matrix API because it 
 ## Proposal
 
 
-Add new client API endpoint `GET /_matrix/client/r0/rooms/{roomId}/timestamp_to_event?ts=<timestamp>?dir=[f|b]` which fetches the closest event to the given timestamp `ts` query parameter in the direction specified by the `dir` query parameter.
+Add new client API endpoint `GET /_matrix/client/r0/rooms/{roomId}/timestamp_to_event?ts=<timestamp>?dir=[f|b]` which fetches the closest `event_id` to the given timestamp `ts` query parameter in the direction specified by the `dir` query parameter.
 
-In order to solve the problem where a remote federated homeserver does not have all of the history in a room and no suitably close event, we also add a server API endpoint `GET /_matrix/federation/v1/timestamp_to_event/{roomId}?ts=<timestamp>?dir=[f|b]` which other homeservers can use to ask about their closest event to the timestamp.
+In order to solve the problem where a remote federated homeserver does not have all of the history in a room and no suitably close event, we also add a server API endpoint `GET /_matrix/federation/v1/timestamp_to_event/{roomId}?ts=<timestamp>?dir=[f|b]` which other homeservers can use to ask about their closest `event_id` to the timestamp. This endpoint also returns `origin_server_ts` to make it easy to do a quick comparison to see if the remote `event_id` fetched is closer than the local one.
 
 The heuristics for deciding when to ask another homeserver for a closer event if your homeserver doesn't have something close, is left up to the homeserver implementation. Although the heuristics will probably be based on whether the closest event is a forward/backward extremity indicating it's next to a gap of events which are potentially closer.
 
+```
+GET /_matrix/client/unstable/org.matrix.msc3030/rooms/<roomID>/timestamp_to_event?ts=<timestamp>&dir=<direction>
+{
+    "event_id": ...
+}
+```
+
+Federation API endpoint:
+```
+GET /_matrix/federation/unstable/org.matrix.msc3030/timestamp_to_event/<roomID>?ts=<timestamp>&dir=<direction>
+{
+    "event_id": ...
+    "origin_server_ts": ...
+}
+```
+
 ---
 
-In order to paginate `/messages`, we needa pagination token which we can get using `GET /_matrix/client/r0/rooms/{roomId}/context/{eventId}?limi=0` for the `event_id` returned by `/timestamp_to_event`.
+In order to paginate `/messages`, we need a pagination token which we can get using `GET /_matrix/client/r0/rooms/{roomId}/context/{eventId}?limi=0` for the `event_id` returned by `/timestamp_to_event`.
 
 
 ## Potential issues

--- a/proposals/3030-jump-to-date.md
+++ b/proposals/3030-jump-to-date.md
@@ -1,0 +1,73 @@
+# MSC3030: Jump to date API endpoint
+
+Add an API that makes it easy to find the closest messages for a given timestamp.
+
+The goal of this change is to have clients be able to implement a jump to date feature in order to see messages back at a given point in time. Pick a date from a calender, heatmap, or paginate next/previous between days and view all of the messages that were sent on that date.
+
+For our [roadmap of feature parity with Gitter](https://github.com/vector-im/roadmap/issues/26), we're also interested in using this for a new better static Matrix archive. Our idea is to server-side render [Hydrogen](https://github.com/vector-im/hydrogen-web) and this new endpoint would allow us to jump back on the fly without having to paginate and keep track of everything in order to display the selected date.
+
+Also useful for archiving and backup use cases. This new endpoint can be used to slice the messages by day and persist to file.
+
+Related issue: [*URL for an arbitrary day of history and navigation for next and previous days* (vector-im/element-web#7677)](https://github.com/vector-im/element-web/issues/7677)
+
+
+## Problem
+
+These types of use cases are not supported by the current Matrix API because it has no way to fetch or filter older messages besides a manual brute force pagination from the latest. Paginating is time-consuming and expensive to process every event as you go (not practical for clients). Imagine wanting to get a message from 3 years ago 😫
+
+
+## Proposal
+
+Add the `?around=<timestamp>` query parameter to the `GET /_matrix/client/r0/rooms/{roomId}/messages` endpoint. This will start the response at the message with `origin_server_ts` closest to the provided `around` timestamp. The direction is determined by the existing `?dir` query parameter.
+
+Use topoligical ordering, just as Element would use if you follow a permalink.
+
+
+## Potential issues
+
+If you ask for “the message with `origin_server_ts` closest to Jan 1st 2018” you might actually get a rogue random delayed one that was backfilled from a federated server, but the human can figure that out by trying again with a slight variation on the date or something.
+
+
+## Alternatives
+
+### Filter by date in `RoomEventFilter`
+
+Extend `RoomEventFilter` to be able to specify a timestamp or a date range. The `RoomEventFilter` can be passed via the `?filter` query param on the `/messages` endpoint.
+
+
+### New `destination_server_ts` field
+
+Add a new field and index on messages called `destination_server_ts` which indicates when the message was received from federation. This gives a more "real" time for how someone would actually consume those messages.
+
+The contract of the API is "show me messages my server received at time T" rather than the messy confusion of showing a delayed message which happened to originally be sent at time T.
+
+We've decided against this approach because the backfill from federated servers could be horribly late.
+
+---
+
+Related issue around `/sync` vs `/messages`, https://github.com/matrix-org/synapse/issues/7164
+
+> Sync returns things in the order they arrive at the server; backfill returns them in the order determined by the event graph.
+>
+> *-- @richvdh, https://github.com/matrix-org/synapse/issues/7164#issuecomment-605877176*
+
+> The general idea is that, if you're following a room in real-time (ie, `/sync`), you probably want to see the messages as they arrive at your server, rather than skipping any that arrived late; whereas if you're looking at a historical section of timeline (ie, `/messages`), you want to see the best representation of the state of the room as others were seeing it at the time.
+>
+> *-- @richvdh , https://github.com/matrix-org/synapse/issues/7164#issuecomment-605953296*
+
+
+## Security considerations
+
+We're only going to expose messages according to the existing message history setting in the room (`m.room.history_visibility`). No extra data is exposed, just a new way to sort through it all.
+
+
+
+## Unstable prefix
+
+*If a proposal is implemented before it is included in the spec, then implementers must ensure that the
+implementation is compatible with the final version that lands in the spec. This generally means that
+experimental implementations should use `/unstable` endpoints, and use vendor prefixes where necessary.
+For more information, see [MSC2324](https://github.com/matrix-org/matrix-doc/pull/2324). This section
+should be used to document things such as what endpoints and names are being used while the feature is
+in development, the name of the unstable feature flag to use to detect support for the feature, or what
+migration steps are needed to switch to newer versions of the proposal.*

--- a/proposals/3030-jump-to-date.md
+++ b/proposals/3030-jump-to-date.md
@@ -1,29 +1,61 @@
 # MSC3030: Jump to date API endpoint
 
-Add an API that makes it easy to find the closest messages for a given timestamp.
+Add an API that makes it easy to find the closest messages for a given
+timestamp.
 
-The goal of this change is to have clients be able to implement a jump to date feature in order to see messages back at a given point in time. Pick a date from a calender, heatmap, or paginate next/previous between days and view all of the messages that were sent on that date.
+The goal of this change is to have clients be able to implement a jump to date
+feature in order to see messages back at a given point in time. Pick a date from
+a calender, heatmap, or paginate next/previous between days and view all of the
+messages that were sent on that date.
 
-For our [roadmap of feature parity with Gitter](https://github.com/vector-im/roadmap/issues/26), we're also interested in using this for a new better static Matrix archive. Our idea is to server-side render [Hydrogen](https://github.com/vector-im/hydrogen-web) and this new endpoint would allow us to jump back on the fly without having to paginate and keep track of everything in order to display the selected date.
+For our [roadmap of feature parity with
+Gitter](https://github.com/vector-im/roadmap/issues/26), we're also interested
+in using this for a new better static Matrix archive. Our idea is to server-side
+render [Hydrogen](https://github.com/vector-im/hydrogen-web) and this new
+endpoint would allow us to jump back on the fly without having to paginate and
+keep track of everything in order to display the selected date.
 
-Also useful for archiving and backup use cases. This new endpoint can be used to slice the messages by day and persist to file.
+Also useful for archiving and backup use cases. This new endpoint can be used to
+slice the messages by day and persist to file.
 
-Related issue: [*URL for an arbitrary day of history and navigation for next and previous days* (vector-im/element-web#7677)](https://github.com/vector-im/element-web/issues/7677)
+Related issue: [*URL for an arbitrary day of history and navigation for next and
+previous days*
+(vector-im/element-web#7677)](https://github.com/vector-im/element-web/issues/7677)
 
 
 ## Problem
 
-These types of use cases are not supported by the current Matrix API because it has no way to fetch or filter older messages besides a manual brute force pagination from the latest. Paginating is time-consuming and expensive to process every event as you go (not practical for clients). Imagine wanting to get a message from 3 years ago 😫
+These types of use cases are not supported by the current Matrix API because it
+has no way to fetch or filter older messages besides a manual brute force
+pagination from the latest. Paginating is time-consuming and expensive to
+process every event as you go (not practical for clients). Imagine wanting to
+get a message from 3 years ago 😫
 
 
 ## Proposal
 
 
-Add new client API endpoint `GET /_matrix/client/r0/rooms/{roomId}/timestamp_to_event?ts=<timestamp>?dir=[f|b]` which fetches the closest `event_id` to the given timestamp `ts` query parameter in the direction specified by the `dir` query parameter. This endpoint also returns `origin_server_ts` to make it easy to do a quick comparison to see if the `event_id` fetched is too far out of range to be useful for your use case.
+Add new client API endpoint `GET
+/_matrix/client/r0/rooms/{roomId}/timestamp_to_event?ts=<timestamp>?dir=[f|b]`
+which fetches the closest `event_id` to the given timestamp `ts` query parameter
+in the direction specified by the `dir` query parameter. This endpoint also
+returns `origin_server_ts` to make it easy to do a quick comparison to see if
+the `event_id` fetched is too far out of range to be useful for your use case.
 
-In order to solve the problem where a remote federated homeserver does not have all of the history in a room and no suitably close event, we also add a server API endpoint `GET /_matrix/federation/v1/timestamp_to_event/{roomId}?ts=<timestamp>?dir=[f|b]` which other homeservers can use to ask about their closest `event_id` to the timestamp. This endpoint also returns `origin_server_ts` to make it easy to do a quick comparison to see if the remote `event_id` fetched is closer than the local one.
+In order to solve the problem where a remote federated homeserver does not have
+all of the history in a room and no suitably close event, we also add a server
+API endpoint `GET
+/_matrix/federation/v1/timestamp_to_event/{roomId}?ts=<timestamp>?dir=[f|b]`
+which other homeservers can use to ask about their closest `event_id` to the
+timestamp. This endpoint also returns `origin_server_ts` to make it easy to do a
+quick comparison to see if the remote `event_id` fetched is closer than the
+local one.
 
-The heuristics for deciding when to ask another homeserver for a closer event if your homeserver doesn't have something close, is left up to the homeserver implementation. Although the heuristics will probably be based on whether the closest event is a forward/backward extremity indicating it's next to a gap of events which are potentially closer.
+The heuristics for deciding when to ask another homeserver for a closer event if
+your homeserver doesn't have something close, is left up to the homeserver
+implementation. Although the heuristics will probably be based on whether the
+closest event is a forward/backward extremity indicating it's next to a gap of
+events which are potentially closer.
 
 ```
 GET /_matrix/client/unstable/org.matrix.msc3030/rooms/<roomID>/timestamp_to_event?ts=<timestamp>&dir=<direction>
@@ -44,12 +76,17 @@ GET /_matrix/federation/unstable/org.matrix.msc3030/timestamp_to_event/<roomID>?
 
 ---
 
-In order to paginate `/messages`, we need a pagination token which we can get using `GET /_matrix/client/r0/rooms/{roomId}/context/{eventId}?limi=0` for the `event_id` returned by `/timestamp_to_event`.
+In order to paginate `/messages`, we need a pagination token which we can get
+using `GET /_matrix/client/r0/rooms/{roomId}/context/{eventId}?limi=0` for the
+`event_id` returned by `/timestamp_to_event`.
 
 
 ## Potential issues
 
-If you ask for "the message with `origin_server_ts` closest to Jan 1st 2018" you might actually get a rogue random delayed one that was backfilled from a federated server, but the human can figure that out by trying again with a slight variation on the date or something.
+If you ask for "the message with `origin_server_ts` closest to Jan 1st 2018" you
+might actually get a rogue random delayed one that was backfilled from a
+federated server, but the human can figure that out by trying again with a
+slight variation on the date or something.
 
 
 ## Alternatives
@@ -57,39 +94,57 @@ If you ask for "the message with `origin_server_ts` closest to Jan 1st 2018" you
 
 ### Paginate `/messages` from timestamp 
 
-Add the `?around=<timestamp>` query parameter to the `GET /_matrix/client/r0/rooms/{roomId}/messages` endpoint. This will start the response at the message with `origin_server_ts` closest to the provided `around` timestamp. The direction is determined by the existing `?dir` query parameter.
+Add the `?around=<timestamp>` query parameter to the `GET
+/_matrix/client/r0/rooms/{roomId}/messages` endpoint. This will start the
+response at the message with `origin_server_ts` closest to the provided `around`
+timestamp. The direction is determined by the existing `?dir` query parameter.
 
 Use topoligical ordering, just as Element would use if you follow a permalink.
 
 ### Filter by date in `RoomEventFilter`
 
-Extend `RoomEventFilter` to be able to specify a timestamp or a date range. The `RoomEventFilter` can be passed via the `?filter` query param on the `/messages` endpoint.
+Extend `RoomEventFilter` to be able to specify a timestamp or a date range. The
+`RoomEventFilter` can be passed via the `?filter` query param on the `/messages`
+endpoint.
 
 
 ### New `destination_server_ts` field
 
-Add a new field and index on messages called `destination_server_ts` which indicates when the message was received from federation. This gives a more "real" time for how someone would actually consume those messages.
+Add a new field and index on messages called `destination_server_ts` which
+indicates when the message was received from federation. This gives a more
+"real" time for how someone would actually consume those messages.
 
-The contract of the API is "show me messages my server received at time T" rather than the messy confusion of showing a delayed message which happened to originally be sent at time T.
+The contract of the API is "show me messages my server received at time T"
+rather than the messy confusion of showing a delayed message which happened to
+originally be sent at time T.
 
-We've decided against this approach because the backfill from federated servers could be horribly late.
+We've decided against this approach because the backfill from federated servers
+could be horribly late.
 
 ---
 
-Related issue around `/sync` vs `/messages`, https://github.com/matrix-org/synapse/issues/7164
+Related issue around `/sync` vs `/messages`,
+https://github.com/matrix-org/synapse/issues/7164
 
-> Sync returns things in the order they arrive at the server; backfill returns them in the order determined by the event graph.
+> Sync returns things in the order they arrive at the server; backfill returns
+> them in the order determined by the event graph.
 >
 > *-- @richvdh, https://github.com/matrix-org/synapse/issues/7164#issuecomment-605877176*
 
-> The general idea is that, if you're following a room in real-time (ie, `/sync`), you probably want to see the messages as they arrive at your server, rather than skipping any that arrived late; whereas if you're looking at a historical section of timeline (ie, `/messages`), you want to see the best representation of the state of the room as others were seeing it at the time.
+> The general idea is that, if you're following a room in real-time (ie,
+> `/sync`), you probably want to see the messages as they arrive at your server,
+> rather than skipping any that arrived late; whereas if you're looking at a
+> historical section of timeline (ie, `/messages`), you want to see the best
+> representation of the state of the room as others were seeing it at the time.
 >
 > *-- @richvdh , https://github.com/matrix-org/synapse/issues/7164#issuecomment-605953296*
 
 
 ## Security considerations
 
-We're only going to expose messages according to the existing message history setting in the room (`m.room.history_visibility`). No extra data is exposed, just a new way to sort through it all.
+We're only going to expose messages according to the existing message history
+setting in the room (`m.room.history_visibility`). No extra data is exposed,
+just a new way to sort through it all.
 
 
 

--- a/proposals/3030-jump-to-date.md
+++ b/proposals/3030-jump-to-date.md
@@ -38,9 +38,11 @@ get a message from 3 years ago 😫
 Add new client API endpoint `GET
 /_matrix/client/v1/rooms/{roomId}/timestamp_to_event?ts=<timestamp>?dir=[f|b]`
 which fetches the closest `event_id` to the given timestamp `ts` query parameter
-in the direction specified by the `dir` query parameter. This endpoint also
-returns `origin_server_ts` to make it easy to do a quick comparison to see if
-the `event_id` fetched is too far out of range to be useful for your use case.
+in the direction specified by the `dir` query parameter. The direction `dir`
+query parameter accepts `f` for forward-in-time from the timestamp and `b` for
+backward-in-time from the timestamp. This endpoint also returns
+`origin_server_ts` to make it easy to do a quick comparison to see if the
+`event_id` fetched is too far out of range to be useful for your use case.
 
 In order to solve the problem where a remote federated homeserver does not have
 all of the history in a room and no suitably close event, we also add a server

--- a/proposals/3030-jump-to-date.md
+++ b/proposals/3030-jump-to-date.md
@@ -47,17 +47,15 @@ When an event can't be found in the given direction, the endpoint throws a 404
 `"errcode":"M_NOT_FOUND",` (example error message `"error":"Unable to find event
 from 1672531200000 in direction f"`).
 
-In order to solve the problem where a remote federated homeserver does not have
-all of the history in a room and no suitably close event, we also add a server
-API endpoint `GET
-/_matrix/federation/v1/timestamp_to_event/{roomId}?ts=<timestamp>?dir=[f|b]`
-which other homeservers can use to ask about their closest `event_id` to the
-timestamp. This endpoint also returns `origin_server_ts` to make it easy to do a
-quick comparison to see if the remote `event_id` fetched is closer than the
-local one. After the local homeserver receives a response from the federation
-endpoint, it should probably should try to backfill this event via the
-federation `/event/<event_id>` endpoint so that it's available to query with
-`/context` from a client in order to get a pagination token.
+In order to solve the problem where a homeserver does not have all of the history in a
+room and no suitably close event, we also add a server API endpoint `GET
+/_matrix/federation/v1/timestamp_to_event/{roomId}?ts=<timestamp>?dir=[f|b]` which other
+homeservers can use to ask about their closest `event_id` to the timestamp. This
+endpoint also returns `origin_server_ts` to make it easy to do a quick comparison to see
+if the remote `event_id` fetched is closer than the local one. After the local
+homeserver receives a response from the federation endpoint, it should probably should
+try to backfill this event via the federation `/event/<event_id>` endpoint so that it's
+available to query with `/context` from a client in order to get a pagination token.
 
 The heuristics for deciding when to ask another homeserver for a closer event if
 your homeserver doesn't have something close, is left up to the homeserver

--- a/proposals/3030-jump-to-date.md
+++ b/proposals/3030-jump-to-date.md
@@ -34,7 +34,6 @@ get a message from 3 years ago 😫
 
 ## Proposal
 
-
 Add new client API endpoint `GET
 /_matrix/client/v1/rooms/{roomId}/timestamp_to_event?ts=<timestamp>?dir=[f|b]`
 which fetches the closest `event_id` to the given timestamp `ts` query parameter
@@ -88,6 +87,9 @@ GET /_matrix/federation/v1/timestamp_to_event/<roomID>?ts=<timestamp>&dir=<direc
 In order to paginate `/messages`, we need a pagination token which we can get
 using `GET /_matrix/client/r0/rooms/{roomId}/context/{eventId}?limit=0` for the
 `event_id` returned by `/timestamp_to_event`.
+
+We can always iterate on `/timestamp_to_event` later and return a pagination
+token directly in another MSC ⏩
 
 
 ## Potential issues

--- a/proposals/3030-jump-to-date.md
+++ b/proposals/3030-jump-to-date.md
@@ -58,8 +58,8 @@ try to backfill this event via the federation `/event/<event_id>` endpoint so th
 available to query with `/context` from a client in order to get a pagination token.
 
 The heuristics for deciding when to ask another homeserver for a closer event if
-your homeserver doesn't have something close, is left up to the homeserver
-implementation. Although the heuristics will probably be based on whether the
+your homeserver doesn't have something close, are left up to the homeserver
+implementation, although the heuristics will probably be based on whether the
 closest event is a forward/backward extremity indicating it's next to a gap of
 events which are potentially closer.
 

--- a/proposals/3030-jump-to-date.md
+++ b/proposals/3030-jump-to-date.md
@@ -94,10 +94,39 @@ token directly in another MSC ⏩
 
 ## Potential issues
 
+
+### Receiving a rogue random delayed event ID
+
 If you ask for "the message with `origin_server_ts` closest to Jan 1st 2018" you
 might actually get a rogue random delayed one that was backfilled from a
 federated server, but the human can figure that out by trying again with a
 slight variation on the date or something.
+
+
+### Receiving an unrenderable event ID
+
+Another issue is that clients could land on an event they can't/won't render,
+such as a reaction, then they'll be forced to desperately seek around the
+timeline until they find an event they can do something with.
+
+Eg:
+ - Client wants to jump to January 1st, 2022
+ - Server says there's an event on January 2nd, 2022 that is close enough
+ - Client finds out there's a ton of unrenderable events like memberships, poll responses, reactions, etc at that time
+ - Client starts paginating forwards, finally finding an event on January 27th it can render
+ - Client wasn't aware that the actual nearest neighbouring event was backwards on December 28th, 2021 because it didn't paginate in that direction
+ - User is confused that they are a month past the target date when the message is *right there*.
+
+Clients can be smarter here though. Clients can see when events were sent as
+they paginate and if they see they're going more than a couple days out, they
+can also try the other direction before going further and further away.
+
+Clients can also just explain to the user what happened with a little toast: "We
+were unable to find an event to display on January 1st, 2022. The closest event
+after that date is on January 27th."
+
+
+### Abusing the `/timestamp_to_event` API to get the `m.room.create` event 
 
 Clients could abuse this new API for getting the `m.room.create` event, so
 servers might want to put extra care into optimizing whatever lookups they do.

--- a/proposals/3030-jump-to-date.md
+++ b/proposals/3030-jump-to-date.md
@@ -8,7 +8,7 @@ feature in order to see messages back at a given point in time. Pick a date from
 a calender, heatmap, or paginate next/previous between days and view all of the
 messages that were sent on that date.
 
-For our [roadmap of feature parity with
+Alongside the [roadmap of feature parity with
 Gitter](https://github.com/vector-im/roadmap/issues/26), we're also interested
 in using this for a new better static Matrix archive. Our idea is to server-side
 render [Hydrogen](https://github.com/vector-im/hydrogen-web) and this new
@@ -35,7 +35,7 @@ Imagine wanting to get a message from 3 years ago 😫
 ## Proposal
 
 Add new client API endpoint `GET
-/_matrix/client/v1/rooms/{roomId}/timestamp_to_event?ts=<timestamp>?dir=[f|b]`
+/_matrix/client/v1/rooms/{roomId}/timestamp_to_event?ts=<timestamp>&dir=[f|b]`
 which fetches the closest `event_id` to the given timestamp `ts` query parameter
 in the direction specified by the `dir` query parameter. The direction `dir`
 query parameter accepts `f` for forward-in-time from the timestamp and `b` for

--- a/proposals/3030-jump-to-date.md
+++ b/proposals/3030-jump-to-date.md
@@ -132,11 +132,15 @@ after that date is on January 27th."
 
 ### Abusing the `/timestamp_to_event` API to get the `m.room.create` event 
 
-Clients could abuse this new API for getting the `m.room.create` event, so
-servers might want to put extra care into optimizing whatever lookups they do.
-The create event contains quite a lot of information that a client needs in
-order to operate, so it is frequently requested by said clients. For example,
-the room type and room version (for displaying warnings about stability).
+Although it's possible to jump to the start of the room and get the first event in the
+room (`m.room.create`) with `/timestamp_to_event?dir=f&ts=0`, clients should still use
+`GET /_matrix/client/v3/rooms/{roomId}/state/m.room.create/` to get the room creation
+event.
+
+In the future, with things like importing history via
+[MSC2716](https://github.com/matrix-org/matrix-spec-proposals/pull/2716), the first
+event you encounter with `/timestamp_to_event?dir=f&ts=0` could be an imported event before
+the room was created.
 
 
 ## Alternatives

--- a/proposals/3030-jump-to-date.md
+++ b/proposals/3030-jump-to-date.md
@@ -53,7 +53,7 @@ room and no suitably close event, we also add a server API endpoint `GET
 homeservers can use to ask about their closest `event_id` to the timestamp. This
 endpoint also returns `origin_server_ts` to make it easy to do a quick comparison to see
 if the remote `event_id` fetched is closer than the local one. After the local
-homeserver receives a response from the federation endpoint, it should probably should
+homeserver receives a response from the federation endpoint, it probably should
 try to backfill this event via the federation `/event/<event_id>` endpoint so that it's
 available to query with `/context` from a client in order to get a pagination token.
 

--- a/proposals/3030-jump-to-date.md
+++ b/proposals/3030-jump-to-date.md
@@ -146,7 +146,7 @@ reason and we could still go down those routes depending on how people like the
 current design.
 
 
-### Paginate `/messages` from timestamp 
+### Paginate `/messages?around=<timestamp>` from timestamp
 
 Add the `?around=<timestamp>` query parameter to the `GET
 /_matrix/client/r0/rooms/{roomId}/messages` endpoint. This will start the
@@ -155,11 +155,27 @@ timestamp. The direction is determined by the existing `?dir` query parameter.
 
 Use topological ordering, just as Element would use if you follow a permalink.
 
+This alternative could be confusing to the end-user around how this plays with
+the existing query parameters
+`/messages?from={paginationToken}&to={paginationToken}` which also determine
+what part of the timeline to query. Those parameters could be extended to accept
+timestamps in addition to pagination tokens but then could get confusing again
+when you start mixing timestamps and pagination tokens. The homeserver also has
+to disambiguate what a pagination token looks like vs a unix timestamp. Since
+pagination tokens don't follow a certain convention, some homeserver
+implementations may already be using arbitrary number tokens already which would
+be impossible to distinguish from  a timestamp.
+
+
 ### Filter by date in `RoomEventFilter`
 
 Extend `RoomEventFilter` to be able to specify a timestamp or a date range. The
 `RoomEventFilter` can be passed via the `?filter` query param on the `/messages`
 endpoint.
+
+This suffers from the same confusion to the end-user of how it plays with how
+this plays with `/messages?from={paginationToken}&to={paginationToken}` which
+also determines what part of the timeline to query.
 
 
 ### New `destination_server_ts` field

--- a/proposals/3030-jump-to-date.md
+++ b/proposals/3030-jump-to-date.md
@@ -44,9 +44,9 @@ backward-in-time from the timestamp. This endpoint also returns
 `origin_server_ts` to make it easy to do a quick comparison to see if the
 `event_id` fetched is too far out of range to be useful for your use case.
 
-When an event can't be found, the endpoint throws a 404
-`"errcode":"M_NOT_FOUND",` (example error message `"error":"Unable to find
-event from 1672531200000 in direction f"`).
+When an event can't be found in the given direction, the endpoint throws a 404
+`"errcode":"M_NOT_FOUND",` (example error message `"error":"Unable to find event
+from 1672531200000 in direction f"`).
 
 In order to solve the problem where a remote federated homeserver does not have
 all of the history in a room and no suitably close event, we also add a server
@@ -96,6 +96,14 @@ slight variation on the date or something.
 
 
 ## Alternatives
+
+We chose the current `/timestamp_to_event` route because it sounded like the
+easist path forward to bring it to fruition and get some real-world experience.
+And was on our mind during the [initial discussion](https://docs.google.com/document/d/1KCEmpnGr4J-I8EeaVQ8QJZKBDu53ViI7V62y5BzfXr0/edit#bookmark=id.qu9k9wje9pxm) because there was some prior art with a [WIP
+implementation](https://github.com/matrix-org/synapse/pull/9445/commits/91b1b3606c9fb9eede0a6963bc42dfb70635449f)
+from @erikjohnston. The alternatives haven't been thrown out for a particular
+reason and we could still go down those routes depending on how people like the
+current design.
 
 
 ### Paginate `/messages` from timestamp 

--- a/proposals/3030-jump-to-date.md
+++ b/proposals/3030-jump-to-date.md
@@ -79,7 +79,7 @@ GET /_matrix/federation/v1/timestamp_to_event/<roomID>?ts=<timestamp>&dir=<direc
 ---
 
 In order to paginate `/messages`, we need a pagination token which we can get
-using `GET /_matrix/client/r0/rooms/{roomId}/context/{eventId}?limi=0` for the
+using `GET /_matrix/client/r0/rooms/{roomId}/context/{eventId}?limit=0` for the
 `event_id` returned by `/timestamp_to_event`.
 
 
@@ -101,7 +101,7 @@ Add the `?around=<timestamp>` query parameter to the `GET
 response at the message with `origin_server_ts` closest to the provided `around`
 timestamp. The direction is determined by the existing `?dir` query parameter.
 
-Use topoligical ordering, just as Element would use if you follow a permalink.
+Use topological ordering, just as Element would use if you follow a permalink.
 
 ### Filter by date in `RoomEventFilter`
 

--- a/proposals/3030-jump-to-date.md
+++ b/proposals/3030-jump-to-date.md
@@ -27,9 +27,9 @@ previous days*
 
 These types of use cases are not supported by the current Matrix API because it
 has no way to fetch or filter older messages besides a manual brute force
-pagination from the latest. Paginating is time-consuming and expensive to
-process every event as you go (not practical for clients). Imagine wanting to
-get a message from 3 years ago 😫
+pagination from the most recent event in the room. Paginating is time-consuming
+and expensive to process every event as you go (not practical for clients).
+Imagine wanting to get a message from 3 years ago 😫
 
 
 ## Proposal
@@ -54,7 +54,10 @@ API endpoint `GET
 which other homeservers can use to ask about their closest `event_id` to the
 timestamp. This endpoint also returns `origin_server_ts` to make it easy to do a
 quick comparison to see if the remote `event_id` fetched is closer than the
-local one.
+local one. After the local homeserver receives a response from the federation
+endpoint, it should probably should try to backfill this event so that it's
+available to query with `/context` from a client in order to get a pagination
+token.
 
 The heuristics for deciding when to ask another homeserver for a closer event if
 your homeserver doesn't have something close, is left up to the homeserver
@@ -93,7 +96,6 @@ token directly in another MSC ⏩
 
 
 ## Potential issues
-
 
 ### Receiving a rogue random delayed event ID
 

--- a/proposals/3030-jump-to-date.md
+++ b/proposals/3030-jump-to-date.md
@@ -191,6 +191,38 @@ this plays with `/messages?from={paginationToken}&to={paginationToken}` which
 also determines what part of the timeline to query.
 
 
+### Return the closest event in any direction
+
+The question you may be asking is "What's the rationale for including a `dir`? Can't we
+just return the closest/nearest event regardless of direction?" Or at least add a
+`dir=c` for the option to find the closest event.
+
+For clients, it doesn't make that much of a difference because you can always compare
+the timestamp you made the request with to the `origin_server_ts` that was returned to
+see what direction you need to paginate further in. And it's a
+[toss-up](https://github.com/matrix-org/matrix-spec-proposals/pull/3030#discussion_r851544627)
+in the amount of client complexity for various use cases on the extra logic (some will
+require more and others won't depending on the approach we pick).
+
+But the `dir` parameter does help us be a little more efficient on the homeserver.
+Without `dir`, the homeserver has to check for a gap both forwards and backwards on
+every request. If we include the `dir` parameter, we only have to check in one
+direction. And then in both cases, the client still decides which direction they want
+paginate further in. (this optimization is kind of a "who cares" point though)
+
+For the archive use case where we only care about showing the messages that happened on
+a specific day, the `dir` parameter helps narrow down specifically on what we
+specifically care about [without extra
+logic](https://github.com/matrix-org/matrix-spec-proposals/pull/3030#discussion_r851544627).
+This applies to a similar use case for fetching windows of time (e.g. Jan 1 (dir = f) -
+Jan 5 (dir = b)).
+
+For the messaging client use case, the user might care more about the closest event
+regardless of direction. But since the closest event could be some unrenderable message
+(like a reaction), the client still needs to find a suitable nearby event anyways making
+the closest event a bit pointless.
+
+
 ### New `destination_server_ts` field
 
 Add a new field and index on messages called `destination_server_ts` which

--- a/proposals/3030-jump-to-date.md
+++ b/proposals/3030-jump-to-date.md
@@ -44,6 +44,10 @@ backward-in-time from the timestamp. This endpoint also returns
 `origin_server_ts` to make it easy to do a quick comparison to see if the
 `event_id` fetched is too far out of range to be useful for your use case.
 
+When an event can't be found, the endpoint throws a 404
+`"errcode":"M_NOT_FOUND",` (example error message `"error":"Unable to find
+event from 1672531200000 in direction f"`).
+
 In order to solve the problem where a remote federated homeserver does not have
 all of the history in a room and no suitably close event, we also add a server
 API endpoint `GET

--- a/proposals/3030-jump-to-date.md
+++ b/proposals/3030-jump-to-date.md
@@ -55,9 +55,9 @@ which other homeservers can use to ask about their closest `event_id` to the
 timestamp. This endpoint also returns `origin_server_ts` to make it easy to do a
 quick comparison to see if the remote `event_id` fetched is closer than the
 local one. After the local homeserver receives a response from the federation
-endpoint, it should probably should try to backfill this event so that it's
-available to query with `/context` from a client in order to get a pagination
-token.
+endpoint, it should probably should try to backfill this event via the
+federation `/event/<event_id>` endpoint so that it's available to query with
+`/context` from a client in order to get a pagination token.
 
 The heuristics for deciding when to ask another homeserver for a closer event if
 your homeserver doesn't have something close, is left up to the homeserver

--- a/proposals/3030-jump-to-date.md
+++ b/proposals/3030-jump-to-date.md
@@ -63,6 +63,9 @@ implementation. Although the heuristics will probably be based on whether the
 closest event is a forward/backward extremity indicating it's next to a gap of
 events which are potentially closer.
 
+These endpoints are authenticated and should be rate-limited like similar client
+and federation endpoints to prevent resource exhaustion abuse.
+
 ```
 GET /_matrix/client/v1/rooms/<roomID>/timestamp_to_event?ts=<timestamp>&dir=<direction>
 {

--- a/proposals/3030-jump-to-date.md
+++ b/proposals/3030-jump-to-date.md
@@ -172,6 +172,15 @@ pagination tokens don't follow a certain convention, some homeserver
 implementations may already be using arbitrary number tokens already which would
 be impossible to distinguish from  a timestamp.
 
+A related alternative is to use `/messages` with a `from_time`/`to_time` (or
+`from_ts`/`to_ts`) query parameters that only accept timestamps which solves the
+confusion and disambigution problem of trying to re-use the existing `from`/`to`
+query paramters. Re-using `/messages` would reduce the number of round-trips and
+potentially client-side implementations for the use case where you want to fetch
+a window of messages from a given time. But has the same round-trip problem if
+you want to use the returned `event_id` with `/context` or another endpoint
+instead.
+
 
 ### Filter by date in `RoomEventFilter`
 

--- a/proposals/3030-jump-to-date.md
+++ b/proposals/3030-jump-to-date.md
@@ -101,10 +101,16 @@ token directly in another MSC ⏩
 
 ### Receiving a rogue random delayed event ID
 
+Since `origin_server_ts` is not enforcably accurate, we can only hope that an event's
+`origin_server_ts` is relevant enough to its `prev_events` and descendants.
+
 If you ask for "the message with `origin_server_ts` closest to Jan 1st 2018" you
 might actually get a rogue random delayed one that was backfilled from a
 federated server, but the human can figure that out by trying again with a
 slight variation on the date or something.
+
+Since there isn't a good or fool-proof way to combat this, it's probably best to just go
+with `origin_server_ts` and not let perfect be the enemy of good.
 
 
 ### Receiving an unrenderable event ID

--- a/proposals/3030-jump-to-date.md
+++ b/proposals/3030-jump-to-date.md
@@ -65,6 +65,10 @@ implementation. Although the heuristics will probably be based on whether the
 closest event is a forward/backward extremity indicating it's next to a gap of
 events which are potentially closer.
 
+A good heuristic for which servers to try first is to sort by servers that have
+been in the room the longest because they're most likely to have anything we ask
+about.
+
 These endpoints are authenticated and should be rate-limited like similar client
 and federation endpoints to prevent resource exhaustion abuse.
 

--- a/proposals/3030-jump-to-date.md
+++ b/proposals/3030-jump-to-date.md
@@ -99,6 +99,12 @@ might actually get a rogue random delayed one that was backfilled from a
 federated server, but the human can figure that out by trying again with a
 slight variation on the date or something.
 
+Clients could abuse this new API for getting the `m.room.create` event, so
+servers might want to put extra care into optimizing whatever lookups they do.
+The create event contains quite a lot of information that a client needs in
+order to operate, so it is frequently requested by said clients. For example,
+the room type and room version (for displaying warnings about stability).
+
 
 ## Alternatives
 


### PR DESCRIPTION
MSC3030: Jump to date API endpoint

[Rendered](https://github.com/matrix-org/matrix-doc/blob/eric/msc-jump-to-date/proposals/3030-jump-to-date.md)
[FCP proposal](https://github.com/matrix-org/matrix-doc/pull/3030#issuecomment-1013856557)

Homeserver implementations:

 - Synapse: https://github.com/matrix-org/synapse/pull/9445

Client implementations:

 - `/jumptodate` slash command, https://github.com/matrix-org/matrix-react-sdk/pull/7372
 - Jump to date headers (with date picker) in timeline: https://github.com/matrix-org/matrix-react-sdk/pull/7339
 - Matrix Public Archive: https://github.com/matrix-org/matrix-public-archive

---

Related issues:

 - https://github.com/vector-im/element-web/issues/7677
 - https://github.com/matrix-org/synapse/issues/7164

