### PR TITLE
MSC3706: Extensions to `/_matrix/federation/v2/send_join/{roomId}/{eventId}` for partial state

### DIFF
--- a/proposals/3706-partial-state-in-send-join.md
+++ b/proposals/3706-partial-state-in-send-join.md
@@ -23,7 +23,8 @@ following changes.
 ### New query parameter
 
 `partial_state` is added as a new query parameter. This can take the values
-`true` or `false`; other values should be rejected with an HTTP 400 error.
+`true` or `false`; other values should be rejected with an HTTP 400 error with
+matrix error code `M_INVALID_PARAM`.
 
 Calling servers use this parameter to indicate support for partial state in
 `send_join`. If it is not set to `true`, receiving servers continue to behave
@@ -41,8 +42,9 @@ The following changes are made to the response:
    to `false` or omitted.
 
  * `state`: if partial state is being returned, then state events with event
-   type `m.room.member` are omitted from the response. (All other room state is
-   returned as normal.)
+   type `m.room.member` are omitted from the response. All other room state is
+   returned as normal. (See 'Alternatives' for discussion on why only
+   `m.room.member` events are omitted.)
  
  * `auth_chain`: The spec currently defines this as "The auth chain for the
    entire current room state". We instead rephrase this as:
@@ -80,8 +82,15 @@ None at present.
 ## Alternatives
 
  * In future, the list of event types to omit could be expanded. (Some rooms
-   may have large numbers of other state events). For now, this has been
-   descoped, but could be revisited in future MSCs.
+   may have large numbers of other state events).
+   
+   Currently, `m.room.member` events are by far the biggest problem. For
+   example, a `/send_join` request for Matrix HQ returns approximately 85000
+   events in `state`, of which all but 44 are `m.room.member`. 
+
+   In order to reduce the scope of the change, we have therefore decided to
+   focus on `m.room.member` events for now. Future MSCs might provde a
+   mechanism for omitting other event types.
  
 ## Security considerations
 

--- a/proposals/3706-partial-state-in-send-join.md
+++ b/proposals/3706-partial-state-in-send-join.md
@@ -6,8 +6,7 @@ It is well known that joining large rooms over federation can be very slow (see,
 for example, [synapse#1211](https://github.com/matrix-org/synapse/issues/1211)).
 
 Much of the reason for this is the large number of events which are returned by
-the
-[`/send_join`](https://spec.matrix.org/v1.2/server-server-api/#put_matrixfederationv2send_joinroomideventid)
+the [`/send_join`](https://spec.matrix.org/v1.2/server-server-api/#put_matrixfederationv2send_joinroomideventid)
 API, and must be validated and stored.
 
 [MSC2775](https://github.com/matrix-org/matrix-doc/pull/2775) makes a number of
@@ -17,12 +16,11 @@ API.
 
 ## Proposal
 
-[`PUT
-/_matrix/federation/v2/send_join/{roomId}/{eventId}/send_join`](https://spec.matrix.org/v1.2/server-server-api/#put_matrixfederationv2send_joinroomideventid)
+[`PUT /_matrix/federation/v2/send_join/{roomId}/{eventId}/send_join`](https://spec.matrix.org/v1.2/server-server-api/#put_matrixfederationv2send_joinroomideventid)
 is extended to support "partial state" in its responses. This involves the
 following changes.
 
-### New query parametter
+### New query parameter
 
 `partial_state` is added as a new query parameter. This can take the values
 `true` or `false`; other values should be rejected with an HTTP 400 error.

--- a/proposals/3706-partial-state-in-send-join.md
+++ b/proposals/3706-partial-state-in-send-join.md
@@ -22,7 +22,7 @@ following changes.
 
 ### New query parameter
 
-`omit_member_events` is added as a new query parameter. This can take the values
+`omit_members` is added as a new query parameter. This can take the values
 `true` or `false`; other values should be rejected with an HTTP 400 error with
 matrix error code `M_INVALID_PARAM`.
 
@@ -37,7 +37,7 @@ free to support it for some rooms and not others.
 
 The following changes are made to the response:
 
- * `member_events_omitted`: a new boolean field is added. This should be set to `true`
+ * `members_omitted`: a new boolean field is added. This should be set to `true`
    to indicate that `m.room.member` events have been omitted from the response.
    It must otherwise be set to `false` or omitted.
 
@@ -55,7 +55,7 @@ The following changes are made to the response:
    (Note that in the case that full state is being returned, the two
    definitions are equivalent.)
 
- * If the `omit_member_events` query parameter was set, we make a further
+ * If the `omit_members` query parameter was set, we make a further
    optimisation to `auth_chain`:
 
    > Any events returned within `state` can be omitted from `auth_chain`.
@@ -64,7 +64,7 @@ The following changes are made to the response:
    must be included in `state`. However, it also forms part of the auth chain
    for all of the returned events, so in the current spec, must *also* be
    included in `auth_chain`. However, this is redundant, so we should omit it
-   for calling servers which opt into that via the `omit_member_events` query param.
+   for calling servers which opt into that via the `omit_members` query param.
 
  * `servers_in_room`: A new field of type `[string]`, listing the servers
    active in the room (ie, those with joined members) before the join.
@@ -72,7 +72,7 @@ The following changes are made to the response:
    This is to be used by the joining server to send outgoing federation
    transactions while it synchronises the full state, as outlined in [MSC3902](https://github.com/matrix-org/matrix-spec-proposals/pull/3902).
 
-   This field is **required** if the `member_events_omitted` response field is true; it
+   This field is **required** if the `members_omitted` response field is true; it
    is otherwise optional.
 
 ## Potential issues
@@ -113,8 +113,8 @@ development:
 
 Proposed final identifier | Purpose         | Development identifier
 ------------------------- | --------------- | ----
-`omit_member_events`      | query parameter | `org.matrix.msc3706.partial_state`
-`member_events_omitted`   | response field  | `org.matrix.msc3706.partial_state`
+`omit_members`            | query parameter | `org.matrix.msc3706.partial_state`
+`members_omitted`         | response field  | `org.matrix.msc3706.partial_state`
 `servers_in_room`         | response field  | `org.matrix.msc3706.servers_in_room`
 
 ## Dependencies

--- a/proposals/3706-partial-state-in-send-join.md
+++ b/proposals/3706-partial-state-in-send-join.md
@@ -70,7 +70,7 @@ The following changes are made to the response:
    active in the room (ie, those with joined members) before the join.
 
    This is to be used by the joining server to send outgoing federation
-   transactions while it synchronises the full state.
+   transactions while it synchronises the full state, as outlined in [MSC3902](https://github.com/matrix-org/matrix-spec-proposals/pull/3902).
 
    This field is **required** if the `partial_state` response field is true; it
    is otherwise optional.

--- a/proposals/3706-partial-state-in-send-join.md
+++ b/proposals/3706-partial-state-in-send-join.md
@@ -1,0 +1,83 @@
+# MSC3706: Extensions to `/_matrix/federation/v2/send_join/{roomId}/{eventId}` for partial state
+
+## Background
+
+It is well known that joining large rooms over federation can be very slow (see,
+for example, [synapse#1211](https://github.com/matrix-org/synapse/issues/1211)).
+
+Much of the reason for this is the large number of events which are returned by
+the
+[`/send_join`](https://spec.matrix.org/v1.2/server-server-api/#put_matrixfederationv2send_joinroomideventid)
+API, and must be validated and stored.
+
+[MSC2775](https://github.com/matrix-org/matrix-doc/pull/2775) makes a number of
+suggestions for ways that this can be improved. This MSC focusses on a specific
+aspect of those suggestions by proposing specific changes to the `/send_join`
+API.
+
+## Proposal
+
+[`PUT
+/_matrix/federation/v2/send_join/{roomId}/{eventId}/send_join`](https://spec.matrix.org/v1.2/server-server-api/#put_matrixfederationv2send_joinroomideventid)
+is extended to support "partial state" in its responses. This involves the
+following changes:
+
+First, we add a query-parameter, `partial_state`. This can take the values
+`true` or `false`; other values should be rejected with an HTTP 400 error.
+
+Calling servers use this parameter to indicate support for partial state in
+`send_join`. If it is not set to `true`, receiving servers continue to behave
+as they do today.
+
+Receiving servers are not obliged to implement partial state; they are also
+free to support it for some rooms and not others.
+
+The following changes are made to the response:
+
+ * `partial_state`: a new boolean field is added. This should be set to `true`
+   to indicate that partial state is being returned. It must otherwise be set
+   to `false` or omitted.
+
+ * `state`: if partial state is being returned, then a subset of the full room
+   state, rather than the complete room state. In particular, the following
+   state should be returned:
+
+     * any state with event type other than `m.room.member`.
+     * TODO: anything else?
+
+ * `auth_chain`: The spec currently defines this as "The auth chain for the
+   entire current room state". We instead rephrase this as:
+
+   All events in the auth chain for the returned join event, as well as
+   those in the auth chains for any events returned in `state`.
+
+   (Note that in the case that full state is being returned, the two
+   definitions are equivalent.)
+
+ * `servers_in_room`: A new field of type `[string]`, listing the servers
+   active in the room (ie, those with joined members) before the join.
+
+   This is to be used by the joining server to send outgoing federation
+   transactions while it synchronises the full state.
+
+
+## Potential issues
+
+TBD
+
+## Alternatives
+
+TBD
+
+## Security considerations
+
+No security issues are currently foreseen with this specific MSC, though the
+larger topic of incremental synchronisation of state has several concerns;
+these will be discussed in other MSCs such as MSC2775.
+
+## Unstable prefix
+
+
+## Dependencies
+
+This MSC does not build on any existing unaccepted MSCs.

--- a/proposals/3706-partial-state-in-send-join.md
+++ b/proposals/3706-partial-state-in-send-join.md
@@ -24,17 +24,17 @@ following changes.
 
 ### New query parametter
 
-`partial_state` is added as a new query parameter This can take the values
+`partial_state` is added as a new query parameter. This can take the values
 `true` or `false`; other values should be rejected with an HTTP 400 error.
 
 Calling servers use this parameter to indicate support for partial state in
 `send_join`. If it is not set to `true`, receiving servers continue to behave
 as they do today.
 
-Receiving servers are not obliged to implement partial state; they are also
-free to support it for some rooms and not others.
-
 ### Changes to the response
+
+Receiving servers are not obliged to implement partial state: they are also
+free to support it for some rooms and not others.
 
 The following changes are made to the response:
 

--- a/proposals/3706-partial-state-in-send-join.md
+++ b/proposals/3706-partial-state-in-send-join.md
@@ -11,7 +11,7 @@ the
 API, and must be validated and stored.
 
 [MSC2775](https://github.com/matrix-org/matrix-doc/pull/2775) makes a number of
-suggestions for ways that this can be improved. This MSC focusses on a specific
+suggestions for ways that this can be improved. This MSC focuses on a specific
 aspect of those suggestions by proposing specific changes to the `/send_join`
 API.
 
@@ -76,6 +76,14 @@ larger topic of incremental synchronisation of state has several concerns;
 these will be discussed in other MSCs such as MSC2775.
 
 ## Unstable prefix
+
+The following mapping will be used for identifiers in this MSC during
+development:
+
+Proposed final identifier       | Purpose | Development identifier
+------------------------------- | ------- | ----
+`partial_state` | query parameter, response field | `org.matrix.msc3706.partial_state`
+`servers_in_room` | response field | `org.matrix.msc3706.servers_in_room`
 
 
 ## Dependencies

--- a/proposals/3706-partial-state-in-send-join.md
+++ b/proposals/3706-partial-state-in-send-join.md
@@ -73,6 +73,8 @@ The following changes are made to the response:
    This is to be used by the joining server to send outgoing federation
    transactions while it synchronises the full state.
 
+   This field is **required** if the `partial_state` response field is true; it
+   is otherwise optional.
 
 ## Potential issues
 

--- a/proposals/3706-partial-state-in-send-join.md
+++ b/proposals/3706-partial-state-in-send-join.md
@@ -22,7 +22,7 @@ following changes.
 
 ### New query parameter
 
-`partial_state` is added as a new query parameter. This can take the values
+`omit_member_events` is added as a new query parameter. This can take the values
 `true` or `false`; other values should be rejected with an HTTP 400 error with
 matrix error code `M_INVALID_PARAM`.
 
@@ -37,9 +37,9 @@ free to support it for some rooms and not others.
 
 The following changes are made to the response:
 
- * `partial_state`: a new boolean field is added. This should be set to `true`
-   to indicate that partial state is being returned. It must otherwise be set
-   to `false` or omitted.
+ * `member_events_omitted`: a new boolean field is added. This should be set to `true`
+   to indicate that `m.room.member` events have been omitted from the response.
+   It must otherwise be set to `false` or omitted.
 
  * `state`: if partial state is being returned, then state events with event
    type `m.room.member` are omitted from the response. All other room state is
@@ -55,7 +55,7 @@ The following changes are made to the response:
    (Note that in the case that full state is being returned, the two
    definitions are equivalent.)
 
- * If the `partial_state` query parameter was set, we make a further
+ * If the `omit_member_events` query parameter was set, we make a further
    optimisation to `auth_chain`:
 
    > Any events returned within `state` can be omitted from `auth_chain`.
@@ -64,7 +64,7 @@ The following changes are made to the response:
    must be included in `state`. However, it also forms part of the auth chain
    for all of the returned events, so in the current spec, must *also* be
    included in `auth_chain`. However, this is redundant, so we should omit it
-   for calling servers which opt into that via the `partial_state` query param.
+   for calling servers which opt into that via the `omit_member_events` query param.
 
  * `servers_in_room`: A new field of type `[string]`, listing the servers
    active in the room (ie, those with joined members) before the join.
@@ -72,7 +72,7 @@ The following changes are made to the response:
    This is to be used by the joining server to send outgoing federation
    transactions while it synchronises the full state, as outlined in [MSC3902](https://github.com/matrix-org/matrix-spec-proposals/pull/3902).
 
-   This field is **required** if the `partial_state` response field is true; it
+   This field is **required** if the `member_events_omitted` response field is true; it
    is otherwise optional.
 
 ## Potential issues
@@ -87,6 +87,14 @@ None at present.
    Currently, `m.room.member` events are by far the biggest problem. For
    example, a `/send_join` request for Matrix HQ returns approximately 85000
    events in `state`, of which all but 44 are `m.room.member`. 
+
+   Additionally: the client-server API already provides a mechanism for
+   omitting `m.room.member` events from the `/sync` response, via
+   [lazy loading](https://spec.matrix.org/v1.4/client-server-api/#lazy-loading-room-members),
+   which means that this change can be implemented without changes to the
+   client-server API. Extending the list of event types to be omitted would
+   require changes to the client-server API and therefore be significantly more
+   involved.
 
    In order to reduce the scope of the change, we have therefore decided to
    focus on `m.room.member` events for now. Future MSCs might provide a
@@ -103,11 +111,11 @@ these will be discussed in other MSCs such as MSC3902.
 The following mapping will be used for identifiers in this MSC during
 development:
 
-Proposed final identifier       | Purpose | Development identifier
-------------------------------- | ------- | ----
-`partial_state` | query parameter, response field | `org.matrix.msc3706.partial_state`
-`servers_in_room` | response field | `org.matrix.msc3706.servers_in_room`
-
+Proposed final identifier | Purpose         | Development identifier
+------------------------- | --------------- | ----
+`omit_member_events`      | query parameter | `org.matrix.msc3706.partial_state`
+`member_events_omitted`   | response field  | `org.matrix.msc3706.partial_state`
+`servers_in_room`         | response field  | `org.matrix.msc3706.servers_in_room`
 
 ## Dependencies
 

--- a/proposals/3706-partial-state-in-send-join.md
+++ b/proposals/3706-partial-state-in-send-join.md
@@ -16,7 +16,7 @@ on a specific aspect of those suggestions by proposing specific changes to the
 
 ## Proposal
 
-[`PUT /_matrix/federation/v2/send_join/{roomId}/{eventId}/send_join`](https://spec.matrix.org/v1.2/server-server-api/#put_matrixfederationv2send_joinroomideventid)
+[`PUT /_matrix/federation/v2/send_join/{roomId}/{eventId}`](https://spec.matrix.org/v1.2/server-server-api/#put_matrixfederationv2send_joinroomideventid)
 is extended to support "partial state" in its responses. This involves the
 following changes.
 
@@ -89,7 +89,7 @@ None at present.
    events in `state`, of which all but 44 are `m.room.member`. 
 
    In order to reduce the scope of the change, we have therefore decided to
-   focus on `m.room.member` events for now. Future MSCs might provde a
+   focus on `m.room.member` events for now. Future MSCs might provide a
    mechanism for omitting other event types.
  
 ## Security considerations

--- a/proposals/3706-partial-state-in-send-join.md
+++ b/proposals/3706-partial-state-in-send-join.md
@@ -9,10 +9,10 @@ Much of the reason for this is the large number of events which are returned by
 the [`/send_join`](https://spec.matrix.org/v1.2/server-server-api/#put_matrixfederationv2send_joinroomideventid)
 API, and must be validated and stored.
 
-[MSC2775](https://github.com/matrix-org/matrix-doc/pull/2775) makes a number of
-suggestions for ways that this can be improved. This MSC focuses on a specific
-aspect of those suggestions by proposing specific changes to the `/send_join`
-API.
+[MSC3902](https://github.com/matrix-org/matrix-doc/pull/3902) gives an overview
+of changes to the matrix protocol to improve this situation. This MSC focuses
+on a specific aspect of those suggestions by proposing specific changes to the
+`/send_join` API.
 
 ## Proposal
 
@@ -40,13 +40,10 @@ The following changes are made to the response:
    to indicate that partial state is being returned. It must otherwise be set
    to `false` or omitted.
 
- * `state`: if partial state is being returned, then a subset of the full room
-   state, rather than the complete room state. In particular, the following
-   state should be returned:
-
-     * any state with event type other than `m.room.member`.
-     * TODO: anything else?
-
+ * `state`: if partial state is being returned, then state events with event
+   type `m.room.member` are omitted from the response. (All other room state is
+   returned as normal.)
+ 
  * `auth_chain`: The spec currently defines this as "The auth chain for the
    entire current room state". We instead rephrase this as:
 
@@ -78,17 +75,19 @@ The following changes are made to the response:
 
 ## Potential issues
 
-TBD
+None at present.
 
 ## Alternatives
 
-TBD
-
+ * In future, the list of event types to omit could be expanded. (Some rooms
+   may have large numbers of other state events). For now, this has been
+   descoped, but could be revisited in future MSCs.
+ 
 ## Security considerations
 
 No security issues are currently foreseen with this specific MSC, though the
 larger topic of incremental synchronisation of state has several concerns;
-these will be discussed in other MSCs such as MSC2775.
+these will be discussed in other MSCs such as MSC3902.
 
 ## Unstable prefix
 


### PR DESCRIPTION
Rendered: https://github.com/matrix-org/matrix-doc/blob/rav/proposal/partial_state_on_join/proposals/3706-partial-state-in-send-join.md

Server-side synapse implementation is in https://github.com/matrix-org/synapse/pull/11967.
Client-side parsing is https://github.com/matrix-org/synapse/pull/12011; the real implementation is an 8-month epic, but https://github.com/matrix-org/synapse/blob/v1.68.0/synapse/handlers/federation.py#L616-L625 is a reasonable place to start looking.

[FCP comment](https://github.com/matrix-org/matrix-spec-proposals/pull/3706#issuecomment-1274758677)