### PR TITLE
MSC3765: Rich text in room topics

### DIFF
--- a/proposals/3677-rich-room-topics.md
+++ b/proposals/3677-rich-room-topics.md
@@ -1,0 +1,97 @@
+# MSC3677: Rich text in room topics
+
+## Problem
+
+Topics are a central piece of room meta data and usually made easily
+accessible to room members in clients. As a result, room administrators
+often extend the use of topics to collect helpful peripheral information
+that is related to the room’s purpose. Most commonly these are links to
+external resources. At the moment, topics are limitted to [plain text]
+which, depending on the number and length of URLs and other content,
+easily gets inconvenient to consume and calls for richer text formatting
+options.
+
+## Proposal
+
+To enrich `m.room.topic` events, we build upon extensible events as
+defined in [MSC1767] and define a new `m.topic` event in `content`.
+The latter contains a list of renderings in the same format that
+[MSC1767] uses for `m.message` events.
+
+``` json
+{
+    "type": "m.room.topic",
+    "state_key": "",
+    "content": {
+        "m.topic": [{
+            "mimetype": "text/html", // optional, default text/plain
+            "body": "All about <b>pizza</b> | <a href=\"https://recipes.pizza.net\">Recipes</a>"
+        }, {
+            "mimetype": "text/plain",
+            "body": "All about **pizza** | [Recipes](https://recipes.pizza.net)"
+        }],
+    },
+    ...
+}
+```
+
+A change to `/_matrix/client/v3/createRoom` is not necessary. The
+endpoint has a plain text `topic` parameter but also allows to specify a
+full `m.room.topic` event in `initial_state`.
+
+Room topics also occur as part of the `PublicRoomsChunk` object in the
+responses of `/_matrix/client/v3/publicRooms` and
+`/_matrix/client/v1/rooms/{roomId}/hierarchy`. The topic can be kept
+plain text here because this data should commonly only be displayed to
+users that are *not* a member of the room yet. These users will not have
+the same need for rich room topics as users who are inside the room.
+
+## Transition
+
+Similar to [MSC1767] a time-constrained transition period is proposed.
+Upon being included in a released version of the specification, the
+following happens:
+
+-   The `topic` field in the content of `m.room.topic` events is
+    deprecated
+-   Clients continue to include `topic` in outgoing events as a fallback
+-   Clients prefer the new `m.topic` format in events which include it
+-   A 1 year timer begins for clients to implement the above conditions
+    -   This can be shortened if the ecosystem adopts the format sooner
+    -   After the (potentially shortened) timer, an MSC is introduced to
+        remove the deprecated `topic` field. Once accepted under the
+        relevant process, clients stop including the field in outgoing
+        events.
+
+## Potential issues
+
+None.
+
+## Alternatives
+
+The combination of `format` and `formatted_body` currently utilised to
+enable HTML in `m.room.message` events could be generalised to
+`m.room.topic` events. However, this would only allow for a single
+format in addition to plain text and is a weaker form of reuse as
+described in the introductory section of [MSC1767].
+
+## Security considerations
+
+Allowing HTML in room topics is subject to the same security
+considerations that apply to HTML in room messages.
+
+## Unstable prefix
+
+While this MSC is not considered stable, implementations should apply
+the behaviours of this MSC on top of room version 9 as
+org.matrix.msc3677.
+
+-   `m.topic` should be referred to as `org.matrix.msc3677.topic` until
+    this MSC lands
+
+## Dependencies
+
+-   [MSC1767]
+
+  [plain text]: https://spec.matrix.org/v1.2/client-server-api/#mroomtopic
+  [MSC1767]: https://github.com/matrix-org/matrix-spec-proposals/pull/1767

--- a/proposals/3765-rich-room-topics.md
+++ b/proposals/3765-rich-room-topics.md
@@ -59,52 +59,17 @@ responses of `/_matrix/client/v3/publicRooms` and
 `/_matrix/client/v1/rooms/{roomId}/hierarchy`. The topic can be kept
 plain text here because this data should commonly only be displayed to
 users that are *not* a member of the room yet. These users will not have
-the same need for rich room topics as users who are inside the room.
+the same need for rich room topics as users who are inside the room. If
+no plain text topic exists, home servers should return an empty topic
+string from these end points. Since this will inevitably lead to bad UX,
+client implementations are encouraged to always include a plain text
+variant when sending `m.topic` events.
 
 ## Transition
 
-The same transition mechanism as in [MSC1767] is proposed. In
-particular, this means a new room version N is introduced. Starting from
-N clients are not permitted to send `m.room.topic` events anymore and
-MUST treat `m.room.topic` as an invalid event type. Instead the new
-`m.topic` event type is to be used.
-
-Similarly, servers use the `m.topic` event type instead of
-`m.room.topic` when creating rooms with a room version greater or equal
-to N.
-
-Specific care should be taken when rooms are upgraded via
-[`/rooms/{roomId}/upgrade`]. If the new room version is greater or
-equal to N, an existing `m.room.topic` event in the old room
-
-``` json5
-{
-  "type": "m.room.topic",
-  "state_key": "",
-  "content": {
-    "topic": "All about pizza"
-  },
-  ...
-}
-```
-
-should be migrated to an `m.topic` event with a single plain-text entry
-in `m.text` in the new room
-
-``` json5
-{
-  "type": "m.topic",
-  "state_key": "",
-  "content": {
-    "m.topic": {
-      "m.text": [{
-          "body": "All about pizza"
-      }]
-    }
-  },
-  ...
-}
-```
+As this MSC replaces `m.room.topic` for an extensible alternative,
+clients and servers are expected to treat `m.room.topic` as invalid in
+extensible event-supporting room versions.
 
 ## Potential issues
 

--- a/proposals/3765-rich-room-topics.md
+++ b/proposals/3765-rich-room-topics.md
@@ -60,17 +60,19 @@ On the server side, any logic that currently operates on `m.room.topic` is
 updated to use `m.topic` instead.
 
 In [`/_matrix/client/v3/createRoom`], the `topic` parameter causes `m.topic`
-to be written with a `text/plain` mimetype. If an `m.topic` event is supplied
-in `initial_state`, the `topic` parameter overwrites its `text/plain` mimetype
-but retains any other mimetypes.
+to be written with a `text/plain` mimetype. If at the same time an `m.topic`
+event is supplied in `initial_state`, it is overwritten entirely. A future MSC
+may generalize the `topic` parameter to allow specifying other mime types
+without `initial_state`.
 
 In [`GET /_matrix/client/v3/publicRooms`], [`GET /_matrix/federation/v1/publicRooms`]
 and their `POST` siblings, the `topic` response field is read from the
 `text/plain` mimetype of `m.topic` if it exists or omitted otherwise.
 A plain text topic is sufficient here because this data is commonly
 only displayed to users that are *not* a member of the room yet. These
-users don't have the same need for rich room topics as users who already
-reside in the room.
+users don't commonly have the same need for rich room topics as users
+who already reside in the room. A future MSC may update these endpoints
+to support rich text topics.
 
 The same logic is applied to [`/_matrix/client/v1/rooms/{roomId}/hierarchy`]
 and [`/_matrix/federation/v1/hierarchy/{roomId}`].

--- a/proposals/3765-rich-room-topics.md
+++ b/proposals/3765-rich-room-topics.md
@@ -43,7 +43,13 @@ repeated here.
 
 The wrapping `m.topic` content block is similar to `m.caption` for file
 uploads as defined in [MSC3551]. It avoids clients accidentally rendering
-the topic state event as a room message.
+the topic as a room message. Note that while [MSC1767] had explicitly
+excluded state events from being treated as extensible, this is being
+changed with [MSC4252]. The extra content block, therefore, allows putting
+a fallback representation that is actually designated for the timeline
+into a separate `content['m.text']` field. Lastly, the `m.topic` content
+block also serves as a good place for additional fields to be added by
+other MSCs in the future.
 
 It is recommended that clients always include a plain text variant within `m.text` when
 sending `m.room.topic` events. This prevents bad UX in situations where a plain
@@ -115,6 +121,7 @@ blocks might have their own prefixing requirements.
 [plain text]: https://spec.matrix.org/v1.12/client-server-api/#mroomtopic
 [MSC1767]: https://github.com/matrix-org/matrix-spec-proposals/pull/1767
 [MSC3551]: https://github.com/matrix-org/matrix-spec-proposals/pull/3551
+[MSC4252]: https://github.com/matrix-org/matrix-spec-proposals/pull/4252
 [sanitise]: https://spec.matrix.org/v1.12/client-server-api/#security-considerations
 [server side search]: https://spec.matrix.org/v1.12/client-server-api/#server-side-search
 [`m.room.topic`]: https://spec.matrix.org/v1.12/client-server-api/#mroomtopic

--- a/proposals/3765-rich-room-topics.md
+++ b/proposals/3765-rich-room-topics.md
@@ -64,28 +64,25 @@ multiline details that are not suitable for room topics in a separate field
 or event type.
 
 On the server side, any logic that currently operates on the `topic` field is
-updated to use the `m.topic` content block instead.
+updated to use the `m.topic` content block instead:
 
-In [`/_matrix/client/v3/createRoom`], the `topic` parameter should cause `m.room.topic`
-to be written with a `text/plain` mimetype in `m.topic`. If at the same time an
-`m.room.topic` event is supplied in `initial_state`, it is overwritten entirely.
-A future MSC may generalize the `topic` parameter to allow specifying other mime
-types without `initial_state`.
-
-In [`GET /_matrix/client/v3/publicRooms`], [`GET /_matrix/federation/v1/publicRooms`]
-and their `POST` siblings, the `topic` response field should be read from the
-`text/plain` mimetype of `m.topic` if it exists or omitted otherwise.
-A plain text topic is sufficient here because this data is commonly
-only displayed to users that are *not* a member of the room yet. These
-users don't commonly have the same need for rich room topics as users
-who already reside in the room. A future MSC may update these endpoints
-to support rich text topics.
-
-The same logic is applied to [`/_matrix/client/v1/rooms/{roomId}/hierarchy`]
-and [`/_matrix/federation/v1/hierarchy/{roomId}`].
-
-In [server side search], the `room_events` category is expanded to search
-over the `m.text` content block of `m.room.topic` events.
+- In [`/_matrix/client/v3/createRoom`], the `topic` parameter should cause `m.room.topic`
+  to be written with a `text/plain` mimetype in `m.topic`. If at the same time an
+  `m.room.topic` event is supplied in `initial_state`, it is overwritten entirely.
+  A future MSC may generalize the `topic` parameter to allow specifying other mime
+  types without `initial_state`.
+- In [`GET /_matrix/client/v3/publicRooms`], [`GET /_matrix/federation/v1/publicRooms`]
+  and their `POST` siblings, the `topic` response field should be read from the
+  `text/plain` mimetype of `m.topic` if it exists or omitted otherwise.
+  A plain text topic is sufficient here because this data is commonly
+  only displayed to users that are *not* a member of the room yet. These
+  users don't commonly have the same need for rich room topics as users
+  who already reside in the room. A future MSC may update these endpoints
+  to support rich text topics.
+- The same logic is applied to [`/_matrix/client/v1/rooms/{roomId}/hierarchy`]
+  and [`/_matrix/federation/v1/hierarchy/{roomId}`].
+- In [server side search], the `room_events` category is expanded to search
+  over the `m.text` content block of `m.room.topic` events.
 
 ## Potential issues
 

--- a/proposals/3765-rich-room-topics.md
+++ b/proposals/3765-rich-room-topics.md
@@ -6,7 +6,7 @@ Topics are a central piece of room meta data and usually made easily
 accessible to room members in clients. As a result, room administrators
 often extend the use of topics to collect helpful peripheral information
 that is related to the room’s purpose. Most commonly these are links to
-external resources. At the moment, topics are limitted to [plain text]
+external resources. At the moment, topics are limited to [plain text]
 which, depending on the number and length of URLs and other content,
 easily gets inconvenient to consume and calls for richer text formatting
 options.

--- a/proposals/3765-rich-room-topics.md
+++ b/proposals/3765-rich-room-topics.md
@@ -15,37 +15,40 @@ options.
 
 Drawing from extensible events as described in [MSC1767],
 `m.room.topic` is formally deprecated and replaced with a new `m.topic`
-event type. The latter contains an `m.markup` content block representing
-the room topic in different mime types.
+event type. The latter contains a new content block `m.topic` which wraps
+an `m.text` content block that allows representing the room topic in
+different mime types.
 
 ``` json5
 {
-    "type": "m.topic",
-    "state_key": "",
-    "content": {
-        "m.markup": [{
-            "mimetype": "text/html",
-            "body": "All about <b>pizza</b> | <a href=\"https://recipes.pizza.net\">Recipes</a>"
-        }, {
-            "mimetype": "text/plain",
-            "body": "All about **pizza** | [Recipes](https://recipes.pizza.net)"
-        }],
-    },
-    ...
+  "type": "m.topic",
+  "state_key": "",
+  "content": {
+    "m.topic": {
+      "m.text": [{
+          "body": "All about **pizza** | [Recipes](https://recipes.pizza.net)"
+      }, {
+          "mimetype": "text/html",
+          "body": "All about <b>pizza</b> | <a href=\"https://recipes.pizza.net\">Recipes</a>"
+      }]
+    }
+  },
+  ...
 }
 ```
 
-Details of how `m.markup` works may be found in [MSC1767] and are not
+Details of how `m.text` works may be found in [MSC1767] and are not
 repeated here.
+
+The wrapping `m.topic` content block is similar to `m.caption` for file
+uploads as defined in [MSC3551]. It avoids clients accidentally rendering
+the topic state event as a room message.
 
 In order to prevent formatting abuse in room topics, clients are
 encouraged to treat the first two lines as the shorthand topic and the
 remainder as additional information. Specifically, this means that
 things like headings and enumerations should be ignored (or formatted
 as regular text) unless they occur after the second line.
-
-While the content of `m.topic` is currently identical to `m.message`, a
-dedicated event type allows the two to diverge in the future.
 
 A change to `/_matrix/client/v3/createRoom` is not necessary. The
 endpoint has a plain text `topic` parameter but also allows to specify a
@@ -76,29 +79,30 @@ equal to N, an existing `m.room.topic` event in the old room
 
 ``` json5
 {
-    "type": "m.room.topic",
-    "state_key": "",
-    "content": {
-        "topic": "All about pizza"
-    },
-    ...
+  "type": "m.room.topic",
+  "state_key": "",
+  "content": {
+    "topic": "All about pizza"
+  },
+  ...
 }
 ```
 
-should be migrated to an `m.topic` event with a single plain-text markup
-in the new room
+should be migrated to an `m.topic` event with a single plain-text entry
+in `m.text` in the new room
 
 ``` json5
 {
-    "type": "m.topic",
-    "state_key": "",
-    "content": {
-        "m.markup": [{
-            "mimetype": "text/plain",
-            "body": "All about pizza"
-        }],
-    },
-    ...
+  "type": "m.topic",
+  "state_key": "",
+  "content": {
+    "m.topic": {
+      "m.text": [{
+          "body": "All about pizza"
+      }]
+    }
+  },
+  ...
 }
 ```
 
@@ -130,4 +134,5 @@ as `org.matrix.msc3765.topic`.
 
   [plain text]: https://spec.matrix.org/v1.2/client-server-api/#mroomtopic
   [MSC1767]: https://github.com/matrix-org/matrix-spec-proposals/pull/1767
+  [MSC3551]: https://github.com/matrix-org/matrix-spec-proposals/pull/3551
   [`/rooms/{roomId}/upgrade`]: https://spec.matrix.org/v1.5/client-server-api/#post_matrixclientv3roomsroomidupgrade

--- a/proposals/3765-rich-room-topics.md
+++ b/proposals/3765-rich-room-topics.md
@@ -85,12 +85,8 @@ considerations that apply to HTML in room messages.
 
 ## Unstable prefix
 
-While this MSC is not considered stable, implementations should apply
-the behaviours of this MSC on top of room version 9 as
-org.matrix.msc3765.
-
--   `m.topic` should be referred to as `org.matrix.msc3765.topic` until
-    this MSC lands
+While this MSC is not considered stable, `m.topic` should be referred
+to as `org.matrix.msc3765.topic`.
 
 ## Dependencies
 

--- a/proposals/3765-rich-room-topics.md
+++ b/proposals/3765-rich-room-topics.md
@@ -38,6 +38,12 @@ the room topic in different mime types.
 Details of how `m.markup` works may be found in [MSC1767] and are not
 repeated here.
 
+In order to prevent formatting abuse in room topics, clients are
+encouraged to treat the first two lines as the shorthand topic and the
+remainder as additional information. Specifically, this means that
+things like headings and enumerations should be ignored (or formatted
+as regular text) unless they occur after the second line.
+
 While the content of `m.topic` is currently identical to `m.message`, a
 dedicated event type allows the two to diverge in the future.
 

--- a/proposals/3765-rich-room-topics.md
+++ b/proposals/3765-rich-room-topics.md
@@ -45,10 +45,11 @@ uploads as defined in [MSC3551]. It avoids clients accidentally rendering
 the topic state event as a room message.
 
 In order to prevent formatting abuse in room topics, clients are
-encouraged to treat the first two lines as the shorthand topic and the
-remainder as additional information. Specifically, this means that
-things like headings and enumerations should be ignored (or formatted
-as regular text) unless they occur after the second line.
+encouraged to limit the length of topics to at most two lines. Additionally,
+clients should ignore things like headings and enumerations (or format them
+as regular text). A future MSC may introduce a mechanism to capture extended
+multiline details that are not suitable for room topics in a separate field
+or event type.
 
 A change to `/_matrix/client/v3/createRoom` is not necessary. The
 endpoint has a plain text `topic` parameter but also allows to specify a

--- a/proposals/3765-rich-room-topics.md
+++ b/proposals/3765-rich-room-topics.md
@@ -44,6 +44,10 @@ The wrapping `m.topic` content block is similar to `m.caption` for file
 uploads as defined in [MSC3551]. It avoids clients accidentally rendering
 the topic state event as a room message.
 
+It is recommended that clients always include a plain text variant when
+sending `m.topic` events. This prevents bad UX in situations where a plain
+text topic is sufficient such as the public rooms directory.
+
 In order to prevent formatting abuse in room topics, clients are
 encouraged to limit the length of topics to at most two lines. Additionally,
 clients should ignore things like headings and enumerations (or format them
@@ -51,26 +55,41 @@ as regular text). A future MSC may introduce a mechanism to capture extended
 multiline details that are not suitable for room topics in a separate field
 or event type.
 
-A change to `/_matrix/client/v3/createRoom` is not necessary. The
-endpoint has a plain text `topic` parameter but also allows to specify a
-full `m.topic` event in `initial_state`.
+On the server side, any logic that currently operates on `m.room.topic` is
+updated to use `m.topic` instead.
 
-Room topics also occur as part of the `PublicRoomsChunk` object in the
-responses of `/_matrix/client/v3/publicRooms` and
-`/_matrix/client/v1/rooms/{roomId}/hierarchy`. The topic can be kept
-plain text here because this data should commonly only be displayed to
-users that are *not* a member of the room yet. These users will not have
-the same need for rich room topics as users who are inside the room. If
-no plain text topic exists, home servers should return an empty topic
-string from these end points. Since this will inevitably lead to bad UX,
-client implementations are encouraged to always include a plain text
-variant when sending `m.topic` events.
+In [`/_matrix/client/v3/createRoom`], the `topic` parameter causes `m.topic`
+to be written with a `text/plain` mimetype. If an `m.topic` event is supplied
+in `initial_state`, the `topic` parameter overwrites its `text/plain` mimetype
+but retains any other mimetypes.
+
+In [`GET /_matrix/client/v3/publicRooms`], [`GET /_matrix/federation/v1/publicRooms`]
+and their `POST` siblings, the `topic` response field is read from the
+`text/plain` mimetype of `m.topic` if it exists or omitted otherwise.
+A plain text topic is sufficient here because this data is commonly
+only displayed to users that are *not* a member of the room yet. These
+users don't have the same need for rich room topics as users who already
+reside in the room.
+
+The same logic is applied to [`/_matrix/client/v1/rooms/{roomId}/hierarchy`]
+and [`/_matrix/federation/v1/hierarchy/{roomId}`].
+
+In [server side search], the `room_events` category is expanded to search
+over the `text/plain` mimetype in `m.topic`.
+
+Finally, `m.topic` is also added to the events that are recommended for
+inclusion in [stripped state].
 
 ## Transition
 
 As this MSC replaces `m.room.topic` for an extensible alternative,
 clients and servers are expected to treat `m.room.topic` as invalid in
-extensible event-supporting room versions.
+extensible event-supporting room versions. Similarly, `m.topic` cannot
+be used in non-extensible-supporting room versions.
+
+It is recommended that servers replicate `m.room.topic` to `m.topic`
+with a plain text mimetype and vice versa when [upgrading] between room
+versions that do and don't support extensible events.
 
 ## Potential issues
 
@@ -87,18 +106,41 @@ described in the introductory section of [MSC1767].
 ## Security considerations
 
 Allowing HTML in room topics is subject to the same security
-considerations that apply to HTML in room messages.
+considerations that apply to HTML in room messages. In particular,
+topics are already included in the content that clients should [sanitise]
+for unsafe HTML.
+
+## Other notes
+
+Normally extensible events would only be permitted in a specific
+room version. However, to facilitate adoption, clients MAY include
+the `m.topic` content block in `m.room.topic` events in room
+versions that don't support extensible events. They must, however,
+take care to always duplicate the plain text mimetype into the
+normal `topic` field, too. This ensures compatibility for clients
+and servers that don't support this proposal. Since such clients
+are likely to delete the `m.topic` content block when updating
+`m.room.topic` themselves, it also helps prevent inconsistencies.
 
 ## Unstable prefix
 
 While this MSC is not considered stable, `m.topic` should be referred to
-as `org.matrix.msc3765.topic`.
+as `org.matrix.msc3765.topic`. Note that extensible events and content
+blocks might have their own prefixing requirements.
 
 ## Dependencies
 
 - [MSC1767]
 
-  [plain text]: https://spec.matrix.org/v1.2/client-server-api/#mroomtopic
-  [MSC1767]: https://github.com/matrix-org/matrix-spec-proposals/pull/1767
-  [MSC3551]: https://github.com/matrix-org/matrix-spec-proposals/pull/3551
-  [`/rooms/{roomId}/upgrade`]: https://spec.matrix.org/v1.5/client-server-api/#post_matrixclientv3roomsroomidupgrade
+[plain text]: https://spec.matrix.org/v1.12/client-server-api/#mroomtopic
+[MSC1767]: https://github.com/matrix-org/matrix-spec-proposals/pull/1767
+[MSC3551]: https://github.com/matrix-org/matrix-spec-proposals/pull/3551
+[sanitise]: https://spec.matrix.org/v1.12/client-server-api/#security-considerations
+[server side search]: https://spec.matrix.org/v1.12/client-server-api/#server-side-search
+[stripped state]: https://spec.matrix.org/v1.12/client-server-api/#stripped-state
+[upgrading]: https://spec.matrix.org/v1.12/client-server-api/#room-upgrades
+[`/_matrix/client/v1/rooms/{roomId}/hierarchy`]: https://spec.matrix.org/v1.12/client-server-api/#get_matrixclientv1roomsroomidhierarchy
+[`/_matrix/client/v3/createRoom`]: https://spec.matrix.org/v1.12/client-server-api/#post_matrixclientv3createroom
+[`/_matrix/federation/v1/hierarchy/{roomId}`]: https://spec.matrix.org/v1.12/server-server-api/#get_matrixfederationv1hierarchyroomid
+[`GET /_matrix/client/v3/publicRooms`]: https://spec.matrix.org/v1.12/client-server-api/#get_matrixclientv3publicrooms
+[`GET /_matrix/federation/v1/publicRooms`]: https://spec.matrix.org/v1.12/server-server-api/#get_matrixfederationv1publicrooms

--- a/proposals/3765-rich-room-topics.md
+++ b/proposals/3765-rich-room-topics.md
@@ -18,7 +18,7 @@ defined in [MSC1767] and define a new `m.topic` event in `content`.
 The latter contains a list of renderings in the same format that
 [MSC1767] uses for `m.message` events.
 
-``` json
+```json5
 {
     "type": "m.room.topic",
     "state_key": "",

--- a/proposals/3765-rich-room-topics.md
+++ b/proposals/3765-rich-room-topics.md
@@ -1,4 +1,4 @@
-# MSC3677: Rich text in room topics
+# MSC3765: Rich text in room topics
 
 ## Problem
 
@@ -84,9 +84,9 @@ considerations that apply to HTML in room messages.
 
 While this MSC is not considered stable, implementations should apply
 the behaviours of this MSC on top of room version 9 as
-org.matrix.msc3677.
+org.matrix.msc3765.
 
--   `m.topic` should be referred to as `org.matrix.msc3677.topic` until
+-   `m.topic` should be referred to as `org.matrix.msc3765.topic` until
     this MSC lands
 
 ## Dependencies

--- a/proposals/3765-rich-room-topics.md
+++ b/proposals/3765-rich-room-topics.md
@@ -45,8 +45,8 @@ The wrapping `m.topic` content block is similar to `m.caption` for file
 uploads as defined in [MSC3551]. It avoids clients accidentally rendering
 the topic state event as a room message.
 
-It is recommended that clients always include a plain text variant when
-sending `m.topic` events. This prevents bad UX in situations where a plain
+It is recommended that clients always include a plain text variant within `m.text` when
+sending `m.room.topic` events. This prevents bad UX in situations where a plain
 text topic is sufficient such as the public rooms directory.
 
 Additionally, clients should duplicate the plain text topic into the existing
@@ -66,14 +66,14 @@ or event type.
 On the server side, any logic that currently operates on the `topic` field is
 updated to use the `m.topic` content block instead.
 
-In [`/_matrix/client/v3/createRoom`], the `topic` parameter causes `m.room.topic`
+In [`/_matrix/client/v3/createRoom`], the `topic` parameter should cause `m.room.topic`
 to be written with a `text/plain` mimetype in `m.topic`. If at the same time an
 `m.room.topic` event is supplied in `initial_state`, it is overwritten entirely.
 A future MSC may generalize the `topic` parameter to allow specifying other mime
 types without `initial_state`.
 
 In [`GET /_matrix/client/v3/publicRooms`], [`GET /_matrix/federation/v1/publicRooms`]
-and their `POST` siblings, the `topic` response field is read from the
+and their `POST` siblings, the `topic` response field should be read from the
 `text/plain` mimetype of `m.topic` if it exists or omitted otherwise.
 A plain text topic is sufficient here because this data is commonly
 only displayed to users that are *not* a member of the room yet. These

--- a/proposals/3765-rich-room-topics.md
+++ b/proposals/3765-rich-room-topics.md
@@ -13,11 +13,11 @@ options.
 
 ## Proposal
 
-Drawing from extensible events as described in [MSC1767],
-`m.room.topic` is formally deprecated and replaced with a new `m.topic`
-event type. The latter contains a new content block `m.topic` which wraps
-an `m.text` content block that allows representing the room topic in
-different mime types.
+Drawing from extensible events as described in [MSC1767], `m.room.topic`
+is prohibited in room versions that support extensible events and replaced
+with a new `m.topic` event type. The latter contains a new content block
+`m.topic` which wraps an `m.text` content block that allows representing
+the room topic in different mime types.
 
 ``` json5
 {

--- a/proposals/3765-rich-room-topics.md
+++ b/proposals/3765-rich-room-topics.md
@@ -25,11 +25,11 @@ events as shown below[^1].
   "state_key": "",
   "content": {
     "m.topic": {
-      "m.text": [{
-        "body": "All about **pizza** | [Recipes](https://recipes.pizza.net)"
-      }, {
+      "m.text": [ {
         "mimetype": "text/html",
         "body": "All about <b>pizza</b> | <a href=\"https://recipes.pizza.net\">Recipes</a>"
+      }, {
+        "body": "All about **pizza** | [Recipes](https://recipes.pizza.net)"
       }]
     },
     "topic": "All about **pizza** | [Recipes](https://recipes.pizza.net)"
@@ -38,16 +38,18 @@ events as shown below[^1].
 }
 ```
 
-Details of how `m.text` works may be found in [MSC1767] and are not
-repeated here.
+In line with [MSC1767], clients should render the first mime type in the
+array that they understand. Further details of how `m.text` works may
+be found in [MSC1767] and are not repeated here.
 
 The wrapping `m.topic` content block is similar to `m.caption` for file
 uploads as defined in [MSC3551]. It avoids clients accidentally rendering
-the topic as a room message. Note that while [MSC1767] had explicitly
-excluded state events from being treated as extensible, this is being
-changed with [MSC4252]. The extra content block, therefore, allows putting
+the topic as a room message. ([MSC1767] specifies that unknown events with
+an `m.text` content block should be rendered as a regular room message, and
+while [MSC1767] had explicitly excluded state events from being treated as 
+extensible, this is being changed with [MSC4252].) The extra content block, therefore, allows putting
 a fallback representation that is actually designated for the timeline
-into a separate `content['m.text']` field. Lastly, the `m.topic` content
+into a separate `content['m.text']` field. In addition, the `m.topic` content
 block also serves as a good place for additional fields to be added by
 other MSCs in the future.
 
@@ -112,15 +114,13 @@ for unsafe HTML.
 ## Unstable prefix
 
 While this MSC is not considered stable, `m.topic` should be referred to
-as `org.matrix.msc3765.topic`. Note that extensible events and content
-blocks might have their own prefixing requirements.
+as `org.matrix.msc3765.topic`.
 
 [^1]: A future MSC may discuss how to adopt the `m.topic` content block in
       new room versions which support extensible events.
 
 [plain text]: https://spec.matrix.org/v1.12/client-server-api/#mroomtopic
 [MSC1767]: https://github.com/matrix-org/matrix-spec-proposals/pull/1767
-[MSC3551]: https://github.com/matrix-org/matrix-spec-proposals/pull/3551
 [MSC4252]: https://github.com/matrix-org/matrix-spec-proposals/pull/4252
 [sanitise]: https://spec.matrix.org/v1.12/client-server-api/#security-considerations
 [server side search]: https://spec.matrix.org/v1.12/client-server-api/#server-side-search

--- a/proposals/3765-rich-room-topics.md
+++ b/proposals/3765-rich-room-topics.md
@@ -49,7 +49,8 @@ sending `m.topic` events. This prevents bad UX in situations where a plain
 text topic is sufficient such as the public rooms directory.
 
 In order to prevent formatting abuse in room topics, clients are
-encouraged to limit the length of topics to at most two lines. Additionally,
+encouraged to limit the length of topics during both entry and display,
+for instance, by capping the number of displayed lines. Additionally,
 clients should ignore things like headings and enumerations (or format them
 as regular text). A future MSC may introduce a mechanism to capture extended
 multiline details that are not suitable for room topics in a separate field

--- a/proposals/3765-rich-room-topics.md
+++ b/proposals/3765-rich-room-topics.md
@@ -35,6 +35,9 @@ The latter contains a list of renderings in the same format that
 }
 ```
 
+While the content of `m.topic` is currently identical to `m.message`, a
+dedicated event type allows the two to diverge in the future.
+
 A change to `/_matrix/client/v3/createRoom` is not necessary. The
 endpoint has a plain text `topic` parameter but also allows to specify a
 full `m.room.topic` event in `initial_state`.

--- a/proposals/3765-rich-room-topics.md
+++ b/proposals/3765-rich-room-topics.md
@@ -75,7 +75,7 @@ The same logic is applied to [`/_matrix/client/v1/rooms/{roomId}/hierarchy`]
 and [`/_matrix/federation/v1/hierarchy/{roomId}`].
 
 In [server side search], the `room_events` category is expanded to search
-over the `text/plain` mimetype in `m.topic`.
+over the `m.text` content block of `m.topic` events.
 
 Finally, `m.topic` is also added to the events that are recommended for
 inclusion in [stripped state].


### PR DESCRIPTION
[Rendered](https://github.com/matrix-org/matrix-spec-proposals/blob/johannes/rich-room-topics/proposals/3765-rich-room-topics.md)

Implementations:

- https://github.com/matrix-org/matrix-events-sdk/pull/5
- https://github.com/matrix-org/matrix-js-sdk/pull/2272
- https://github.com/matrix-org/matrix-react-sdk/pull/8215

---

In line with https://github.com/matrix-org/matrix-spec/issues/1700, the following disclosure applies:

I am a Systems Architect at [gematik](https://www.gematik.de/), Software Engineer at [Unomed](https://www.unomed.ch/), Matrix community member and former Element employee. This proposal was written and published with my community member hat on.

---

[FCP tickyboxes](https://github.com/matrix-org/matrix-spec-proposals/pull/3765#issuecomment-2430107320)