### PR TITLE
@MSC2666: Add "may return 400" qualifier

### DIFF
--- a/proposals/2666-get-rooms-in-common.md
+++ b/proposals/2666-get-rooms-in-common.md
@@ -26,6 +26,9 @@ The response format will be an array containing all rooms where both the authent
 a membership of type `join`. If the `user_id` does not exist, or does not share any rooms with the authenticated user,
 an empty array should be returned.
 
+Additionally, a server may respond with a `400` `M_UNKNOWN` to this endpoint for any reason, 
+signalling its unwillingess (or inability) to satisfy the request.
+
 ```
 GET /_matrix/client/r0/user/mutual_rooms/%40bob%3Aexample.com
 ```


### PR DESCRIPTION
Resolves this [comment](https://github.com/matrix-org/matrix-spec-proposals/pull/2666#discussion_r830500133) 

Rationale for `M_UNKNOWN`: There's not a "semantically more close" variant of that error, and i'm hesitant to add a new error.

cc @Half-Shot