### PR TITLE
MSC3771: Read receipts for threads

### DIFF
--- a/proposals/3771-read-receipts-for-threads.md
+++ b/proposals/3771-read-receipts-for-threads.md
@@ -283,13 +283,6 @@ deliberate to avoid losing message / missing notifications.
 Solutions to this problem are deemed out of scope of this MSC. A solution that
 was briefly explored was [ranged read receipts](https://hackmd.io/Gxm8zuuSROeencoJ6gjgSg).
 
-### Second-order relations
-
-For simplicity, clients may wish to send receipts for events which are not directly
-related to a root thread event (e.g. a reaction to thread event). This should
-generally be treated as acceptable by the server (i.e. the server should only care
-about the ordering of events, not about whether the events are in the same thread).
-
 ### Federation compatibility
 
 A homeserver which does not understand threaded receipts will be unable to properly

--- a/proposals/3771-read-receipts-for-threads.md
+++ b/proposals/3771-read-receipts-for-threads.md
@@ -155,6 +155,13 @@ with `errcode` of `M_INVALID_PARAM`:
 
 * A non-string `thread_id` (or empty) `thread_id` field.
 * Providing the `thread_id` properties for a receipt of type `m.fully_read`.
+* If the given `event_id` is not related to the `thread_id`. There may be multiple
+  relations between events ((e.g. a `m.annotation` to `m.thread`), homeservers
+  should apply a reasonable maximum number of relations to traverse when attempting
+  to identify if an event is part of a thread.
+
+  It is recommended that at least 3 relations are traversed when attempting to find
+  a thread, implementations should be careful to not infinitely recurse.[^3]
 
 Given a threaded message:
 
@@ -361,3 +368,10 @@ unthreaded receipts, but it is allowed. The only known use-case for this is that
 a threaded client can use this to clear *all* notifications in a room by sending
 an unthreaded read receipt on the latest event in the room (regardless of which
 thread it appears in).
+
+[^3]: Three relations is relatively arbitrary, but is meant to cover an edit or
+reaction to a thread (to an event with no relations, i.e. the root of a thread):
+`A<--[m.thread]--B<--[m.annotation]--C`.
+With an additional leftover for future improvements. This is considered reasonable
+since threads cannot fork, edits cannot modify relation information, and generally
+annotations to annotations are ignored by user interfaces.

--- a/proposals/3771-read-receipts-for-threads.md
+++ b/proposals/3771-read-receipts-for-threads.md
@@ -50,11 +50,11 @@ user then reads the thread, the client has no way to mark `E` as read.
 ### Threaded receipts
 
 This MSC proposes allowing the same receipt type to exist multiple times in a room,
-once per thread (and once for the "main" timeline of the room).
+once per thread (and once for the "main" timeline of the room). This still does not
+allow a caller to move their receipts backwards in a room.
 
 The body of request to the [`/receipt` endpoint](https://spec.matrix.org/v1.2/client-server-api/#post_matrixclientv3roomsroomidreceiptreceipttypeeventid)
 gains the following fields:
-
 
 * `thread_id` (`string`): The thread that the receipt belongs to (i.e. the
   `event_id` contained within the `m.relates_to` of the event represented by

--- a/proposals/3771-read-receipts-for-threads.md
+++ b/proposals/3771-read-receipts-for-threads.md
@@ -1,0 +1,154 @@
+# MSC3771: Read receipts for threads
+
+Currently, each room has a single read receipt per user. This is used to sync the
+read status of a room across clients and calculate the number of unread messages.
+
+Unfortunately a client displaying threads may show a subset of a room's messages
+at a time, causing the read receipt to be misleading.
+
+This might better be described by an example. Given a room with the following
+DAG of events (note that the dotted lines are a thread relation, as specified by
+[MSC3440](https://github.com/matrix-org/matrix-doc/pull/3440)):
+
+```mermaid
+flowchart RL
+    F-->E
+    E-->D
+    D-->C
+    C-->B
+    B-->A
+    D-.->A
+    F-.->A
+```
+
+A client might interpret this as:
+
+```mermaid
+flowchart RL
+    subgraph Main timeline
+    C-->B
+    B-->A
+    F-->C
+    end
+    subgraph Thread timeline
+    D-->A
+    E-->D
+    end
+
+    style A fill:cyan,stroke:#333,stroke-width:2px
+    style E fill:orange,stroke:#333,stroke-width:2px
+```
+
+While viewing the "main" timeline of the room, a client might move the read
+receipt from event `A` to event `E` without ever showing events `D` and `F`. The
+user then reads the thread, the client has no way to mark `F` as read.
+
+## Proposal
+
+This MSC proposes adding a new receipt type of `m.read.thread.private` is to be
+added. This receipt type is used for clients to sync the read status of each
+thread in a room.
+
+The `/receipt` endpoint gains a new optional path part and becomes:
+
+`POST /_matrix/client/v3/rooms/{roomId}/receipt/{receiptType}/{eventId}/{context}`
+
+The `context` contains the thread that the read receipts belongs to (i.e. it should
+match the `event_id` contained within the `m.relates_to` of the event represented
+by `eventId`). This updates the unique tuple for receipts from
+`(room ID, user ID, receipt type)` to `(room ID, user ID, receipt type, context)`.
+For backwards compatibility, a missing `context` is equivalent to an empty context.
+
+Given a threaded message:
+
+```json
+{
+  "event_id": "$thread_reply",
+  "room_id": "!room:example.org",
+  "content": {
+    "m.relates_to": {
+      "rel_type": "m.thread",
+      "event_id": "$thread_root"
+    }
+  }
+}
+```
+
+A client could mark this as read by sending a request:
+
+```
+POST /_matrix/client/r0/rooms/!room:example.org/receipt/m.read.thread.private/$thread_reply/$thread_root
+
+{}
+```
+
+Similarly to the hidden read receipts from [MSC2285](https://github.com/matrix-org/matrix-spec-proposals/pull/2285),
+homeservers are not to send the receipt to any other users except the sender nor
+over federation.
+
+## Potential issues
+
+For long-lived rooms or rooms with many threads there could be a significant number
+of receipts. This has a few downsides:
+
+* The size of the `/sync` response would increase without bound.
+* The effort to generate and process the receipts for each room would increase
+  without bound.
+
+Due to both of the above, this proposal is limited to a *private* read receipt for
+threads. This limits the impact to a user's own read receipts for threads, but
+does not completely solve the issue.
+
+[MSC2285](https://github.com/matrix-org/matrix-spec-proposals/pull/2285) suggests
+that the `/read_markers` endpoint should become a generic bulk receipt endpoint.
+This is not compatible with the additional `context` parameter in this MSC.
+
+## Alternatives
+
+Instead of adding the thread ID as a new path part, it could be added to the body
+of the receipt. There may be a small backwards compatibility benefit to this, but
+it seems clearer to put it as part of the URL.
+
+Similarly, instead of adding a new receipt type, the read status of each thread in
+a room could be added to the body of the `m.read.private` receipt. This could
+cause data integrity issues if multiple clients attempt to update the receipt
+without first reading it.
+
+Instead of adding the thread ID as a new path part, it could be  encoded as a suffix
+on the receipt, e.g. `m.thread.read.private-$abcd`. This has the benefit of not
+changing the current receipt mechanisms, but seems sub-par and requires additional
+parsing of opaque identifiers.
+
+## Security considerations
+
+There is potential for abuse by allowing clients to specify a unique `context`.
+A mitigation could be to ensure that it is the related event of the thread, ensuring
+that each thread only has a single context.
+
+## Future extensions
+
+Future extensions will tackle how the thread read receipts impact notification counts.
+
+## Unstable prefix
+
+During implementation the receipt type shall be `org.matrix.mscXXXX`.
+
+To avoid receipts that will never be updated, after stabilization, homeservers are
+expected to reject the unstable receipt type and purge all receipts using the
+unstable receipt type.
+
+To detect server support, clients can either rely on the spec version (when stable)
+or the presence of a `org.matrix.msc3771` flag in `unstable_features` on `/versions`.
+
+## Dependencies
+
+This MSC depends on the following MSCs, which at the time of writing have not yet
+been accepted into the spec:
+
+* [MSC2285](https://github.com/matrix-org/matrix-spec-proposals/pull/2285): Hidden read receipts
+
+As well as the following MSCs, which have been accepted into the spec, but have
+yet to be released:
+
+* [MSC2674](https://github.com/matrix-org/matrix-doc/pull/2674): Event Relationships
+* [MSC3440](https://github.com/matrix-org/matrix-spec-proposals/pull/3440): Threading via `m.thread` relation

--- a/proposals/3771-read-receipts-for-threads.md
+++ b/proposals/3771-read-receipts-for-threads.md
@@ -139,7 +139,7 @@ No other changes to receipts are proposed, i.e. this still does not allow a call
 to move their receipts backwards in a room. The relationship between `m.read` and
 `m.read.private` is not changed.
 
-The body of request to the [`/receipt` endpoint](https://spec.matrix.org/v1.2/client-server-api/#post_matrixclientv3roomsroomidreceiptreceipttypeeventid)
+The request body to the [`/receipt` endpoint](https://spec.matrix.org/v1.2/client-server-api/#post_matrixclientv3roomsroomidreceiptreceipttypeeventid)
 gains the following optional fields:
 
 * `thread_id` (`string`): The thread that the receipt belongs to (i.e. the

--- a/proposals/3771-read-receipts-for-threads.md
+++ b/proposals/3771-read-receipts-for-threads.md
@@ -86,6 +86,28 @@ Similarly to the hidden read receipts from [MSC2285](https://github.com/matrix-o
 homeservers are not to send the receipt to any other users except the sender nor
 over federation.
 
+This would then come down `/sync` for the user with other receipts:
+
+```json
+{
+  "content": {
+    "$thread_reply": {
+      "m.read.thread.private": {
+        "@rikj:jki.re": {
+          "ts": 1436451550453,
+          "context": "$thread_root"
+        }
+      }
+    }
+  },
+  "room_id": "!jEsUZKDJdhlrceRyVU:example.org",
+  "type": "m.receipt"
+}
+```
+
+Since this is not shared, only the own user's matrix ID would be expected to
+have this kind of receipt.
+
 ## Potential issues
 
 For long-lived rooms or rooms with many threads there could be a significant number

--- a/proposals/3771-read-receipts-for-threads.md
+++ b/proposals/3771-read-receipts-for-threads.md
@@ -49,7 +49,8 @@ This MSC proposes adding a new receipt type of `m.read.thread.private` is to be
 added. This receipt type is used for clients to sync the read status of each
 thread in a room.
 
-The `/receipt` endpoint gains a new optional path part and becomes:
+The [`/receipt`](https://spec.matrix.org/v1.2/client-server-api/#post_matrixclientv3roomsroomidreceiptreceipttypeeventid)
+endpoint gains a new optional path part and becomes:
 
 `POST /_matrix/client/v3/rooms/{roomId}/receipt/{receiptType}/{eventId}/{context}`
 

--- a/proposals/3771-read-receipts-for-threads.md
+++ b/proposals/3771-read-receipts-for-threads.md
@@ -45,6 +45,8 @@ user then reads the thread, the client has no way to mark `E` as read.
 
 ## Proposal
 
+### Sending a threaded read receipt
+
 This MSC proposes allowing the same receipt type to exist multiple times in a room
 by adding a `threadId` parameter to reach receipt.
 
@@ -85,6 +87,8 @@ POST /_matrix/client/r0/rooms/!room:example.org/receipt/m.read/$thread_reply/$th
 {}
 ```
 
+### Received threaded read receipts
+
 This would then come down `/sync` for the user with other receipts, but with an
 additional property in the body containing the thread ID:
 
@@ -104,6 +108,14 @@ additional property in the body containing the thread ID:
   "type": "m.receipt"
 }
 ```
+
+### Notifications
+
+[MSC3773](https://github.com/matrix-org/matrix-spec-proposals/pull/3773) discusses
+how notifications for threads are created and returned to the client, but does
+not provide a way to clear threaded notifications. A threaded read receipt should
+clear notifications for the matching thread following the [same rules](https://spec.matrix.org/latest/client-server-api/#receiving-notifications)
+as notifications which are not part of a thread.
 
 ## Potential issues
 
@@ -155,4 +167,4 @@ or the presence of a `org.matrix.msc3771` flag in `unstable_features` on `/versi
 This MSC depends on the following MSCs, which have been accepted into the spec,
 but have yet to be released:
 
-* [MSC3440](https://github.com/matrix-org/matrix-spec-proposals/pull/3440): Threading via `m.thread` relation
+* [MSC3773](https://github.com/matrix-org/matrix-spec-proposals/pull/3773): Notifications for threads

--- a/proposals/3771-read-receipts-for-threads.md
+++ b/proposals/3771-read-receipts-for-threads.md
@@ -89,7 +89,7 @@ they clear notifications:
 Using the above diagrams with threaded read receipts on `E` and `I`; and an
 unthreaded read receipt on `D` would give:
 
-```
+```mermaid
 flowchart RL
     subgraph "Main" timeline
     B-->A

--- a/proposals/3771-read-receipts-for-threads.md
+++ b/proposals/3771-read-receipts-for-threads.md
@@ -45,9 +45,8 @@ user then reads the thread, the client has no way to mark `E` as read.
 
 ## Proposal
 
-This MSC proposes adding a new receipt type of `m.read.thread.private` is to be
-added. This receipt type is used for clients to sync the read status of each
-thread in a room.
+This MSC proposes adding a new receipt type of `m.read.thread.private`, which is
+used for clients to sync the read status of each thread in a room.
 
 The [`/receipt`](https://spec.matrix.org/v1.2/client-server-api/#post_matrixclientv3roomsroomidreceiptreceipttypeeventid)
 endpoint gains a new optional path part and becomes:

--- a/proposals/3771-read-receipts-for-threads.md
+++ b/proposals/3771-read-receipts-for-threads.md
@@ -184,7 +184,12 @@ clients. Using the example room DAG from the preamble of this MSC:
 * A user which has an unthreaded receipt on event `D` and a threaded receipt on
   event `E` would likely see event `E` as unread on an "unthreaded" client.
 
-Solutions to this problem are deemed out of scope of this MSC.
+The proposed solution may result in events being incorrectly marked as unread
+(when they have been read). The false positive for unread notifications is
+deliberate to avoid losing message / missing notifications.
+
+Solutions to this problem are deemed out of scope of this MSC. A solution that
+was briefly explored was [ranged read receipts](https://hackmd.io/Gxm8zuuSROeencoJ6gjgSg).
 
 ### Second-order relations
 

--- a/proposals/3771-read-receipts-for-threads.md
+++ b/proposals/3771-read-receipts-for-threads.md
@@ -203,7 +203,7 @@ POST /_matrix/client/r0/rooms/!room:example.org/receipt/m.read/$thread_root
 As it is today, not providing the `thread_id` field sends an unthreaded receipt:
 
 ```
-POST /_matrix/client/r0/rooms/!room:example.org/receipt/m.read/$thread_root
+POST /_matrix/client/r0/rooms/!room:example.org/receipt/m.read/$thread_reply
 
 {}
 ```

--- a/proposals/3771-read-receipts-for-threads.md
+++ b/proposals/3771-read-receipts-for-threads.md
@@ -74,7 +74,9 @@ they do not wish to incorporate threads.
 This MSC proposes allowing a receipt per thread, as well as an unthreaded receipt.
 Thus, receipts are split into two categories, which this document calls "unthreaded"
 and "threaded". Threaded receipts are identified by the root message of the thread;
-additionally there is a special pseudo-thread for the main timeline.
+additionally there is a special pseudo-thread for the main timeline. This allows marking
+the main timeline (a pseudo-thread) as read, without marking any actual threads (split
+ off from the main timeline) as read.
 
 The most significant difference between threaded and unthreaded receipts is how
 they clear notifications:

--- a/proposals/3771-read-receipts-for-threads.md
+++ b/proposals/3771-read-receipts-for-threads.md
@@ -109,6 +109,9 @@ additional property in the body containing the thread ID:
 }
 ```
 
+A missing (or empty) `thread_id` refers to the "main" timeline (or events which are
+not part of a thread).
+
 ### Notifications
 
 [MSC3773](https://github.com/matrix-org/matrix-spec-proposals/pull/3773) discusses
@@ -138,14 +141,32 @@ clients. Solutions to this problem are deemed out of scope of this MSC.
 
 ## Alternatives
 
+### Thread ID location
+
 Instead of adding the thread ID as a new path part, it could be added to the body
 of the receipt. There may be a small backwards compatibility benefit to this, but
 it seems clearer to put it as part of the URL.
 
-Instead of encoding the thread ID as an integral part of the receipt, the read
-threads could be added to the body of the receipt. This could cause data
-integrity issues if multiple clients attempt to update the receipt without first
-reading it.
+Instead of encoding the thread ID as an integral part of the receipt, all of the
+read threads could be added to the body of the single receipt. This could cause
+data integrity issues if multiple clients attempt to update the receipt without
+first reading it.
+
+### Receipt type
+
+To potentially improve compatibility it could make sense to use a separate receipt
+type (e.g. `m.read.thread`) as the read receipt for threads. Without some syncing
+mechanism between unthreaded and threaded receipts this seems likely to cause
+users to re-read the same notifications on threaded and unthreaded clients.
+
+While it is possible to map from an unthreaded read receipt to multiple threaded
+read receipts, the opposite is not possible (to the author's knowledge). In short,
+it seems the [compatibility issues discussed above](#compatibility-with-unthreaded-clients)
+would not be solved by adding more receipt types.
+
+This also gets more complcated with the addition of the `m.read.private` receipt --
+would there additionally be an `m.read.private.thread`? How do you map between
+all of these?
 
 ## Security considerations
 

--- a/proposals/3771-read-receipts-for-threads.md
+++ b/proposals/3771-read-receipts-for-threads.md
@@ -17,8 +17,8 @@ flowchart RL
     D-->C
     C-->B
     B-->A
-    D-.->A
-    F-.->A
+    C-.->A
+    E-.->A
 ```
 
 A client might interpret this as:
@@ -26,22 +26,22 @@ A client might interpret this as:
 ```mermaid
 flowchart RL
     subgraph Main timeline
-    C-->B
+    D-->B
     B-->A
-    F-->C
+    F-->D
     end
     subgraph Thread timeline
-    D-->A
-    E-->D
+    C-->A
+    E-->C
     end
 
     style A fill:cyan,stroke:#333,stroke-width:2px
-    style E fill:orange,stroke:#333,stroke-width:2px
+    style F fill:orange,stroke:#333,stroke-width:2px
 ```
 
 While viewing the "main" timeline of the room, a client might move the read
-receipt from event `A` to event `E` without ever showing events `D` and `F`. The
-user then reads the thread, the client has no way to mark `F` as read.
+receipt from event `A` to event `F` without ever showing events `C` and `E`. The
+user then reads the thread, the client has no way to mark `E` as read.
 
 ## Proposal
 

--- a/proposals/3771-read-receipts-for-threads.md
+++ b/proposals/3771-read-receipts-for-threads.md
@@ -1,9 +1,11 @@
 # MSC3771: Read receipts for threads
 
 Currently, each room can only have a single receipt of each type per user. The
-read receipt ([`m.read`](https://spec.matrix.org/v1.3/client-server-api/#receipts) or [`m.read.private`](https://github.com/matrix-org/matrix-spec-proposals/pull/2285)) is used to sync the read status of a
-room across clients, to share with other users which events have been read and
-is used by the homeserver to calculate the number of unread messages.
+read receipt ([`m.read`](https://spec.matrix.org/v1.3/client-server-api/#receipts)
+or [`m.read.private`](https://github.com/matrix-org/matrix-spec-proposals/pull/2285))
+is used to sync the read status of a room across clients, to share with other
+users which events have been read and is used by the homeserver to calculate the
+number of unread messages.
 
 Unfortunately a client displaying threads may show a subset of a room's messages
 at a time, causing a user's read receipt to be misleading.

--- a/proposals/3771-read-receipts-for-threads.md
+++ b/proposals/3771-read-receipts-for-threads.md
@@ -187,7 +187,7 @@ or the presence of a `org.matrix.msc3771` flag in `unstable_features` on `/versi
 
 ## Dependencies
 
-This MSC depends on the following MSCs, which have been accepted into the spec,
-but have yet to be released:
+This MSC depends on the following MSCs, which have not yet been accepted into
+the spec:
 
 * [MSC3773](https://github.com/matrix-org/matrix-spec-proposals/pull/3773): Notifications for threads

--- a/proposals/3771-read-receipts-for-threads.md
+++ b/proposals/3771-read-receipts-for-threads.md
@@ -95,7 +95,7 @@ additional property in the body containing the thread ID:
       "m.read.thread.private": {
         "@rikj:jki.re": {
           "ts": 1436451550453,
-          "threadId": "$thread_root"
+          "thread_id": "$thread_root"
         }
       }
     }

--- a/proposals/3771-read-receipts-for-threads.md
+++ b/proposals/3771-read-receipts-for-threads.md
@@ -76,7 +76,7 @@ Thus, receipts are split into two categories, which this document calls "unthrea
 and "threaded". Threaded receipts are identified by the root message of the thread;
 additionally there is a special pseudo-thread for the main timeline. This allows marking
 the main timeline (a pseudo-thread) as read, without marking any actual threads (split
- off from the main timeline) as read.
+off from the main timeline) as read.
 
 The most significant difference between threaded and unthreaded receipts is how
 they clear notifications:
@@ -149,7 +149,7 @@ gains the following optional fields:
   A special value of `"main"` corresponds to the receipt being for the main
   timeline (i.e. events which are not part of a thread).
 
-  If this field is not provided than the receipt applies to the unthreaded
+  If this field is not provided then the receipt applies to the unthreaded
   version of the room.[^2]
 
 The following conditions are errors and should be rejected with a `400` error
@@ -320,7 +320,7 @@ read receipts, the opposite is not possible (to the author's knowledge). In shor
 it seems the [compatibility issues discussed above](#compatibility-with-unthreaded-clients)
 would not be solved by adding more receipt types.
 
-This also gets more complcated with the addition of the `m.read.private` receipt --
+This also gets more complicated with the addition of the `m.read.private` receipt --
 would there additionally be an `m.read.private.thread`? How do you map between
 all of these?
 

--- a/proposals/3771-read-receipts-for-threads.md
+++ b/proposals/3771-read-receipts-for-threads.md
@@ -1,10 +1,12 @@
 # MSC3771: Read receipts for threads
 
-Currently, each room has a single read receipt per user. This is used to sync the
-read status of a room across clients and calculate the number of unread messages.
+Currently, each room can only have a single receipt of each type per user. The
+read receipt (`m.read` or `m.read.private`) is used to sync the read status of a
+room across clients, to share with other users which events have been read and
+is used by the homeserver to calculate the number of unread messages.
 
 Unfortunately a client displaying threads may show a subset of a room's messages
-at a time, causing the read receipt to be misleading.
+at a time, causing a user's read receipt to be misleading.
 
 This might better be described by an example. Given a room with the following
 DAG of events (note that the dotted lines are a thread relation, as specified by
@@ -45,10 +47,10 @@ user then reads the thread, the client has no way to mark `E` as read.
 
 ## Proposal
 
-### Sending a threaded read receipt
+### Threaded read receipts
 
-This MSC proposes allowing the same receipt type to exist multiple times in a room
-by adding a `threadId` parameter to reach receipt.
+This MSC proposes allowing the same receipt type to exist multiple times in a room,
+once per thread.
 
 The [`/receipt`](https://spec.matrix.org/v1.2/client-server-api/#post_matrixclientv3roomsroomidreceiptreceipttypeeventid)
 endpoint gains a new optional path part and becomes:
@@ -87,7 +89,7 @@ POST /_matrix/client/r0/rooms/!room:example.org/receipt/m.read/$thread_reply/$th
 {}
 ```
 
-### Received threaded read receipts
+### Receiving threaded read receipts
 
 This would then come down `/sync` for the user with other receipts, but with an
 additional property in the body containing the thread ID:

--- a/proposals/3771-read-receipts-for-threads.md
+++ b/proposals/3771-read-receipts-for-threads.md
@@ -1,7 +1,7 @@
 # MSC3771: Read receipts for threads
 
 Currently, each room can only have a single receipt of each type per user. The
-read receipt (`m.read` or `m.read.private`) is used to sync the read status of a
+read receipt ([`m.read`](https://spec.matrix.org/v1.3/client-server-api/#receipts) or [`m.read.private`](https://github.com/matrix-org/matrix-spec-proposals/pull/2285)) is used to sync the read status of a
 room across clients, to share with other users which events have been read and
 is used by the homeserver to calculate the number of unread messages.
 

--- a/proposals/3771-read-receipts-for-threads.md
+++ b/proposals/3771-read-receipts-for-threads.md
@@ -96,7 +96,7 @@ additional property in the body containing the thread ID:
 {
   "content": {
     "$thread_reply": {
-      "m.read.thread.private": {
+      "m.read": {
         "@rikj:jki.re": {
           "ts": 1436451550453,
           "thread_id": "$thread_root"

--- a/proposals/3771-read-receipts-for-threads.md
+++ b/proposals/3771-read-receipts-for-threads.md
@@ -299,14 +299,15 @@ users, it will not impact notifications.
 
 ### Thread ID location
 
-Instead of adding the thread ID as a new path part, it could be added to the body
-of the receipt. There may be a small backwards compatibility benefit to this, but
-it seems clearer to put it as part of the URL.
+Instead of adding the thread ID in the body, it could be provided as part of the
+URL path or as a query parameter. Adding it to the URL (as part of the path or a
+query parameter) would make it difficult to differentiate the receipt's event ID
+field from the thread ID.
 
-Instead of encoding the thread ID as an integral part of the receipt, all of the
-read threads could be added to the body of the single receipt. This could cause
-data integrity issues if multiple clients attempt to update the receipt without
-first reading it.
+Another idea was to encode information for all threads in the single receipt, e.g.
+by adding them to the body of the single read receipt. This could cause data
+integrity issues if multiple clients attempt to update the receipt without first
+reading it.
 
 ### Receipt type
 


### PR DESCRIPTION
[Rendered](https://github.com/matrix-org/matrix-spec-proposals/blob/clokep/threads-read-receipts/proposals/3771-read-receipts-for-threads.md)

---

Implementations:

* Synapse: matrix-org/synapse#13782
* Element Web: matrix-org/matrix-js-sdk#2635 / matrix-org/matrix-react-sdk#9239

----

[FCP tickyboxes](https://github.com/matrix-org/matrix-spec-proposals/pull/3771#issuecomment-1238476257)