### PR TITLE
Pull request templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/ready-proposal.md
+++ b/.github/PULL_REQUEST_TEMPLATE/ready-proposal.md
@@ -1,0 +1,21 @@
+---
+name: Proposal ready for review
+about: A proposal that is ready for review by the core team and community.
+title: ''
+labels: proposal, proposal-in-review
+assignees: ''
+
+---
+
+<!-- Put your "rendered" link here -->
+
+### Pull Request Checklist
+
+<!-- Please read CONTRIBUTING.md before submitting your pull request -->
+
+* [ ] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec-proposals/blob/master/CONTRIBUTING.md#sign-off)
+* [ ] Update the title and file name of your proposal to match this PR's number (after opening).
+* [ ] Pull request includes a ['Rendered' link](https://matrix.org/docs/spec/proposals#process) above.
+* [ ] Ask in
+      [#matrix-spec:matrix.org](https://matrix.to/#/#matrix-spec:matrix.org) to
+      get feedback on this PR.

--- a/.github/PULL_REQUEST_TEMPLATE/wip-proposal.md
+++ b/.github/PULL_REQUEST_TEMPLATE/wip-proposal.md
@@ -1,0 +1,19 @@
+---
+name: WIP Proposal
+about: A proposal that isn't quite ready for formal review yet.
+title: '[WIP] Your Proposal Title'
+labels: proposal
+assignees: ''
+
+---
+
+<!-- Put your "rendered" link here -->
+
+### Pull Request Checklist
+
+<!-- Please read CONTRIBUTING.md before submitting your pull request -->
+
+* [ ] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec-proposals/blob/master/CONTRIBUTING.md#sign-off)
+* [ ] Update the title and file name of your proposal to match this PR's number (after opening).
+* [ ] Pull request includes a ['Rendered' link](https://matrix.org/docs/spec/proposals#process) above.
+* [ ] Ask in [#matrix-spec:matrix.org](https://matrix.to/#/#matrix-spec:matrix.org) to get this marked as ready for review, once it is ready for review.

--- a/.github/PULL_REQUEST_TEMPLATE/wip-proposal.md
+++ b/.github/PULL_REQUEST_TEMPLATE/wip-proposal.md
@@ -16,4 +16,5 @@ assignees: ''
 * [ ] Pull request includes a [sign off](https://github.com/matrix-org/matrix-spec-proposals/blob/master/CONTRIBUTING.md#sign-off)
 * [ ] Update the title and file name of your proposal to match this PR's number (after opening).
 * [ ] Pull request includes a ['Rendered' link](https://matrix.org/docs/spec/proposals#process) above.
-* [ ] Ask in [#matrix-spec:matrix.org](https://matrix.to/#/#matrix-spec:matrix.org) to get this marked as ready for review, once it is ready for review.
+
+<!-- Once the proposal is ready for review, ask in [#matrix-spec:matrix.org](https://matrix.to/#/#matrix-spec:matrix.org) to get it marked as such. -->


### PR DESCRIPTION
Mostly lifted from https://github.com/matrix-org/matrix-spec/tree/188eba69696e3429f25928103e7d60417c871d29/.github/PULL_REQUEST_TEMPLATE, where they were misplaced.