### PR TITLE
MSC3786: Add a default push rule to ignore `m.room.server_acl` events

### DIFF
--- a/proposals/0000-acl-notifs.md
+++ b/proposals/0000-acl-notifs.md
@@ -1,0 +1,35 @@
+# MSC0000: Add a default push rule to ignore `m.room.server_acl` events
+
+`m.room.server_acl` events allow for expressing which servers can participate in
+a room. Often during spam attacks, these events are sent quite frequently, which
+causes the users to be overwhelmed by notifications. (See
+<https://github.com/vector-im/element-web/issues/20788>) As this is very
+unideal, this MSC proposes a new push rule to avoid this.
+
+## Proposal
+
+A new default override rule is to be added that ignores `m.room.server_acl`
+events:
+
+```json
+{
+    "rule_id": ".m.rule.room.server_acl",
+    "default": true,
+    "enabled": true,
+    "conditions": [
+        {
+            "kind": "event_match",
+            "key": "type",
+            "pattern": "m.room.server_acl"
+        }
+    ],
+    "actions": [
+        "dont_notify"
+    ]
+}
+```
+
+## Unstable prefix
+
+During development, `org.matrix.msc0000.rule.room.server_acl` is to be used
+instead of `.m.rule.room.server_acl`.

--- a/proposals/3786-acl-notifs.md
+++ b/proposals/3786-acl-notifs.md
@@ -2,7 +2,7 @@
 
 `m.room.server_acl` events allow for expressing which servers can participate in
 a room. Room server ACLs aren't something the user should have to worry about,
-so these events should not trigger notifications, though right now they DO
+so these events should not trigger notifications; however right now they *do*
 trigger notifications, if they have the room rule set to `notify` (`All
 messages` in Element). To add to this, often during spam attacks, these events
 are sent quite frequently, which causes the users to be overwhelmed by

--- a/proposals/3786-acl-notifs.md
+++ b/proposals/3786-acl-notifs.md
@@ -31,5 +31,5 @@ events:
 
 ## Unstable prefix
 
-During development, `org.matrix.msc3786.rule.room.server_acl` is to be used
+During development, `.org.matrix.msc3786.rule.room.server_acl` is to be used
 instead of `.m.rule.room.server_acl`.

--- a/proposals/3786-acl-notifs.md
+++ b/proposals/3786-acl-notifs.md
@@ -1,4 +1,4 @@
-# MSC0000: Add a default push rule to ignore `m.room.server_acl` events
+# MSC3786: Add a default push rule to ignore `m.room.server_acl` events
 
 `m.room.server_acl` events allow for expressing which servers can participate in
 a room. Often during spam attacks, these events are sent quite frequently, which
@@ -31,5 +31,5 @@ events:
 
 ## Unstable prefix
 
-During development, `org.matrix.msc0000.rule.room.server_acl` is to be used
+During development, `org.matrix.msc3786.rule.room.server_acl` is to be used
 instead of `.m.rule.room.server_acl`.

--- a/proposals/3786-acl-notifs.md
+++ b/proposals/3786-acl-notifs.md
@@ -31,7 +31,7 @@ events:
 }
 ```
 
-This new push rule is inserted immediately after `.m.rule.reaction`.
+This new push rule is inserted immediately after `.m.rule.tombstone`.
 
 ## Unstable prefix
 

--- a/proposals/3786-acl-notifs.md
+++ b/proposals/3786-acl-notifs.md
@@ -13,8 +13,7 @@ notifications. (See <https://github.com/vector-im/element-web/issues/20788>.)
 Due to these problems, this MSC proposes a new push rule to ignore these events.
 The new push rule is analogous to `.m.rule.member_event` (see https://spec.matrix.org/v1.2/client-server-api/#default-override-rules), or `.m.rule.reaction`
 (from [MSC2153](https://github.com/matrix-org/matrix-spec-proposals/pull/2153)
-or [MSC2677](https://github.com/matrix-org/matrix-spec-proposals/pull/2677))
-when merged.
+or [MSC2677](https://github.com/matrix-org/matrix-spec-proposals/pull/2677)).
 
 ## Proposal
 

--- a/proposals/3786-acl-notifs.md
+++ b/proposals/3786-acl-notifs.md
@@ -11,7 +11,7 @@ which causes the users to be overwhelmed by
 notifications. (See <https://github.com/vector-im/element-web/issues/20788>.)
 
 Due to these problems, this MSC proposes a new push rule to ignore these events.
-The new push rule is analogues to `.m.rule.member_event` or `.m.rule.reaction`
+The new push rule is analogous to `.m.rule.member_event` (see https://spec.matrix.org/v1.2/client-server-api/#default-override-rules), or `.m.rule.reaction`
 (from [MSC2153](https://github.com/matrix-org/matrix-spec-proposals/pull/2153)
 or [MSC2677](https://github.com/matrix-org/matrix-spec-proposals/pull/2677))
 when merged.

--- a/proposals/3786-acl-notifs.md
+++ b/proposals/3786-acl-notifs.md
@@ -4,8 +4,10 @@
 a room. Room server ACLs aren't something the user should have to worry about,
 so these events should not trigger notifications; however right now they *do*
 trigger notifications, if the user has the room rule set to `notify` (`All
-messages` in Element). To add to this, often during spam attacks, these events
-are sent quite frequently, which causes the users to be overwhelmed by
+messages` in Element). 
+
+Additionally, these events are often sent quite frequently during spam attacks, 
+which causes the users to be overwhelmed by
 notifications. (See <https://github.com/vector-im/element-web/issues/20788>)
 
 Due to these problems, this MSC proposes a new push rule to ignore these events.

--- a/proposals/3786-acl-notifs.md
+++ b/proposals/3786-acl-notifs.md
@@ -4,14 +4,14 @@
 a room. Room server ACLs aren't something the user should have to worry about,
 so these events should not trigger notifications; however right now they *do*
 trigger notifications, if the user has the room rule set to `notify` (`All
-messages` in Element). 
+messages` in Element).
 
-Additionally, these events are often sent quite frequently during spam attacks, 
+Additionally, these events are often sent quite frequently during spam attacks,
 which causes the users to be overwhelmed by
 notifications. (See <https://github.com/vector-im/element-web/issues/20788>.)
 
 Due to these problems, this MSC proposes a new push rule to ignore these events.
-The new push rule is analogous to `.m.rule.member_event` (see https://spec.matrix.org/v1.2/client-server-api/#default-override-rules), or `.m.rule.reaction`
+The new push rule is analogous to `.m.rule.member_event` (see <https://spec.matrix.org/v1.2/client-server-api/#default-override-rules>), or `.m.rule.reaction`
 (from [MSC2153](https://github.com/matrix-org/matrix-spec-proposals/pull/2153)
 or [MSC2677](https://github.com/matrix-org/matrix-spec-proposals/pull/2677)).
 
@@ -31,6 +31,11 @@ to be added that ignores `m.room.server_acl` events:
             "kind": "event_match",
             "key": "type",
             "pattern": "m.room.server_acl"
+        },
+        {
+            "kind": "event_match",
+            "key": "state_key",
+            "pattern": ""
         }
     ],
     "actions": []

--- a/proposals/3786-acl-notifs.md
+++ b/proposals/3786-acl-notifs.md
@@ -33,9 +33,7 @@ to be added that ignores `m.room.server_acl` events:
             "pattern": "m.room.server_acl"
         }
     ],
-    "actions": [
-        "dont_notify"
-    ]
+    "actions": []
 }
 ```
 

--- a/proposals/3786-acl-notifs.md
+++ b/proposals/3786-acl-notifs.md
@@ -3,7 +3,7 @@
 `m.room.server_acl` events allow for expressing which servers can participate in
 a room. Room server ACLs aren't something the user should have to worry about,
 so these events should not trigger notifications; however right now they *do*
-trigger notifications, if they have the room rule set to `notify` (`All
+trigger notifications, if the user has the room rule set to `notify` (`All
 messages` in Element). To add to this, often during spam attacks, these events
 are sent quite frequently, which causes the users to be overwhelmed by
 notifications. (See <https://github.com/vector-im/element-web/issues/20788>)

--- a/proposals/3786-acl-notifs.md
+++ b/proposals/3786-acl-notifs.md
@@ -31,6 +31,8 @@ events:
 }
 ```
 
+This new push rule is inserted immediately after `.m.rule.reaction`.
+
 ## Unstable prefix
 
 During development, `.org.matrix.msc3786.rule.room.server_acl` is to be used

--- a/proposals/3786-acl-notifs.md
+++ b/proposals/3786-acl-notifs.md
@@ -2,9 +2,11 @@
 
 `m.room.server_acl` events allow for expressing which servers can participate in
 a room. Often during spam attacks, these events are sent quite frequently, which
-causes the users to be overwhelmed by notifications. (See
+causes the users to be overwhelmed by notifications, if they have the room rule
+set to `notify` (`All messages` in Element). (See
 <https://github.com/vector-im/element-web/issues/20788>) As this is very
-unideal, this MSC proposes a new push rule to avoid this.
+unideal, this MSC proposes a new push rule to avoid this. It is analogues
+to [MSC2153](https://github.com/matrix-org/matrix-spec-proposals/pull/2153).
 
 ## Proposal
 

--- a/proposals/3786-acl-notifs.md
+++ b/proposals/3786-acl-notifs.md
@@ -1,17 +1,24 @@
 # MSC3786: Add a default push rule to ignore `m.room.server_acl` events
 
 `m.room.server_acl` events allow for expressing which servers can participate in
-a room. Often during spam attacks, these events are sent quite frequently, which
-causes the users to be overwhelmed by notifications, if they have the room rule
-set to `notify` (`All messages` in Element). (See
-<https://github.com/vector-im/element-web/issues/20788>) As this is very
-unideal, this MSC proposes a new push rule to avoid this. It is analogues
-to [MSC2153](https://github.com/matrix-org/matrix-spec-proposals/pull/2153).
+a room. Room server ACLs aren't something the user should have to worry about,
+so these events should not trigger notifications, though right now they DO
+trigger notifications, if they have the room rule set to `notify` (`All
+messages` in Element). To add to this, often during spam attacks, these events
+are sent quite frequently, which causes the users to be overwhelmed by
+notifications. (See <https://github.com/vector-im/element-web/issues/20788>)
+
+Due to these problems, this MSC proposes a new push rule to ignore these events.
+The new push rule is analogues to `.m.rule.member_event` or `.m.rule.reaction`
+(from [MSC2153](https://github.com/matrix-org/matrix-spec-proposals/pull/2153)
+or [MSC2677](https://github.com/matrix-org/matrix-spec-proposals/pull/2677))
+when merged.
 
 ## Proposal
 
-A new [default override rule](https://spec.matrix.org/v1.2/client-server-api/#default-override-rules) is to be added that ignores `m.room.server_acl`
-events:
+A new [default override
+rule](https://spec.matrix.org/v1.2/client-server-api/#default-override-rules) is
+to be added that ignores `m.room.server_acl` events:
 
 ```json
 {

--- a/proposals/3786-acl-notifs.md
+++ b/proposals/3786-acl-notifs.md
@@ -8,7 +8,7 @@ messages` in Element).
 
 Additionally, these events are often sent quite frequently during spam attacks, 
 which causes the users to be overwhelmed by
-notifications. (See <https://github.com/vector-im/element-web/issues/20788>)
+notifications. (See <https://github.com/vector-im/element-web/issues/20788>.)
 
 Due to these problems, this MSC proposes a new push rule to ignore these events.
 The new push rule is analogues to `.m.rule.member_event` or `.m.rule.reaction`

--- a/proposals/3786-acl-notifs.md
+++ b/proposals/3786-acl-notifs.md
@@ -8,7 +8,7 @@ unideal, this MSC proposes a new push rule to avoid this.
 
 ## Proposal
 
-A new default override rule is to be added that ignores `m.room.server_acl`
+A new [default override rule](https://spec.matrix.org/v1.2/client-server-api/#default-override-rules) is to be added that ignores `m.room.server_acl`
 events:
 
 ```json


### PR DESCRIPTION
For https://github.com/vector-im/element-web/issues/20788
[Rendered](https://github.com/matrix-org/matrix-spec-proposals/blob/SimonBrandner/msc/acl-notifs/proposals/3786-acl-notifs.md)

<hr>

[`matrix-js-sdk` PR](https://github.com/matrix-org/matrix-js-sdk/pull/2333)
[`synapse` PR](https://github.com/matrix-org/synapse/pull/12601)

----

[FCP ticky boxes](https://github.com/matrix-org/matrix-spec-proposals/pull/3786#issuecomment-1136169287)