### PR TITLE
MSC3818: Copy room type on upgrade

### DIFF
--- a/proposals/3818-copy-room-type-on-upgrade.md
+++ b/proposals/3818-copy-room-type-on-upgrade.md
@@ -23,7 +23,9 @@ It becomes:
 
 ## Potential issues
 
-Non-applicable.
+Some room types such as Spaces also require copying over state events as a part of the update progress,
+in case of Spaces, `m.space.child` events. However as that can be changed later and done by the client,
+it's out of scope for this MSC.
 
 ## Alternatives
 

--- a/proposals/3818-copy-room-type-on-upgrade.md
+++ b/proposals/3818-copy-room-type-on-upgrade.md
@@ -29,7 +29,11 @@ it's out of scope for this MSC.
 
 ## Alternatives
 
-Non-applicable.
+A suggested alternative is having every room type specify their own update process if they use other
+room types. However this would complicate the MSC process with even simple client-side proposals
+requiring also a server-side implementation. This could also result in room types dependent on a
+particular server software or discourage using Matrix for a smaller project where an MSC wasn't
+otherwise consider necessary.
 
 ## Security considerations
 

--- a/proposals/3818-copy-room-type-on-upgrade.md
+++ b/proposals/3818-copy-room-type-on-upgrade.md
@@ -1,4 +1,4 @@
-# MSCXXXX: Copy room type on upgrade.
+# MSC3818: Copy room type on upgrade
 
 There can never be enough templates in the world, and MSCs shouldn't be any different. The level
 of detail expected of proposals can be unclear - this is what this example proposal (which doubles

--- a/proposals/3818-copy-room-type-on-upgrade.md
+++ b/proposals/3818-copy-room-type-on-upgrade.md
@@ -1,9 +1,5 @@
 # MSC3818: Copy room type on upgrade
 
-There can never be enough templates in the world, and MSCs shouldn't be any different. The level
-of detail expected of proposals can be unclear - this is what this example proposal (which doubles
-as a template itself) aims to resolve.
-
 Unless the room upgrade API specifies that room type must be copied over, clients cannot rely on
 rooms staying the same type leading to trouble.
 

--- a/proposals/3818-copy-room-type-on-upgrade.md
+++ b/proposals/3818-copy-room-type-on-upgrade.md
@@ -17,7 +17,7 @@ The Spec currently specfies this in [section 11.32.3. server behaviour](https://
 It becomes:
 
 > 2. Creates a replacement room with a `m.room.create` event containing a `predecessor` field, a
-> `type` field if it was set in the previous room, and the applicable `room_version`.
+> `type` field set to what it was in the previous room (if it was set), and the applicable `room_version`.
 
 
 ## Potential issues

--- a/proposals/3818-copy-room-type-on-upgrade.md
+++ b/proposals/3818-copy-room-type-on-upgrade.md
@@ -8,7 +8,7 @@ rooms staying the same type leading to trouble.
 
 This MSC proposes that the room upgade API MUST copy the [room type](https://spec.matrix.org/v1.2/client-server-api/#types)
 over to the new room. Otherwise clients cannot trust that to happen and [Spaces](https://spec.matrix.org/v1.2/client-server-api/#spaces)
-or [MSC3588](https://github.com/matrix-org/matrix-doc/pull/3588) Story rooms may incorrectly become
+or [MSC3588](https://github.com/matrix-org/matrix-spec-proposals/pull/3588) Story rooms may incorrectly become
 normal rooms breaking user-experience.
 
 The Spec currently specfies this in [section 11.32.3. server behaviour](https://spec.matrix.org/v1.2/client-server-api/#server-behaviour-16):

--- a/proposals/3818-copy-room-type-on-upgrade.md
+++ b/proposals/3818-copy-room-type-on-upgrade.md
@@ -6,8 +6,8 @@ rooms staying the same type leading to trouble.
 
 ## Proposal
 
-This MSC proposes that the room upgade API MUST copy the [room type](https://spec.matrix.org/latest/client-server-api/#types)
-over to the new room. Otherwise clients cannot trust that to happen and [Spaces](https://spec.matrix.org/latest/client-server-api/#spaces)
+This MSC proposes that the room upgade API MUST copy the [room type](https://spec.matrix.org/v1.2/client-server-api/#types)
+over to the new room. Otherwise clients cannot trust that to happen and [Spaces](https://spec.matrix.org/v1.2/client-server-api/#spaces)
 or [MSC3588](https://github.com/matrix-org/matrix-doc/pull/3588) Story rooms may incorrectly become
 normal rooms breaking user-experience.
 

--- a/proposals/3818-copy-room-type-on-upgrade.md
+++ b/proposals/3818-copy-room-type-on-upgrade.md
@@ -10,6 +10,15 @@ This MSC proposes that the room upgade API MUST copy the room type over to the n
 clients cannot trust that to happen and Spaces or MSC3588 Story rooms may incorrectly become normal
 rooms breaking user-experience.
 
+The Spec currently specfies this in [section 11.32.3. server behaviour](https://spec.matrix.org/v1.2/client-server-api/#server-behaviour-16):
+
+> 2. Creates a replacement room with a `m.room.create` event containing a `predecessor` field and the applicable `room_version`.
+
+It becomes:
+
+> 2. Creates a replacement room with a `m.room.create` event containing a `predecessor` field, a
+> `type` field if it was set in the previous room, and the applicable `room_version`.
+
 
 ## Potential issues
 

--- a/proposals/3818-copy-room-type-on-upgrade.md
+++ b/proposals/3818-copy-room-type-on-upgrade.md
@@ -6,9 +6,10 @@ rooms staying the same type leading to trouble.
 
 ## Proposal
 
-This MSC proposes that the room upgade API MUST copy the room type over to the new room. Otherwise
-clients cannot trust that to happen and Spaces or MSC3588 Story rooms may incorrectly become normal
-rooms breaking user-experience.
+This MSC proposes that the room upgade API MUST copy the [room type](https://spec.matrix.org/latest/client-server-api/#types)
+over to the new room. Otherwise clients cannot trust that to happen and [Spaces](https://spec.matrix.org/latest/client-server-api/#spaces)
+or [MSC3588](https://github.com/matrix-org/matrix-doc/pull/3588) Story rooms may incorrectly become
+normal rooms breaking user-experience.
 
 The Spec currently specfies this in [section 11.32.3. server behaviour](https://spec.matrix.org/v1.2/client-server-api/#server-behaviour-16):
 

--- a/proposals/xxxx-copy-room-type-on-upgrade.md
+++ b/proposals/xxxx-copy-room-type-on-upgrade.md
@@ -1,0 +1,36 @@
+# MSCXXXX: Copy room type on upgrade.
+
+There can never be enough templates in the world, and MSCs shouldn't be any different. The level
+of detail expected of proposals can be unclear - this is what this example proposal (which doubles
+as a template itself) aims to resolve.
+
+Unless the room upgrade API specifies that room type must be copied over, clients cannot rely on
+rooms staying the same type leading to trouble.
+
+
+## Proposal
+
+This MSC proposes that the room upgade API MUST copy the room type over to the new room. Otherwise
+clients cannot trust that to happen and Spaces or MSC3588 Story rooms may incorrectly become normal
+rooms breaking user-experience.
+
+
+## Potential issues
+
+Non-applicable.
+
+## Alternatives
+
+Non-applicable.
+
+## Security considerations
+
+Non-applicable.
+
+## Unstable prefix
+
+Non-applicable.
+
+## Dependencies
+
+Non-applicable.


### PR DESCRIPTION
This or equivalent MSC is blocking vector-im/element-web#19208 <s>and matrix-org/synapse#11896.</s>

[Rendered](https://github.com/Mikaela/matrix-spec-proposals/blob/copy-room-type-on-upgrade/proposals/3818-copy-room-type-on-upgrade.md)

Resolves: matrix-org/matrix-spec#911

Signed-off-by: Aminda Suomalainen 

Implementations: https://github.com/matrix-org/synapse/pull/12786

FCP proposal: https://github.com/matrix-org/matrix-spec-proposals/pull/3818#issuecomment-1189171267