### PR TITLE
MSC3820: Room version 11

### DIFF
--- a/proposals/3820-rooms-v11.md
+++ b/proposals/3820-rooms-v11.md
@@ -1,0 +1,24 @@
+# MSC3604: Room Version 11
+
+A new room version, `11`, is proposed using room version 10 (unspecified as of writing) as a base
+and incorporating the following MSCs:
+
+* [MSC2174](https://github.com/matrix-org/matrix-spec-proposals/pull/2174) - Move `redacts` to sane place
+* [MSC2176](https://github.com/matrix-org/matrix-spec-proposals/pull/2176) - Update to redaction rules
+
+Though other MSCs are capable of being included in this version, they do not have sufficient implementation to be
+considered stable enough for v11 rooms. A future room version may still include them. Such examples of ineligible MSCs
+are:
+
+* [MSC2244](https://github.com/matrix-org/matrix-spec-proposals/pull/2244) - Mass redactions
+* [MSC2175](https://github.com/matrix-org/matrix-spec-proposals/pull/2175) - Remove extraneous `creator` field
+* [MSC2828](https://github.com/matrix-org/matrix-spec-proposals/pull/2828) - Restrict allowed user IDs over federation
+* [MSC1229](https://github.com/matrix-org/matrix-spec-proposals/issues/1229) - Mitigating abuse of `depth`
+
+Room version 11 upon being added to the specification shall be considered stable. No other room versions are affected
+by this MSC.
+
+## Unstable prefix
+
+Implementations looking to test v11 before written into the specification should use `org.matrix.msc3820.opt1`
+as the room version, treating it as unstable.

--- a/proposals/3820-rooms-v11.md
+++ b/proposals/3820-rooms-v11.md
@@ -1,6 +1,6 @@
 # MSC3604: Room Version 11
 
-A new room version, `11`, is proposed using room version 10 (unspecified as of writing) as a base
+A new room version, `11`, is proposed using [room version 10](https://spec.matrix.org/v1.7/rooms/v10/) as a base
 and incorporating the following MSCs:
 
 * [MSC2174](https://github.com/matrix-org/matrix-spec-proposals/pull/2174) - Move `redacts` to sane place

--- a/proposals/3820-rooms-v11.md
+++ b/proposals/3820-rooms-v11.md
@@ -4,21 +4,25 @@ A new room version, `11`, is proposed using room version 10 (unspecified as of w
 and incorporating the following MSCs:
 
 * [MSC2174](https://github.com/matrix-org/matrix-spec-proposals/pull/2174) - Move `redacts` to sane place
-* [MSC2176](https://github.com/matrix-org/matrix-spec-proposals/pull/2176) - Update to redaction rules
+* [MSC2175](https://github.com/matrix-org/matrix-spec-proposals/pull/2175) - Remove `creator` field from `m.room.create` events
+* [MSC2176](https://github.com/matrix-org/matrix-spec-proposals/pull/2176) - Updates to redaction rules
+* [MSC3989](https://github.com/matrix-org/matrix-spec-proposals/pull/3989) - Redact `origin` on events
+* [MSC3821](https://github.com/matrix-org/matrix-spec-proposals/pull/3821) - More updates to redaction rules
 
 Though other MSCs are capable of being included in this version, they do not have sufficient implementation to be
 considered stable enough for v11 rooms. A future room version may still include them. Such examples of ineligible MSCs
 are:
 
 * [MSC2244](https://github.com/matrix-org/matrix-spec-proposals/pull/2244) - Mass redactions
-* [MSC2175](https://github.com/matrix-org/matrix-spec-proposals/pull/2175) - Remove extraneous `creator` field
-* [MSC2828](https://github.com/matrix-org/matrix-spec-proposals/pull/2828) - Restrict allowed user IDs over federation
-* [MSC1229](https://github.com/matrix-org/matrix-spec-proposals/issues/1229) - Mitigating abuse of `depth`
+* A number of MSCs which have not yet been accepted (they are not iterated here).
 
 Room version 11 upon being added to the specification shall be considered stable. No other room versions are affected
 by this MSC.
 
 ## Unstable prefix
 
-Implementations looking to test v11 before written into the specification should use `org.matrix.msc3820.opt1`
+Implementations looking to test v11 before written into the specification should use `org.matrix.msc3820.opt2`
 as the room version, treating it as unstable.
+
+Note: `org.matrix.msc3820.opt1` is from a prior draft of this proposal, consisting of different MSCs than the
+current iteration. Implementations should not treat opt1 the same as other unstable-for-MSC3820 versions.


### PR DESCRIPTION
[Rendered](https://github.com/matrix-org/matrix-spec-proposals/blob/travis/msc/v11/proposals/3820-rooms-v11.md)

The following MSCs are included in this proposal. MSCs without a checkmark are blocking FCP from being proposed here.
* [x] [MSC2174](https://github.com/matrix-org/matrix-spec-proposals/pull/2174) - Move `redacts` to sane place
* [x] [MSC2175](https://github.com/matrix-org/matrix-spec-proposals/pull/2175) - Remove `creator` field from `m.room.create` events
* [x] [MSC2176](https://github.com/matrix-org/matrix-spec-proposals/pull/2176) - Updates to redaction rules
* [x] [MSC3989](https://github.com/matrix-org/matrix-spec-proposals/pull/3989) - Redact `origin` on events
* [x] [MSC3821](https://github.com/matrix-org/matrix-spec-proposals/pull/3821) - More updates to redaction rules

Implementations:
* Synapse, option 2: https://github.com/matrix-org/synapse/pull/15666

[FCP tickyboxes](https://github.com/matrix-org/matrix-spec-proposals/pull/3820#issuecomment-1597331110)