### PR TITLE
MSC3821: Update the redaction rules, again

### DIFF
--- a/proposals/3821-update-redaction-rules-again.md
+++ b/proposals/3821-update-redaction-rules-again.md
@@ -22,5 +22,3 @@ In a new room version due to redactions affecting event hashes, we:
 
 Implementations looking to test these changes before adopted into a stable room version should use
 `org.matrix.msc3821.opt1` as the room version, using v9 as a base and treating it as unstable.
-
-**However, servers are not encouraged to attempt implementation until this MSC leaves draft/WIP state.**

--- a/proposals/3821-update-redaction-rules-again.md
+++ b/proposals/3821-update-redaction-rules-again.md
@@ -1,22 +1,29 @@
 # Update redaction rules, again
 
 The current [redaction algorithm](https://spec.matrix.org/v1.6/rooms/v9/#redactions) are
-still missing some key fields, even after [MSC2176](https://github.com/matrix-org/matrix-spec-proposals/pull/2176)
-attempted to fix some of the obvious cases. This MSC aims to fix more fields.
+still missing some key properties, even after [MSC2176](https://github.com/matrix-org/matrix-spec-proposals/pull/2176)
+attempted to fix some of the obvious cases. This MSC aims to fix those missing cases.
 
 ## Proposal
 
 *Note*: It is recommended to read [MSC2176](https://github.com/matrix-org/matrix-spec-proposals/pull/2176)
 before this proposal as MSC2176 contains a lot of backing context.
 
-In a new room version (due to redactions affecting event hashes):
+In a future room version, the following changes are made to the [redaction algorithm](https://spec.matrix.org/v1.6/rooms/v10/#redactions).
+Note that this requires a new room version because changing the redaction algorithm changes how
+[event IDs](https://spec.matrix.org/v1.6/rooms/v10/#event-ids) are calculated, as they are
+[reference hashes](https://spec.matrix.org/v1.6/server-server-api/#calculating-the-reference-hash-for-an-event)
+which redact the event during calculation.
 
-* `m.room.member` events additionally preserve part of `third_party_invite` under `content`, if present:
-  * Spec: https://spec.matrix.org/v1.6/client-server-api/#mroommember
-  * Under `third_party_invite`, `signed` is preserved. Rationale being that the `signed` block is required
-    for the server to validate the event, however excess fields and `display_name` are not as important.
-    Clients which are trying to represent a redacted `m.room.member` event with `third_party_invite` should
-    not rely on `display_name` being present but rather state "Bob accepted a third party invite" or similar.
+* [`m.room.member`](https://spec.matrix.org/v1.6/client-server-api/#mroommember) events preserve a portion
+  of `third_party_invite` under `content`, if present. Those properties being:
+
+  * `signed`: the block is required for the server to validate the event, however excess adjacent properties
+    such as `display_name` are not important.
+
+Clients should note that because `display_name` is *not* preserved during redaction they might need to change
+how that event is rendered/presented to users. For example, when rendering such a redacted event the client
+might show it as "Bob accepted a third party invite".
 
 ## Unstable prefix
 

--- a/proposals/3821-update-redaction-rules-again.md
+++ b/proposals/3821-update-redaction-rules-again.md
@@ -1,6 +1,6 @@
 # Update redaction rules, again
 
-The current [redaction algorithm](https://spec.matrix.org/v1.2/rooms/v9/#redactions) are
+The current [redaction algorithm](https://spec.matrix.org/v1.6/rooms/v9/#redactions) are
 still missing some key fields, even after [MSC2176](https://github.com/matrix-org/matrix-spec-proposals/pull/2176)
 attempted to fix some of the obvious cases. This MSC aims to fix more fields.
 
@@ -12,7 +12,7 @@ before this proposal as MSC2176 contains a lot of backing context.
 In a new room version due to redactions affecting event hashes, we:
 
 * `m.room.member` events additionally preserve part of `third_party_invite` under `content`, if present:
-  * Spec: https://spec.matrix.org/v1.2/client-server-api/#mroommember
+  * Spec: https://spec.matrix.org/v1.6/client-server-api/#mroommember
   * Under `third_party_invite`, `signed` is preserved. Rationale being that the `signed` block is required
     for the server to validate the event, however excess fields and `display_name` are not as important.
     Clients which are trying to represent a redacted `m.room.member` event with `third_party_invite` should

--- a/proposals/3821-update-redaction-rules-again.md
+++ b/proposals/3821-update-redaction-rules-again.md
@@ -1,8 +1,11 @@
-# Update redaction rules, again
+# MSC3821: Update redaction rules, again
 
-The current [redaction algorithm](https://spec.matrix.org/v1.6/rooms/v9/#redactions) are
-still missing some key properties, even after [MSC2176](https://github.com/matrix-org/matrix-spec-proposals/pull/2176)
-attempted to fix some of the obvious cases. This MSC aims to fix those missing cases.
+[MSC2176](https://github.com/matrix-org/matrix-spec-proposals/pull/2176) aimed to fix inconsistencies
+with the [redaction algorithm](https://spec.matrix.org/v1.6/rooms/v10/#redactions) where server-side
+event auth required properties to exist that were being removed. While MSC2176 fixed a number of cases,
+one was unfortunately missed.
+
+This MSC aims to fix that missing case, originally identified long ago by [synapse#1831](https://github.com/matrix-org/synapse/issues/1831).
 
 ## Proposal
 
@@ -28,4 +31,7 @@ might show it as "Bob accepted a third party invite".
 ## Unstable prefix
 
 Implementations looking to test these changes before adopted into a stable room version should use
-`org.matrix.msc3821.opt1` as the room version, using v9 as a base and treating it as unstable.
+`org.matrix.msc3821.opt1` as the room version, using **v9** as a base and treating it as unstable.
+
+**History**: This MSC was originally written before room version 10 existed. Implementations wishing to use
+v10 as a base instead of v9 should use `org.matrix.msc3821.opt1.v10` as the room version instead.

--- a/proposals/3821-update-redaction-rules-again.md
+++ b/proposals/3821-update-redaction-rules-again.md
@@ -9,7 +9,7 @@ attempted to fix some of the obvious cases. This MSC aims to fix more fields.
 *Note*: It is recommended to read [MSC2176](https://github.com/matrix-org/matrix-spec-proposals/pull/2176)
 before this proposal as MSC2176 contains a lot of backing context.
 
-In a new room version due to redactions affecting event hashes, we:
+In a new room version (due to redactions affecting event hashes):
 
 * `m.room.member` events additionally preserve part of `third_party_invite` under `content`, if present:
   * Spec: https://spec.matrix.org/v1.6/client-server-api/#mroommember

--- a/proposals/3821-update-redaction-rules-again.md
+++ b/proposals/3821-update-redaction-rules-again.md
@@ -1,0 +1,26 @@
+# Update redaction rules, again
+
+The current [redaction algorithm](https://spec.matrix.org/v1.2/rooms/v9/#redactions) are
+still missing some key fields, even after [MSC2176](https://github.com/matrix-org/matrix-spec-proposals/pull/2176)
+attempted to fix some of the obvious cases. This MSC aims to fix more fields.
+
+## Proposal
+
+*Note*: It is recommended to read [MSC2176](https://github.com/matrix-org/matrix-spec-proposals/pull/2176)
+before this proposal as MSC2176 contains a lot of backing context.
+
+In a new room version due to redactions affecting event hashes, we:
+
+* `m.room.member` events additionally preserve part of `third_party_invite` under `content`, if present:
+  * Spec: https://spec.matrix.org/v1.2/client-server-api/#mroommember
+  * Under `third_party_invite`, `signed` is preserved. Rationale being that the `signed` block is required
+    for the server to validate the event, however excess fields and `display_name` are not as important.
+    Clients which are trying to represent a redacted `m.room.member` event with `third_party_invite` should
+    not rely on `display_name` being present but rather state "Bob accepted a third party invite" or similar.
+
+## Unstable prefix
+
+Implementations looking to test these changes before adopted into a stable room version should use
+`org.matrix.msc3821.opt1` as the room version, using v9 as a base and treating it as unstable.
+
+**However, servers are not encouraged to attempt implementation until this MSC leaves draft/WIP state.**


### PR DESCRIPTION
[Rendered](https://github.com/matrix-org/matrix-spec-proposals/blob/travis/msc/redaction-rules-change-again/proposals/3821-update-redaction-rules-again.md)

Implementation: https://github.com/matrix-org/synapse/pull/15563

[FCP tickyboxes](https://github.com/matrix-org/matrix-spec-proposals/pull/3821#issuecomment-1562045957)