### PR TITLE
Update MSC2175 "removed auth rule" note

### DIFF
--- a/proposals/2175-remove-creator-field.md
+++ b/proposals/2175-remove-creator-field.md
@@ -10,7 +10,7 @@ and that the `sender` field be used instead.
 
 Note that `creator` is mentioned in the [auth
 rules](https://matrix.org/docs/spec/rooms/v1#authorization-rules). It can
-safely be removed.
+safely be replaced with a check against the `sender` instead.
 
 `creator` is also mentioned as a key to be preserved during [Event
 redaction](https://matrix.org/docs/spec/client_server/r0.5.0#redactions). It


### PR DESCRIPTION
We use the markdown version for spec writing, so important to get this detail in there.