### PR TITLE
MSC3844: Remove unused policy room sharing mechanism

### DIFF
--- a/proposals/3844-remove-mjolnir-sharing.md
+++ b/proposals/3844-remove-mjolnir-sharing.md
@@ -1,0 +1,12 @@
+# MSC3844: Remove "Mjolnir" (policy room) sharing mechanism
+
+Way back when [MSC2313](https://github.com/matrix-org/matrix-spec-proposals/pull/2313) was written,
+it included a [sharing](https://spec.matrix.org/v1.3/client-server-api/#sharing-1) mechanism that
+never got used.
+
+That sharing mechanism is to be removed from the specification due to lack of use and questionable
+technical approach. In practice, users and implementations have been handing out room aliases to
+policy rooms just fine.
+
+Normally an MSC would propose deprecation followed by eventual removal, however seeing as the core
+team is aware of exactly zero implementations of this feature it feels safe to just outright remove.


### PR DESCRIPTION
[Rendered](https://github.com/matrix-org/matrix-spec-proposals/blob/travis/msc/remove-mjolnir-sharing/proposals/3844-remove-mjolnir-sharing.md)