### PR TITLE
MSC3860: Media Download Redirects

### DIFF
--- a/proposals/3860-media-download-redirect.md
+++ b/proposals/3860-media-download-redirect.md
@@ -38,8 +38,8 @@ repo itself a bad actor, thus this does not present any increased security issue
 
 ## Unstable Prefix
 
-No need for an unstable prefix for redirects as it stands. If a query string was to be used to
-enable this functionality this could use the following unstable prefix:
+Until this functionality has landed in the spec, the `allow_redirect` query
+parameter should be prefixed with `com.beeper.msc3860.`:
 
 ```
 ?com.beeper.msc3860.allow_redirect=true

--- a/proposals/3860-media-download-redirect.md
+++ b/proposals/3860-media-download-redirect.md
@@ -1,11 +1,15 @@
 # MSC3860: Media Download Redirects
 
-Currently the media download endpoints must return either a 200 with content or error responses. This means the media server instance must stream the data from wherever it is stored, which is likely not local to itself. Allowing redirects on these endpoints would 
-make it possible for the media repo to tell clients/servers to pull data direct from the source, eg. a CDN.
+Currently the media download endpoints must return either a 200 with content or error responses. This
+means the media server instance must stream the data from wherever it is stored, which is likely not
+local to itself. Allowing redirects on these endpoints would  make it possible for the media repo to
+tell clients/servers to pull data direct from the source, eg. a CDN.
 
 ## Proposal
 
-This MSC simply proposes that a 307 redirect code is allowed and followed according to the `Location` header. It is possible some clients would already follow these which needs to be confirmed. Specifc endpoints in question:
+This MSC simply proposes that a 307 redirect code is allowed and followed according to the `Location`
+header. It is possible some clients would already follow these which needs to be confirmed. Specifc
+endpoints in question:
 
 + `/_matrix/media/v3/download/{serverName}/{mediaId}`
 + `/_matrix/media/v3/download/{serverName}/{mediaId}/{fileName}`

--- a/proposals/3860-media-download-redirect.md
+++ b/proposals/3860-media-download-redirect.md
@@ -23,6 +23,9 @@ client respects redirect responses it can make requests like so to the media end
 + `/_matrix/media/v3/download/{serverName}/{mediaId}/{fileName}?allow_redirect=true`
 + `/_matrix/media/v3/thumbnail/{serverName}/{mediaId}?allow_redirect=true`
 
+In the case where a client wishes not to redirect (either implictly with no parameter or explicitly
+providing `allow_redirect=false`) the server must continue to serve media directly with no redirect.
+
 ## Potential Issues
 
 None, as opt-in functionality this change is 100% backwards compatible.

--- a/proposals/3860-media-download-redirect.md
+++ b/proposals/3860-media-download-redirect.md
@@ -3,12 +3,12 @@
 Currently the media download endpoints must return either a 200 with content or error responses. This
 means the media server instance must stream the data from wherever it is stored, which is likely not
 local to itself. Allowing redirects on these endpoints would  make it possible for the media repo to
-tell clients/servers to pull data direct from the source, eg. a CDN.
+tell clients/servers to pull data direct from the source, e.g. a CDN.
 
 ## Proposal
 
 This MSC proposes that a 307 redirect code is allowed and followed according to the `Location`
-header. It is possible some clients would already follow these which needs to be confirmed. Specifc
+header. It is possible some clients would already follow these which needs to be confirmed. Specific
 endpoints in question:
 
 + `/_matrix/media/v3/download/{serverName}/{mediaId}`

--- a/proposals/3860-media-download-redirect.md
+++ b/proposals/3860-media-download-redirect.md
@@ -18,3 +18,27 @@ endpoints in question:
 The media repo already conforms to standard HTTP practices so this may already work as expected. The
 MSC is proposing to add redirects to the list of possible HTTP responses for the above endpoints in
 the Matrix Specifiction. Implementation would be confirming that this works in all the major clients.
+
+## Potential Issues
+
+There may be clients that don't follow redirect responses properly, in which case they would fail
+to retrieve the media. One possible workaround for this is utilising an opt-in query string parameter
+to allow redirects, e.g `?allow-redirect=true`.
+
+## Alternatives
+
+None at this time.
+
+## Security Considerations
+
+A media repo could redirect requests to a bad actor, although this would make the primary media
+repo itself a bad actor, this does present any increased security issues.
+
+## Unstable Prefix
+
+No need for an unstable prefix for redirects as it stands. If a query string was to be used to
+enable this functionality this could use the following unstable prefix:
+
+```
+?com.beeper.msc3860.allow-redirects=true
+```

--- a/proposals/3860-media-download-redirect.md
+++ b/proposals/3860-media-download-redirect.md
@@ -28,7 +28,7 @@ client respects redirect responses it can make requests like so to the media end
 + `/_matrix/media/v3/download/{serverName}/{mediaId}/{fileName}?allow_redirect=true`
 + `/_matrix/media/v3/thumbnail/{serverName}/{mediaId}?allow_redirect=true`
 
-In the case where a client wishes not to redirect (either implictly with no parameter or explicitly
+In the case where a client wishes not to redirect (either implicitly with no parameter or explicitly
 providing `allow_redirect=false`) the server must continue to serve media directly with no redirect.
 
 ## Potential Issues

--- a/proposals/3860-media-download-redirect.md
+++ b/proposals/3860-media-download-redirect.md
@@ -14,3 +14,7 @@ endpoints in question:
 + `/_matrix/media/v3/download/{serverName}/{mediaId}`
 + `/_matrix/media/v3/download/{serverName}/{mediaId}/{fileName}`
 + `/_matrix/media/v3/thumbnail/{serverName}/{mediaId}`
+
+The media repo already conforms to standard HTTP practices so this may already work as expected. The
+MSC is proposing to add redirects to the list of possible HTTP responses for the above endpoints in
+the Matrix Specifiction. Implementation would be confirming that this works in all the major clients.

--- a/proposals/3860-media-download-redirect.md
+++ b/proposals/3860-media-download-redirect.md
@@ -33,7 +33,14 @@ providing `allow_redirect=false`) the server must continue to serve media direct
 
 ## Potential Issues
 
-None, as opt-in functionality this change is 100% backwards compatible.
+None for clients, as opt-in functionality this change is 100% backwards compatible.
+
+With redirects it becomes easier to force another homeserver to be your CDN, which isn't great
+(clients could already do that, but not without recompiling).
+
+Redirects also potentially allow changing of media underneath the users as different redirects could
+be returned over time. It is worth noting that a badly behaving media server can already just return
+different content as well.
 
 ## Alternatives
 

--- a/proposals/3860-media-download-redirect.md
+++ b/proposals/3860-media-download-redirect.md
@@ -9,7 +9,7 @@ tell clients/servers to pull data direct from the source, e.g. a CDN.
 
 This MSC proposes that a 307 or 308 redirect code is allowed and followed according to the `Location`
 header. It is possible some clients would already follow these which needs to be confirmed. Specific
-endpoints in question:
+endpoints in question ([current spec link for these](https://spec.matrix.org/v1.6/client-server-api/#get_matrixmediav3downloadservernamemediaid)):
 
 + `/_matrix/media/v3/download/{serverName}/{mediaId}`
 + `/_matrix/media/v3/download/{serverName}/{mediaId}/{fileName}`

--- a/proposals/3860-media-download-redirect.md
+++ b/proposals/3860-media-download-redirect.md
@@ -5,6 +5,11 @@ means the media server instance must stream the data from wherever it is stored,
 local to itself. Allowing redirects on these endpoints would  make it possible for the media repo to
 tell clients/servers to pull data direct from the source, e.g. a CDN.
 
+Additionally redirects could be used to avoid downloading media from untrusted homeservers. Currently
+users can make their homeserver download, cache and proxy any matrix mid that I want, including
+bad/illegal content. Allowing for a 307 redirect would permit cautious server operators to not
+store and provide any media that floats in the matrixverse, but just refer to the "original" media.
+
 ## Proposal
 
 This MSC proposes that a 307 or 308 redirect code is allowed and followed according to the `Location`

--- a/proposals/3860-media-download-redirect.md
+++ b/proposals/3860-media-download-redirect.md
@@ -7,7 +7,7 @@ tell clients/servers to pull data direct from the source, e.g. a CDN.
 
 ## Proposal
 
-This MSC proposes that a 307 redirect code is allowed and followed according to the `Location`
+This MSC proposes that a 307 or 308 redirect code is allowed and followed according to the `Location`
 header. It is possible some clients would already follow these which needs to be confirmed. Specific
 endpoints in question:
 

--- a/proposals/3860-media-download-redirect.md
+++ b/proposals/3860-media-download-redirect.md
@@ -1,4 +1,4 @@
-# MSCXXX: Media Download Redirects
+# MSC3860: Media Download Redirects
 
 Currently the media download endpoints must return either a 200 with content or error responses. This means the media server instance must stream the data from wherever it is stored, which is likely not local to itself. Allowing redirects on these endpoints would 
 make it possible for the media repo to tell clients/servers to pull data direct from the source, eg. a CDN.

--- a/proposals/3860-media-download-redirect.md
+++ b/proposals/3860-media-download-redirect.md
@@ -34,7 +34,7 @@ None at this time.
 ## Security Considerations
 
 A media repo could redirect requests to a bad actor, although this would make the primary media
-repo itself a bad actor, this does present any increased security issues.
+repo itself a bad actor, thus this does not present any increased security issues.
 
 ## Unstable Prefix
 

--- a/proposals/3860-media-download-redirect.md
+++ b/proposals/3860-media-download-redirect.md
@@ -7,7 +7,7 @@ tell clients/servers to pull data direct from the source, eg. a CDN.
 
 ## Proposal
 
-This MSC simply proposes that a 307 redirect code is allowed and followed according to the `Location`
+This MSC proposes that a 307 redirect code is allowed and followed according to the `Location`
 header. It is possible some clients would already follow these which needs to be confirmed. Specifc
 endpoints in question:
 
@@ -15,15 +15,17 @@ endpoints in question:
 + `/_matrix/media/v3/download/{serverName}/{mediaId}/{fileName}`
 + `/_matrix/media/v3/thumbnail/{serverName}/{mediaId}`
 
-The media repo already conforms to standard HTTP practices so this may already work as expected. The
-MSC is proposing to add redirects to the list of possible HTTP responses for the above endpoints in
-the Matrix Specifiction. Implementation would be confirming that this works in all the major clients.
+To prevent breaking clients that don't properly follow the redirect response this functionality will
+be enabled by a query string flag `allow_redirect=true`. So specifically in the above cases if a
+client respects redirect responses it can make requests like so to the media endpoints:
+
++ `/_matrix/media/v3/download/{serverName}/{mediaId}?allow_redirect=true`
++ `/_matrix/media/v3/download/{serverName}/{mediaId}/{fileName}?allow_redirect=true`
++ `/_matrix/media/v3/thumbnail/{serverName}/{mediaId}?allow_redirect=true`
 
 ## Potential Issues
 
-There may be clients that don't follow redirect responses properly, in which case they would fail
-to retrieve the media. One possible workaround for this is utilising an opt-in query string parameter
-to allow redirects, e.g `?allow-redirect=true`.
+None, as opt-in functionality this change is 100% backwards compatible.
 
 ## Alternatives
 
@@ -40,5 +42,5 @@ No need for an unstable prefix for redirects as it stands. If a query string was
 enable this functionality this could use the following unstable prefix:
 
 ```
-?com.beeper.msc3860.allow-redirects=true
+?com.beeper.msc3860.allow_redirect=true
 ```

--- a/proposals/xxx-media-download-redirect.md
+++ b/proposals/xxx-media-download-redirect.md
@@ -1,0 +1,8 @@
+# MSCXXX: Media Download Redirects
+
+Currently the media download endpoints must return either a 200 with content or error responses. This means the media server instance must stream the data from wherever it is stored, which is likely not local to itself. Allowing redirects on these endpoints would 
+make it possible for the media repo to tell clients/servers to pull data direct from the source, eg. a CDN.
+
+## Proposal
+
+This MSC simply proposes that a 307 redirect code is allowed and followed according to the `Location` header. It is possible some clients would already follow these which needs to be confirmed.

--- a/proposals/xxx-media-download-redirect.md
+++ b/proposals/xxx-media-download-redirect.md
@@ -5,4 +5,8 @@ make it possible for the media repo to tell clients/servers to pull data direct 
 
 ## Proposal
 
-This MSC simply proposes that a 307 redirect code is allowed and followed according to the `Location` header. It is possible some clients would already follow these which needs to be confirmed.
+This MSC simply proposes that a 307 redirect code is allowed and followed according to the `Location` header. It is possible some clients would already follow these which needs to be confirmed. Specifc endpoints in question:
+
++ `/_matrix/media/v3/download/{serverName}/{mediaId}`
++ `/_matrix/media/v3/download/{serverName}/{mediaId}/{fileName}`
++ `/_matrix/media/v3/thumbnail/{serverName}/{mediaId}`


### PR DESCRIPTION
[Rendered](https://github.com/Fizzadar/matrix-spec-proposals/blob/media-download-redirect/proposals/3860-media-download-redirect.md).

Signed off by Nick @ Beeper (@fizzadar) <nick@beeper.com>.

**Server implementation**: added in https://github.com/beeper/matrix-media-repo/commit/32051bf1c6b4d695c418d2ddf915522d8b1767b2 & flag in https://github.com/beeper/matrix-media-repo/commit/d75aa32d5af90dbe444308692a3d1414634a8715.

We have also implemented this on our hard fork of the media repo in a similar manner. The only difference is we have extended this to generate public URLs for buckets we have defined as public (ie so cache headers can be set on redirect).

[FCP tickyboxes](https://github.com/matrix-org/matrix-spec-proposals/pull/3860#issuecomment-1513172407)