### PR TITLE
MSC3873: event_match dotted keys

### DIFF
--- a/proposals/3873-event-match-dotted-keys.md
+++ b/proposals/3873-event-match-dotted-keys.md
@@ -4,7 +4,7 @@ The current specification of [`event_match`] describes the parameter
 `key` as
 
 > `key`: The dot-separated path of the property of the event to match,
-> e.g. `content.body`.
+> e.g. `content.body`.
 
 It does, however, not clarify how to handle collisions such as in
 
@@ -16,17 +16,28 @@ It does, however, not clarify how to handle collisions such as in
 where it is unclear which field the dot-separated path `m.foo` should
 match ([#648]).
 
-While collisions are often not a practical problem, the ambiguity in the
-specification leads to incompatible implementations as evidenced by
-[matrix-org/matrix-js-sdk#1454]. The current proposal resolves the
-ambiguity by leveraging the existing solution for the same problem in
-the [filter API].
+Previously collions are not often a practical problem, but as dotted-field names
+have become more common in Matrix, e.g. `m.relates_to` or [MSC1767]-style
+extensible events ,this ambiguity is no longer satisfactory.
+
+The ambiguity in the specification leads to incompatible implementations as
+evidenced by [matrix-org/matrix-js-sdk#1454]. The current proposal resolves the
+ambiguity by leveraging the existing solution for the same problem used by the
+`event_fields` of [filters]:
+
+> List of event fields to include. If this list is absent then all fields are included.
+> The entries may include ‘.’ characters to indicate sub-fields. So [‘content.body’]
+> will include the ‘body’ field of the ‘content’ object. A literal ‘.’ character
+> in a field name may be escaped using a ‘\’.
 
 ## Proposal
 
-The . character in the `key` parameter is changed to be exclusively
-reserved for field separators. Any literal key in field names is to be
-escaped using a \\.
+The dot (`.`) character in the `key` parameter is changed to be exclusively
+reserved for field separators. Any literal dot in field names are to be
+escaped using a backslash (`\.`) and any literal backslashes are also escaped with
+a backslash (`\\`). A backslash before any other character has no special meaning
+and is left as-is, but it is recommended that implementations do not redundantly
+escape characters, as they may be used for escape sequences in the future.
 
 Revisiting the example from above
 
@@ -39,58 +50,52 @@ this means that `"key": "m.foo"` unambiguously matches the nested `foo`
 field. The top-level `m.foo` field in turn can be matched through
 `"key": "m\.foo"`.
 
-As mentioned above, this exact solution is already employed in the
-[filter API]. Reusing it here, therefore, increases the
+As mentioned above, this exact solution is already employed by
+[filters]. Reusing it here, therefore, increases the
 specification’s coherence.
-
-## Backwards compatibility
-
-In order to provide partial backwards compatibility, implementations
-should continue supporting unescaped dot-separated paths in situations
-where they are collision-free. In other words, `"key": "m.foo"` should
-continue matching both
-
-    {
-      "m": { "foo": "bar" },
-    }
-
-and
-
-    {
-      "m.foo": "baz"
-    }
-
-but not
-
-    {
-      "m": { "foo": "bar" },
-      "m.foo": "baz"
-    }
-
-It is recommend that implementations maintain this fallback for a
-certain transition period, e.g. one year, to give clients a chance to
-update any affected push rules.
 
 ## Potential issues
 
-The proposed solution is only partially backwards compatible and will
-break any push rule that relies on implicit implementation behavior
-caused by the ambiguity. This is, unfortunately, unavoidable because the
-very purpose of this proposal is to resolve said ambiguity.
+This MSC provides no mechanism for backwards compatibility. [^1] This should not
+impact the vast majority of users since none of the default push rules (nor common
+custom push rules, e.g. for keywords) are dependent on dotted field names.
+
+Implementations could attempt to disambiguate the `key` by checking all possible
+ambiguous version this is fragile: what do you do if both ambiguous fields exist?
+This gets worse as additional nested objects exist:
+
+```json
+{
+  "m": { 
+    "foo": { "bar":  "abc" },
+    "foo.bar": "def"
+  },
+  "m.foo": { "bar": "ghi" },
+  "m.foo.bar": "jkl"
+}
+```
+
+This may break custom push rules that users have configured, but it is asserted
+that those are broken anyway, as mentioned above (see [matrix-org/matrix-js-sdk#1454]).
 
 ## Alternatives
 
-An alternative to the current proposal are [JSON pointers]. While
-being more versatile than the simplistic escaping proposed here, JSON
-pointers introduce a wholly new DSL for the `key` parameter which breaks
-backwards compatibility for *all* existing `event_match` conditions.
+Alternatives to the current proposal are to use [JSON pointers] or [JSONPath]. While
+being more versatile than the simplistic escaping proposed here, these are
+unnecessary and break backwards compatibility for *all* existing `event_match`
+conditions.
 
 ## Security considerations
 
 None.
 
+[^1]: See [a previous version].
+
   [`event_match`]: https://spec.matrix.org/v1.3/client-server-api/#conditions-1
+  [MSC1767]: https://github.com/matrix-org/matrix-spec-proposals/pull/1767
   [#648]: https://github.com/matrix-org/matrix-spec/issues/648
   [matrix-org/matrix-js-sdk#1454]: https://github.com/matrix-org/matrix-js-sdk/issues/1454
-  [filter API]: https://spec.matrix.org/v1.3/client-server-api/#post_matrixclientv3useruseridfilter
+  [filters]: https://spec.matrix.org/v1.3/client-server-api/#post_matrixclientv3useruseridfilter
   [JSON pointers]: https://www.rfc-editor.org/rfc/rfc6901
+  [JSONPath]: https://goessner.net/articles/JsonPath/
+  [a previous version]: https://github.com/matrix-org/matrix-spec-proposals/blob/cd906fcb263f667a7b8e5a626cc5b55fba3b9262/proposals/3873-event-match-dotted-keys.md?rgh-link-date=2022-08-21T18%3A02%3A02Z#backwards-compatibility

--- a/proposals/3873-event-match-dotted-keys.md
+++ b/proposals/3873-event-match-dotted-keys.md
@@ -30,6 +30,14 @@ ambiguity by leveraging the existing solution for the same problem used by the
 > will include the ‘body’ field of the ‘content’ object. A literal ‘.’ character
 > in a field name may be escaped using a ‘\’.
 
+This ambiguity is blocking other MSCs which all attempt to create rules on fields
+with dots in them, such as:
+
+* [MSC3952] Intentional Mentions
+* [MSC3958] Suppress notifications from message edits
+
+And likely any push rule for keywords using extensible events.
+
 ## Proposal
 
 The dot (`.`) character in the `key` parameter is changed to be exclusively
@@ -95,6 +103,8 @@ None.
   [MSC1767]: https://github.com/matrix-org/matrix-spec-proposals/pull/1767
   [#648]: https://github.com/matrix-org/matrix-spec/issues/648
   [matrix-org/matrix-js-sdk#1454]: https://github.com/matrix-org/matrix-js-sdk/issues/1454
+  [MSC3952]: https://github.com/matrix-org/matrix-spec-proposals/pull/3952
+  [MSC3958]: https://github.com/matrix-org/matrix-spec-proposals/pull/3958
   [filters]: https://spec.matrix.org/v1.3/client-server-api/#post_matrixclientv3useruseridfilter
   [JSON pointers]: https://www.rfc-editor.org/rfc/rfc6901
   [JSONPath]: https://goessner.net/articles/JsonPath/

--- a/proposals/3873-event-match-dotted-keys.md
+++ b/proposals/3873-event-match-dotted-keys.md
@@ -1,4 +1,4 @@
-# MSCXXXX: event_match dotted keys
+# MSC3873: event_match dotted keys
 
 The current specification of [`event_match`] describes the parameter
 `key` as

--- a/proposals/3873-event-match-dotted-keys.md
+++ b/proposals/3873-event-match-dotted-keys.md
@@ -17,7 +17,7 @@ where it is unclear which field the dot-separated path `m.foo` should
 match ([#648]).
 
 While collisions are often not a practical problem, the ambiguity in the
-specification leads to incomptible implementations as evidenced by
+specification leads to incompatible implementations as evidenced by
 [matrix-org/matrix-js-sdk#1454]. The current proposal resolves the
 ambiguity by leveraging the existing solution for the same problem in
 the [filter API].
@@ -35,7 +35,7 @@ Revisiting the example from above
       "m.foo": "baz"
     }
 
-this means that `"key": "m.foo"` unambigously matches the nested `foo`
+this means that `"key": "m.foo"` unambiguously matches the nested `foo`
 field. The top-level `m.foo` field in turn can be matched through
 `"key": "m\.foo"`.
 
@@ -82,7 +82,7 @@ very purpose of this proposal is to resolve said ambiguity.
 
 An alternative to the current proposal are [JSON pointers]. While
 being more versatile than the simplistic escaping proposed here, JSON
-pointers introduce a wholy new DSL for the `key` parameter which breaks
+pointers introduce a wholly new DSL for the `key` parameter which breaks
 backwards compatibility for *all* existing `event_match` conditions.
 
 ## Security considerations

--- a/proposals/3873-event-match-dotted-keys.md
+++ b/proposals/3873-event-match-dotted-keys.md
@@ -6,7 +6,7 @@ The current specification of [`event_match`] describes the parameter
 > `key`: The dot-separated path of the property of the event to match,
 > e.g. `content.body`.
 
-It does, however, not clarify how to handle collisions such as in
+It does not, however, clarify how to handle collisions such as in
 
     {
       "m": { "foo": "bar" },
@@ -16,9 +16,9 @@ It does, however, not clarify how to handle collisions such as in
 where it is unclear which field the dot-separated path `m.foo` should
 match ([#648]).
 
-Previously collions are not often a practical problem, but as dotted-field names
+Previously collisions are not often a practical problem, but as dotted-field names
 have become more common in Matrix, e.g. `m.relates_to` or [MSC1767]-style
-extensible events ,this ambiguity is no longer satisfactory.
+extensible events, this ambiguity is no longer satisfactory.
 
 The ambiguity in the specification leads to incompatible implementations as
 evidenced by [matrix-org/matrix-js-sdk#1454]. The current proposal resolves the

--- a/proposals/3873-event-match-dotted-keys.md
+++ b/proposals/3873-event-match-dotted-keys.md
@@ -16,7 +16,7 @@ It does not, however, clarify how to handle collisions such as in
 where it is unclear which field the dot-separated path `m.foo` should
 match ([#648]).
 
-Previously collisions are not often a practical problem, but as dotted-field names
+Previously collisions were not often a practical problem, but as dotted-field names
 have become more common in Matrix, e.g. `m.relates_to` or [MSC1767]-style
 extensible events, this ambiguity is no longer satisfactory.
 

--- a/proposals/XXXX-event-match-dotted-keys.md
+++ b/proposals/XXXX-event-match-dotted-keys.md
@@ -1,0 +1,96 @@
+# MSCXXXX: event_match dotted keys
+
+The current specification of [`event_match`] describes the parameter
+`key` as
+
+> `key`: The dot-separated path of the property of the event to match,
+> e.g. `content.body`.
+
+It does, however, not clarify how to handle collisions such as in
+
+    {
+      "m": { "foo": "bar" },
+      "m.foo": "baz"
+    }
+
+where it is unclear which field the dot-separated path `m.foo` should
+match ([#648]).
+
+While collisions are often not a practical problem, the ambiguity in the
+specification leads to incomptible implementations as evidenced by
+[matrix-org/matrix-js-sdk#1454]. The current proposal resolves the
+ambiguity by leveraging the existing solution for the same problem in
+the [filter API].
+
+## Proposal
+
+The . character in the `key` parameter is changed to be exclusively
+reserved for field separators. Any literal key in field names is to be
+escaped using a \\.
+
+Revisiting the example from above
+
+    {
+      "m": { "foo": "bar" },
+      "m.foo": "baz"
+    }
+
+this means that `"key": "m.foo"` unambigously matches the nested `foo`
+field. The top-level `m.foo` field in turn can be matched through
+`"key": "m\.foo"`.
+
+As mentioned above, this exact solution is already employed in the
+[filter API]. Reusing it here, therefore, increases the
+specification’s coherence.
+
+## Backwards compatibility
+
+In order to provide partial backwards compatibility, implementations
+should continue supporting unescaped dot-separated paths in situations
+where they are collision-free. In other words, `"key": "m.foo"` should
+continue matching both
+
+    {
+      "m": { "foo": "bar" },
+    }
+
+and
+
+    {
+      "m.foo": "baz"
+    }
+
+but not
+
+    {
+      "m": { "foo": "bar" },
+      "m.foo": "baz"
+    }
+
+It is recommend that implementations maintain this fallback for a
+certain transition period, e.g. one year, to give clients a chance to
+update any affected push rules.
+
+## Potential issues
+
+The proposed solution is only partially backwards compatible and will
+break any push rule that relies on implicit implementation behavior
+caused by the ambiguity. This is, unfortunately, unavoidable because the
+very purpose of this proposal is to resolve said ambiguity.
+
+## Alternatives
+
+An alternative to the current proposal are [JSON pointers]. While
+being more versatile than the simplistic escaping proposed here, JSON
+pointers introduce a wholy new DSL for the `key` parameter which breaks
+backwards compatibility for *all* existing `event_match` conditions.
+
+## Security considerations
+
+None.
+
+  [`event_match`]: https://spec.matrix.org/v1.3/client-server-api/#conditions-1
+  [#648]: https://github.com/matrix-org/matrix-spec/issues/648
+  [matrix-org/matrix-js-sdk#1454]: https://github.com/matrix-org/matrix-js-sdk/issues/1454
+  [filter API]: https://spec.matrix.org/v1.3/client-server-api/#post_matrixclientv3useruseridfilter
+  [JSON pointers]: https://www.rfc-editor.org/rfc/rfc6901


### PR DESCRIPTION
[Rendered](https://github.com/matrix-org/matrix-spec-proposals/blob/johannes/event-match-dotted-keys/proposals/3873-event-match-dotted-keys.md)

Implementations:

* mautrix-go: https://github.com/mautrix/go/commit/61b0553ae9883bf8d7ce8f099b7da10e7ecac402
* Synapse: matrix-org/synapse#15004
* matrix-js-sdk: matrix-org/matrix-js-sdk#3134

Fixes https://github.com/matrix-org/matrix-spec/issues/648

[FCP tickyboxes](https://github.com/matrix-org/matrix-spec-proposals/pull/3873#issuecomment-1421617428)