### PR TITLE
MSC3882: Allow an existing session to sign in a new session

### DIFF
--- a/proposals/3882-login-token-request.md
+++ b/proposals/3882-login-token-request.md
@@ -116,7 +116,8 @@ The capability should use the unstable prefix:
 - `org.matrix.msc3882.get_logintoken`
 
 For reference - an earlier revision of this proposal used an unstable prefix of
-`/_matrix/client/unstable/org.matrix.msc3882/login/token` with an unstable feature advertised as `org.matrix.msc3882`
+`/_matrix/client/unstable/org.matrix.msc3882/login/token` with an unstable feature advertised 
+in the response to `GET /_matrix/client/versions` as `org.matrix.msc3882`
 set to `true`. This may be referred to as "revision zero" in existing implementations.
 
 ## Dependencies

--- a/proposals/3882-login-token-request.md
+++ b/proposals/3882-login-token-request.md
@@ -79,41 +79,12 @@ by default for the new endpoint. The purpose being that consent is obtained from
 [spec](https://spec.matrix.org/v1.6/client-server-api/#rate-limiting). It may be appropriate for the homeserver admin to
 to configure a low limit ("low" relative to other enforced limits). For example, a rate of once per minute could be appropriate.
 
-If a homeserver admin deems that they have a suitable alternative to UIA in place, they can make use of
-["dummy auth"](https://spec.matrix.org/v1.6/client-server-api/#dummy-auth) and have the homeserver respond with a response similar to:
+n.b. A homeserver admin may deem that they have suitable protections in place and offer the endpoint without UIA auth as described
+in the existing spec:
 
-```http
-HTTP/1.1 401 Unauthorized
-Content-Type: application/json
-```
-
-```json
-{
-  "flows": [
-    {
-      "stages": ["m.login.dummy"]
-    }
-  ],
-  "params": {},
-  "session": "xxxxxx"
-}
-```
-
-The client can then complete UIA without requiring action from the user by sending the following JSON request body:
-
-```http
-POST /_matrix/client/v1/login/get_token HTTP/1.1
-Content-Type: application/json
-```
-
-```json
-{
-  "auth": {
-    "type": "m.login.dummy",
-    "session": "xxxxxx"
-  }
-}
-```
+> A request to an endpoint that uses User-Interactive Authentication never succeeds without auth. Homeservers may allow requests
+> that don’t require auth by offering a stage with only the m.login.dummy auth type, but they must still give a 401 response to
+> requests with no auth data.
 
 ## Unstable prefix
 

--- a/proposals/3882-login-token-request.md
+++ b/proposals/3882-login-token-request.md
@@ -25,6 +25,10 @@ Add a new POST endpoint to the Client-Server API that issues a time limited `m.l
 This new endpoint should be protected by user interactive authentication (UIA). However the the homeserver admin may
 choose to disable UIA if they deem suitable alternative protections are in place.
 
+It should also be protected by rate-limiting in accordance with the existing
+[spec](https://spec.matrix.org/v1.6/client-server-api/#rate-limiting). It may be appropriate for the homeserver admin to
+to configure a low limit ("low" relative to other enforced limits). For example, a rate of once per minute could be appropriate.
+
 The values returned are:
 
 - `login_token` - required, the token to use with `m.login.token`

--- a/proposals/3882-login-token-request.md
+++ b/proposals/3882-login-token-request.md
@@ -1,11 +1,13 @@
 # MSC3882: Allow an existing session to sign in a new session
 
-In [MSC3906](https://github.com/matrix-org/matrix-spec-proposals/pull/3906) a proposal is made to allow a user to login on a new device using an existing device by means of scanning a
-QR code.
+In [MSC3906](https://github.com/matrix-org/matrix-spec-proposals/pull/3906) a proposal is made to allow a user to login
+on a new device using an existing device by means of scanning a QR code.
 
-In order to support the above proposal a mechanism is needed where by the new device can obtain a new access token that it can use with the Client-Server API.
+In order to support the above proposal a mechanism is needed where by the new device can obtain a new access token that
+it can use with the Client-Server API.
 
-It is proposed that the current `m.login.token` mechanism is extended to allow the issuance of a login token by an existing client session.
+It is proposed that the current `m.login.token` mechanism is extended to allow the issuance of a login token by an
+existing client session.
 
 ## Proposal
 
@@ -16,11 +18,12 @@ Add a new POST endpoint to the Client-Server API that issues a time limited `m.l
 ```json
 {
     "login_token": "<login token>",
-    "expires_in": 3600
+    "expires_in": 120
 }
 ```
 
-This new endpoint MAY be protected by user interactive authentication.
+This new endpoint should be protected by user interactive authentication (UIA). However the the homeserver admin may
+choose to disable UIA if they deem suitable alternative protections are in place.
 
 The values returned are:
 
@@ -49,8 +52,8 @@ could use the device authorization grant flow which allows for a new device to b
 
 ## Security considerations
 
-A malicious client could use the mechanism to spawn more than one session. For this reason the endpoint can be placed
-behind user interactive authentication.
+A malicious client could use the mechanism to spawn more than one session. For this reason the endpoint should by default
+be placed behind user interactive authentication.
 
 ## Unstable prefix
 

--- a/proposals/3882-login-token-request.md
+++ b/proposals/3882-login-token-request.md
@@ -22,6 +22,11 @@ Add a new POST endpoint to the Client-Server API that issues a time limited `m.l
 
 This new endpoint MAY be protected by user interactive authentication.
 
+The values returned are:
+
+- `login_token` - required, the token to use with `m.login.token`
+- `expires_in` - required, the expiry time for the token in seconds
+
 This token can then be used as per the existing Login spec of the Client-Server API as follows:
 
 `POST /login`

--- a/proposals/3882-login-token-request.md
+++ b/proposals/3882-login-token-request.md
@@ -1,4 +1,4 @@
-# MSCxxxx: Allow an existing session to sign in a new session
+# MSC3882: Allow an existing session to sign in a new session
 
 todo
 

--- a/proposals/3882-login-token-request.md
+++ b/proposals/3882-login-token-request.md
@@ -11,7 +11,7 @@ existing client session.
 
 ## Proposal
 
-Add a new POST endpoint to the Client-Server API that issues a single-use, time-limited `m.login.token` token:
+Add a new optional POST endpoint to the Client-Server API that issues a single-use, time-limited `m.login.token` token:
 
 `POST /_matrix/client/v1/login/get_token`
 
@@ -56,6 +56,24 @@ Content-Type: application/json
 }
 ```
 
+The availability of the new API endpoint should be determined via a new `m.get_logintoken`
+[capability](https://spec.matrix.org/v1.6/client-server-api/#capabilities-negotiation).
+
+This capability has a single flag, `enabled`, to denote whether the `/login/get_token` API is available or not.
+Cases for disabling might include security restrictions imposed by the homeserver admin.
+
+An example of the capability API’s response for this capability is:
+
+```json
+{
+  "capabilities": {
+    "m.get_logintoken": {
+      "enabled": true
+    }
+  }
+}
+```
+
 ## Potential issues
 
 None identified.
@@ -93,23 +111,13 @@ While this feature is in development the new endpoint should be exposed using th
 
 - `/_matrix/client/unstable/org.matrix.msc3882/login/get_token`
 
-Additionally, the feature is to be advertised as unstable feature in the `GET /_matrix/client/versions` response, with
-the key `org.matrix.msc3882.r1` set to `true`. (The `r1` in the feature name is used to indicate that the server implements the first revision of this proposal)
+The capability should use the unstable prefix:
 
-So, the response could look then as following:
+- `org.matrix.msc3882.get_logintoken`
 
-```json
-{
-    "versions": ["r0.6.0"],
-    "unstable_features": {
-        "org.matrix.msc3882.r1": true
-    }
-}
-```
-
-For reference - an earlier iteration of this proposal used an unstable prefix of
+For reference - an earlier revision of this proposal used an unstable prefix of
 `/_matrix/client/unstable/org.matrix.msc3882/login/token` with an unstable feature advertised as `org.matrix.msc3882`
-set to `true`.
+set to `true`. This may be referred to as "revision zero" in existing implementations.
 
 ## Dependencies
 

--- a/proposals/3882-login-token-request.md
+++ b/proposals/3882-login-token-request.md
@@ -1,6 +1,11 @@
 # MSC3882: Allow an existing session to sign in a new session
 
-todo
+In MSCyyyy (to be published) a proposal is made to allow a user to login on a new device using an existing device by means of scanning a
+QR code.
+
+In order to support the above proposal a mechanism is needed where by the new device can obtain a new access token that it can use with the Client-Server API.
+
+It is proposed that the current `m.login.token` mechanism is extended to allow the issuance of a login token by an existing client session.
 
 ## Proposal
 
@@ -30,7 +35,7 @@ This token can then be used as per the existing Login spec of the Client-Server 
 
 ## Potential issues
 
-todo
+None identified.
 
 ## Alternatives
 
@@ -44,7 +49,7 @@ behind user interactive authentication.
 
 ## Unstable prefix
 
-tbd
+None.
 
 ## Dependencies
 

--- a/proposals/3882-login-token-request.md
+++ b/proposals/3882-login-token-request.md
@@ -1,6 +1,6 @@
 # MSC3882: Allow an existing session to sign in a new session
 
-In MSCyyyy (to be published) a proposal is made to allow a user to login on a new device using an existing device by means of scanning a
+In [MSC3906](https://github.com/matrix-org/matrix-spec-proposals/pull/3906) a proposal is made to allow a user to login on a new device using an existing device by means of scanning a
 QR code.
 
 In order to support the above proposal a mechanism is needed where by the new device can obtain a new access token that it can use with the Client-Server API.

--- a/proposals/3882-login-token-request.md
+++ b/proposals/3882-login-token-request.md
@@ -49,7 +49,22 @@ behind user interactive authentication.
 
 ## Unstable prefix
 
-None.
+While this feature is in development the new endpoint should be exposed using the following unstable prefix:
+
+- `/_matrix/client/unstable/org.matrix.msc3882/login/token`
+
+Additionally, the feature is to be advertised as unstable feature in the `GET /_matrix/client/versions`
+response, with the key `org.matrix.msc3882` set to `true`. So, the response could look then as
+following:
+
+```json
+{
+    "versions": ["r0.6.0"],
+    "unstable_features": {
+        "org.matrix.msc3882": true
+    }
+}
+```
 
 ## Dependencies
 

--- a/proposals/3882-login-token-request.md
+++ b/proposals/3882-login-token-request.md
@@ -106,7 +106,7 @@ another client by checking the
 [capabilities](https://spec.matrix.org/v1.6/client-server-api/#capabilities-negotiation)
 advertised by the homeserver.
 
-Where the client is authenticated the client can determine whether the new API endpoint is available
+The unauthenticated client can also determine whether the new API endpoint is available
 via the [capability negotiation](https://spec.matrix.org/v1.6/client-server-api/#capabilities-negotiation)
 mechanism.
 
@@ -167,7 +167,7 @@ While this feature is in development the following unstable prefixes should be u
 - capability `m.get_login_token` => `org.matrix.msc3882.get_login_token`
 - login flow field `get_login_token` => `org.matrix.msc3882.get_login_token`
 
-For reference - an earlier revision of this proposal used an unstable prefix of
+For reference - an earlier revision of this proposal used an unstable endpoint of
 `/_matrix/client/unstable/org.matrix.msc3882/login/token` with an unstable feature advertised 
 in the response to `GET /_matrix/client/versions` as `org.matrix.msc3882`
 set to `true`. This may be referred to as "revision zero" in existing implementations.

--- a/proposals/3882-login-token-request.md
+++ b/proposals/3882-login-token-request.md
@@ -11,32 +11,42 @@ existing client session.
 
 ## Proposal
 
-Add a new POST endpoint to the Client-Server API that issues a time limited `m.login.token` token:
+Add a new POST endpoint to the Client-Server API that issues a single-use, time-limited `m.login.token` token:
 
-`POST /login/token`
+`POST /_matrix/client/v1/login/get_token`
+
+The client should send an empty JSON body for the `POST` request.
+
+As detailed in the security selection below, this new endpoint should be protected by user interactive authentication
+(UIA) as detailed in the existing
+["User-interactive API in the REST API"](https://spec.matrix.org/v1.5/client-server-api/#user-interactive-api-in-the-rest-api)
+section of the spec.
+
+Once UIA has been completed a `200` response with JSON body is returned. The body contains the following fields:
+
+- `login_token` - required, the token to use with `m.login.token`
+- `expires_in_ms` - required, how long until the token expires in milliseconds
+
+An example response is as follows:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+```
 
 ```json
 {
     "login_token": "<login token>",
-    "expires_in": 120
+    "expires_in_ms": 120000
 }
 ```
 
-This new endpoint should be protected by user interactive authentication (UIA). However the the homeserver admin may
-choose to disable UIA if they deem suitable alternative protections are in place.
-
-It should also be protected by rate-limiting in accordance with the existing
-[spec](https://spec.matrix.org/v1.6/client-server-api/#rate-limiting). It may be appropriate for the homeserver admin to
-to configure a low limit ("low" relative to other enforced limits). For example, a rate of once per minute could be appropriate.
-
-The values returned are:
-
-- `login_token` - required, the token to use with `m.login.token`
-- `expires_in` - required, how long until the token expires in seconds
-
 This token can then be used as per the existing [Login spec](https://spec.matrix.org/v1.6/client-server-api/#login) as follows:
 
-`POST /login`
+```http
+POST /_matrix/client/v3/login HTTP/1.1
+Content-Type: application/json
+```
 
 ```json
 {
@@ -56,27 +66,78 @@ could use the device authorization grant flow which allows for a new device to b
 
 ## Security considerations
 
-A malicious client could use the mechanism to spawn more than one session. For this reason the endpoint should by default
-be placed behind user interactive authentication.
+A malicious client could use the mechanism to spawn more than one session. The following mitigations should be applied:
+
+1. The homeserver must only allow the token to be used for a single login. If the user wishes to sign in multiple
+ additional clients a token must be issued for each client.
+
+2. The homeserver should enforce
+[user interactive authentication](https://spec.matrix.org/v1.6/client-server-api/#user-interactive-authentication-api)
+by default for the new endpoint. The purpose being that consent is obtained from the user for each additional client.
+
+3. The homeserver should enforce rate-limiting in accordance with the existing
+[spec](https://spec.matrix.org/v1.6/client-server-api/#rate-limiting). It may be appropriate for the homeserver admin to
+to configure a low limit ("low" relative to other enforced limits). For example, a rate of once per minute could be appropriate.
+
+If a homeserver admin deems that they have a suitable alternative to UIA in place, they can make use of
+["dummy auth"](https://spec.matrix.org/v1.6/client-server-api/#dummy-auth) and have the homeserver respond with a response similar to:
+
+```http
+HTTP/1.1 401 Unauthorized
+Content-Type: application/json
+```
+
+```json
+{
+  "flows": [
+    {
+      "stages": ["m.login.dummy"]
+    }
+  ],
+  "params": {},
+  "session": "xxxxxx"
+}
+```
+
+The client can then complete UIA without requiring action from the user by sending the following JSON request body:
+
+```http
+POST /_matrix/client/v1/login/get_token HTTP/1.1
+Content-Type: application/json
+```
+
+```json
+{
+  "auth": {
+    "type": "m.login.dummy",
+    "session": "xxxxxx"
+  }
+}
+```
 
 ## Unstable prefix
 
 While this feature is in development the new endpoint should be exposed using the following unstable prefix:
 
-- `/_matrix/client/unstable/org.matrix.msc3882/login/token`
+- `/_matrix/client/unstable/org.matrix.msc3882/login/get_token`
 
-Additionally, the feature is to be advertised as unstable feature in the `GET /_matrix/client/versions`
-response, with the key `org.matrix.msc3882` set to `true`. So, the response could look then as
-following:
+Additionally, the feature is to be advertised as unstable feature in the `GET /_matrix/client/versions` response, with
+the key `org.matrix.msc3882.r1` set to `true`. (The `r1` in the feature name is used to indicate that the server implements the first revision of this proposal)
+
+So, the response could look then as following:
 
 ```json
 {
     "versions": ["r0.6.0"],
     "unstable_features": {
-        "org.matrix.msc3882": true
+        "org.matrix.msc3882.r1": true
     }
 }
 ```
+
+For reference - an earlier iteration of this proposal used an unstable prefix of
+`/_matrix/client/unstable/org.matrix.msc3882/login/token` with an unstable feature advertised as `org.matrix.msc3882`
+set to `true`.
 
 ## Dependencies
 

--- a/proposals/3882-login-token-request.md
+++ b/proposals/3882-login-token-request.md
@@ -28,9 +28,9 @@ choose to disable UIA if they deem suitable alternative protections are in place
 The values returned are:
 
 - `login_token` - required, the token to use with `m.login.token`
-- `expires_in` - required, the expiry time for the token in seconds
+- `expires_in` - required, how long until the token expires in seconds
 
-This token can then be used as per the existing Login spec of the Client-Server API as follows:
+This token can then be used as per the existing [Login spec](https://spec.matrix.org/v1.6/client-server-api/#login) as follows:
 
 `POST /login`
 

--- a/proposals/3882-login-token-request.md
+++ b/proposals/3882-login-token-request.md
@@ -34,11 +34,13 @@ todo
 
 ## Alternatives
 
-If Matrix was already using OIDC as per [MSC3861](https://github.com/matrix-org/matrix-spec-proposals/pull/3861) then we could use the device authorization grant flow which allows for a new device to be signed in using an existing device.
+If Matrix was already using OIDC as per [MSC3861](https://github.com/matrix-org/matrix-spec-proposals/pull/3861) then we
+could use the device authorization grant flow which allows for a new device to be signed in using an existing device.
 
 ## Security considerations
 
-A malicious client could use the mechanism to spawn more than one session. For this reason the endpoint can be placed behind user interactive authentication.
+A malicious client could use the mechanism to spawn more than one session. For this reason the endpoint can be placed
+behind user interactive authentication.
 
 ## Unstable prefix
 

--- a/proposals/xxxx-login-token-request.md
+++ b/proposals/xxxx-login-token-request.md
@@ -1,0 +1,49 @@
+# MSCxxxx: Allow an existing session to sign in a new session
+
+todo
+
+## Proposal
+
+Add a new POST endpoint to the Client-Server API that issues a time limited `m.login.token` token:
+
+`POST /login/token`
+
+```json
+{
+    "login_token": "<login token>",
+    "expires_in": 3600
+}
+```
+
+This new endpoint MAY be protected by user interactive authentication.
+
+This token can then be used as per the existing Login spec of the Client-Server API as follows:
+
+`POST /login`
+
+```json
+{
+  "type": "m.login.token",
+  "token": "<login token>"
+}
+```
+
+## Potential issues
+
+todo
+
+## Alternatives
+
+If Matrix was already using OIDC as per [MSC3861](https://github.com/matrix-org/matrix-spec-proposals/pull/3861) then we could use the device authorization grant flow which allows for a new device to be signed in using an existing device.
+
+## Security considerations
+
+A malicious client could use the mechanism to spawn more than one session. For this reason the endpoint can be placed behind user interactive authentication.
+
+## Unstable prefix
+
+tbd
+
+## Dependencies
+
+None.


### PR DESCRIPTION
[Rendered](https://github.com/matrix-org/matrix-spec-proposals/blob/hughns/login-token-requests/proposals/3882-login-token-request.md)

Implementations of initial revision:

- Homeservers:
   - [x] Synapse: https://github.com/matrix-org/synapse/pull/13722
- Clients:
   - [x] Element Web:
       - [x] matrix-js-sdk: https://github.com/matrix-org/matrix-js-sdk/pull/2687
       - [x] matrix-react-sdk: https://github.com/matrix-org/matrix-react-sdk/pull/9403
   - [x] Element iOS: used as part of the Sign In with QR capability
   - [x] Element Android: used as part of the Sign In with QR capability

Implementations of revision 1:

- Homeservers:
   - [x] Synapse: https://github.com/matrix-org/synapse/pull/15388
- Clients:
   - [x] Element Web:
       - [x] matrix-js-sdk: https://github.com/matrix-org/matrix-js-sdk/pull/3228
       - [x] matrix-react-sdk: https://github.com/matrix-org/matrix-react-sdk/pull/10443
   - [ ] Element iOS:
   - [x] Element Android: https://github.com/vector-im/element-android/pull/8299
 
[FCP tickyboxes](https://github.com/matrix-org/matrix-spec-proposals/pull/3882#issuecomment-1467406297)