### PR TITLE
MSC3886: Simple client rendezvous capability

### DIFF
--- a/proposals/3886-simple-rendezvous-capability.md
+++ b/proposals/3886-simple-rendezvous-capability.md
@@ -1,4 +1,4 @@
-# MSC3886: Simple rendezvous capability
+# MSC3886: Simple client rendezvous capability
 
 In MSCyyyy a proposal is made to allow a user to login on a new device using an existing device by means of scanning a
 QR code.

--- a/proposals/3886-simple-rendezvous-capability.md
+++ b/proposals/3886-simple-rendezvous-capability.md
@@ -10,6 +10,8 @@ information such as:
 - the user ID
 - facilitation of issuing a new access token
 - device ID for end-to-end encryption
+- data for establishing a secure communication channel (e.g. via
+  [MSC3903](https://github.com/matrix-org/matrix-spec-proposals/pull/3903))
 
 To enable [MSC3906](https://github.com/matrix-org/matrix-spec-proposals/pull/3906) and support any future proposals this MSC proposes a simple HTTP based protocol that can be used to
 establish a direct communication channel between two IP connected devices.
@@ -296,7 +298,9 @@ following:
 
 ## Dependencies
 
-None, although it's intended to be used with [MSC3906](https://github.com/matrix-org/matrix-spec-proposals/pull/3906).
+None, although it's intended to be used with
+[MSC3903](https://github.com/matrix-org/matrix-spec-proposals/pull/3903) and
+[MSC3906](https://github.com/matrix-org/matrix-spec-proposals/pull/3906).
 
 ## Credits
 

--- a/proposals/3886-simple-rendezvous-capability.md
+++ b/proposals/3886-simple-rendezvous-capability.md
@@ -33,21 +33,21 @@ sequenceDiagram
   Note over A: Device A determines which rendezvous server to use
 
   A->R: POST / Hello from A
-  R->A: 201 Created Location: <rendezvous ID>
+  R->A: 201 Created Location: /abc-def-123-456
 
-  A-->B: Rendezvous URI between clients, perhaps as QR code: https://rendzvous-server/<rendezvous ID>
+  A-->B: Rendezvous URI between clients, perhaps as QR code: e.g. https://rendzvous-server/abc-def-123-456
 
   Note over A: Device A starts polling for contact at the rendezvous
 
-  B->R: GET /<rendezvous ID>
+  B->R: GET <rendezvous URI>
   R->B: 200 OK Hello from A
 
   loop Device A polls for rendezvous updates
-    A->R: GET /<rendezvous ID> If-None-Match: <ETag>
+    A->R: GET <rendezvous URI> If-None-Match: <ETag>
     R->A: 304 Not Modified
   end
 
-  B->R: PUT /<rendezvous ID> Hello from B
+  B->R: PUT <rendezvous URI> Hello from B
   R->B: 202 Accepted 
 
   Note over A,B: Rendezvous now established
@@ -76,7 +76,7 @@ HTTP response codes:
 
 HTTP response headers for `201 Created`:
 
-- `Location` - required, the allocated rendezvous ID represented as a URI safe **relative path**. e.g. `Location: abc-def-1234`
+- `Location` - required, the allocated rendezvous URI which can be on a different server
 - `X-Max-Bytes` - required, the maximum allowed bytes for the payload
 - `ETag` - required, ETag for the current payload at the rendezvous point as per [RFC7232](https://httpwg.org/specs/rfc7232.html#header.etag)
 - `Expires` - required, the expiry time of the rendezvous as per [RFC7233](https://httpwg.org/specs/rfc7234.html#header.expires)
@@ -85,14 +85,14 @@ HTTP response headers for `201 Created`:
 Example response headers:
 
 ```http
-Location: abcdEFG12345
+Location: /abcdEFG12345
 X-Max-Bytes: 10240
 ETag: VmbxF13QDusTgOCt8aoa0d2PQcnBOXeIxEqhw5aQ03o=
 Expires: Wed, 07 Sep 2022 14:28:51 GMT
 Last-Modified: Wed, 07 Sep 2022 14:27:51 GMT
 ```
 
-#### Update payload at rendezvous point: `PUT /<rendezvous id>`
+#### Update payload at rendezvous point: `PUT <rendezvous URI>`
 
 HTTP request headers:
 
@@ -107,7 +107,7 @@ HTTP request body:
 HTTP response codes:
 
 - `202 Accepted` - payload updated
-- `404 Not Found` - rendezvous ID is not valid (it could have expired)
+- `404 Not Found` - rendezvous URI is not valid (it could have expired)
 - `413 Payload Too Large` - the supplied payload is too large
 - `412 Precondition Failed` - when `If-Match` is supplied and the ETag does not match
 - `429 Too Many Requests` - the request has been rate limited
@@ -118,7 +118,7 @@ HTTP response headers for `202 Accepted` and `412 Precondition Failed`:
 - `Expires` - required, the expiry time of the rendezvous as per [RFC7233](https://httpwg.org/specs/rfc7234.html#header.expires)
 - `Last-Modified` - required, the last modified date of the payload as per [RFC7232](https://httpwg.org/specs/rfc7232.html#header.last-modified)
 
-#### Get payload from rendezvous point: `GET /<rendezvous id>`
+#### Get payload from rendezvous point: `GET <rendezvous URI>`
 
 HTTP request headers:
 
@@ -128,7 +128,7 @@ only return data if given ETag does not match
 HTTP response codes:
 
 - `200 OK` - payload returned
-- `404 Not Found` - rendezvous ID is not valid (it could have expired)
+- `404 Not Found` - rendezvous URI is not valid (it could have expired)
 - `304 Not Modified` - when `If-None-Match` is supplied and the ETag does not match
 - `429 Too Many Requests` - the request has been rate limited
 
@@ -140,12 +140,12 @@ HTTP response headers for `200 OK` and `304 Not Modified`:
 
 - `Content-Type` - required for `200 OK`
 
-#### Cancel a rendezvous: `DELETE /<rendezvous id>`
+#### Cancel a rendezvous: `DELETE <rendezvous URI>`
 
 HTTP response codes:
 
 - `204 No Content` - rendezvous cancelled
-- `404 Not Found` - rendezvous ID is not valid (it could have expired)
+- `404 Not Found` - rendezvous URI is not valid (it could have expired)
 - `429 Too Many Requests` - the request has been rate limited
 
 ### Maximum payload size

--- a/proposals/3886-simple-rendezvous-capability.md
+++ b/proposals/3886-simple-rendezvous-capability.md
@@ -10,10 +10,12 @@ information such as:
 - the user ID
 - facilitation of issuing a new access token
 - device ID for end-to-end encryption
-- device keys for end-to-end encryption
 
 To enable [MSC3906](https://github.com/matrix-org/matrix-spec-proposals/pull/3906) and support any future proposals this MSC proposes a simple HTTP based protocol that can be used to
 establish a direct communication channel between two IP connected devices.
+
+This channel SHOULD be considered untrusted by both devices, and SHOULD NOT be
+used to transmit sensitive data in plaintext.
 
 It will work with devices behind NAT. It doesn't require homeserver administrators to deploy a separate server.
 

--- a/proposals/3886-simple-rendezvous-capability.md
+++ b/proposals/3886-simple-rendezvous-capability.md
@@ -17,7 +17,7 @@ To enable [MSC3906](https://github.com/matrix-org/matrix-spec-proposals/pull/390
 establish a direct communication channel between two IP connected devices.
 
 This channel [SHOULD be considered untrusted](#confidentiality-of-data)
-by both devices, and SHOULD NOT be used to transmit sensitive data in plaintext.
+by both devices, and SHOULD NOT be used to transmit sensitive data in cleartext.
 
 It will work with devices behind NAT. It doesn't require homeserver administrators to deploy a separate server.
 

--- a/proposals/3886-simple-rendezvous-capability.md
+++ b/proposals/3886-simple-rendezvous-capability.md
@@ -68,12 +68,12 @@ HTTP request body:
 
 - any data up to maximum size allowed by the server
 
-HTTP response codes:
+HTTP response codes, and Matrix error codes:
 
 - `201 Created` - rendezvous created
-- `403 Forbidden` - forbidden by server policy
-- `413 Payload Too Large` - the supplied payload is too large
-- `429 Too Many Requests` - the request has been rate limited
+- `403 Forbidden` (`M_FORBIDDEN`) - forbidden by server policy
+- `413 Payload Too Large` (`M_TOO_LARGE`) - the supplied payload is too large
+- `429 Too Many Requests` (`M_UNKNOWN`) - the request has been rate limited
 - `307 Temporary Redirect` - if the request should be served from somewhere else specified in the `Location` response header
 
 n.b. the relatively unusual [`307 Temporary Redirect`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/307) response
@@ -111,13 +111,13 @@ HTTP request body:
 
 - any data up to maximum size allowed by the server
 
-HTTP response codes:
+HTTP response codes, and Matrix error codes:
 
 - `202 Accepted` - payload updated
-- `404 Not Found` - rendezvous URI is not valid (it could have expired)
-- `412 Precondition Failed` - when `If-Match` is supplied and the ETag does not match
-- `413 Payload Too Large` - the supplied payload is too large
-- `429 Too Many Requests` - the request has been rate limited
+- `404 Not Found` (`M_NOT_FOUND`) - rendezvous URI is not valid (it could have expired)
+- `412 Precondition Failed` (`M_DIRTY_WRITE`, **a new error code**) - when `If-Match` is supplied and the ETag does not match
+- `413 Payload Too Large` (`M_TOO_LARGE`) - the supplied payload is too large
+- `429 Too Many Requests` (`M_UNKNOWN`) - the request has been rate limited
 
 HTTP response headers for `202 Accepted` and `412 Precondition Failed`:
 
@@ -132,12 +132,12 @@ HTTP request headers:
 - `If-None-Match` - optional, as per [RFC7232](https://httpwg.org/specs/rfc7232.html#header.if-none-match) server will
 only return data if given ETag does not match
 
-HTTP response codes:
+HTTP response codes, and Matrix error codes:
 
 - `200 OK` - payload returned
 - `304 Not Modified` - when `If-None-Match` is supplied and the ETag does not match
-- `404 Not Found` - rendezvous URI is not valid (it could have expired)
-- `429 Too Many Requests` - the request has been rate limited
+- `404 Not Found` (`M_NOT_FOUND`) - rendezvous URI is not valid (it could have expired)
+- `429 Too Many Requests` (`M_UNKNOWN`)- the request has been rate limited
 
 HTTP response headers for `200 OK` and `304 Not Modified`:
 
@@ -152,8 +152,8 @@ HTTP response headers for `200 OK` and `304 Not Modified`:
 HTTP response codes:
 
 - `204 No Content` - rendezvous cancelled
-- `404 Not Found` - rendezvous URI is not valid (it could have expired)
-- `429 Too Many Requests` - the request has been rate limited
+- `404 Not Found` (`M_NOT_FOUND`) - rendezvous URI is not valid (it could have expired)
+- `429 Too Many Requests` (`M_UNKNOWN`)- the request has been rate limited
 
 ### Authentication
 

--- a/proposals/3886-simple-rendezvous-capability.md
+++ b/proposals/3886-simple-rendezvous-capability.md
@@ -81,7 +81,7 @@ HTTP response headers for `201 Created`:
 - `Location` - required, the allocated rendezvous URI which can be on a different server
 - `X-Max-Bytes` - required, the maximum allowed bytes for the payload
 - `ETag` - required, ETag for the current payload at the rendezvous point as per [RFC7232](https://httpwg.org/specs/rfc7232.html#header.etag)
-- `Expires` - required, the expiry time of the rendezvous as per [RFC7233](https://httpwg.org/specs/rfc7234.html#header.expires)
+- `Expires` - required, the expiry time of the rendezvous as per [RFC7234](https://httpwg.org/specs/rfc7234.html#header.expires)
 - `Last-Modified` - required, the last modified date of the payload as per [RFC7232](https://httpwg.org/specs/rfc7232.html#header.last-modified)
 
 Example response headers:
@@ -201,7 +201,7 @@ The proposed protocol requires the devices to have IP connectivity to the server
 
 Try and do something with STUN or TURN or [COAP](http://coap.technology/).
 
-Rather than requiring the devices to poll for updated "long-polling" could be used instead similar to `/sync`.
+Rather than requiring the devices to poll for updates, "long-polling" could be used instead similar to `/sync`.
 
 ## Security considerations
 

--- a/proposals/3886-simple-rendezvous-capability.md
+++ b/proposals/3886-simple-rendezvous-capability.md
@@ -177,6 +177,8 @@ Access-Control-Allow-Origin: *
 Access-Control-Expose-Headers: ETag,Location,X-Max-Bytes
 ```
 
+These headers are different from the ones currently specified in the [spec](https://spec.matrix.org/v1.4/client-server-api/#web-browser-clients).
+
 ### Choice of server
 
 Ultimately it will be up to the Matrix client implementation to decide which rendezvous server to use.

--- a/proposals/3886-simple-rendezvous-capability.md
+++ b/proposals/3886-simple-rendezvous-capability.md
@@ -1,6 +1,6 @@
 # MSC3886: Simple client rendezvous capability
 
-In MSCyyyy (to be published) a proposal is made to allow a user to login on a new device using an existing device by means of scanning a
+In [MSC3906](https://github.com/matrix-org/matrix-spec-proposals/pull/3906) a proposal is made to allow a user to login on a new device using an existing device by means of scanning a
 QR code.
 
 In order to facilitate this the two devices need some bi-directional communication channel which they can use to exchange
@@ -12,7 +12,7 @@ information such as:
 - device ID for end-to-end encryption
 - device keys for end-to-end encryption
 
-To enable MSCyyyy and support any future proposals this MSC proposes a simple HTTP based protocol that can be used to
+To enable [MSC3906](https://github.com/matrix-org/matrix-spec-proposals/pull/3906) and support any future proposals this MSC proposes a simple HTTP based protocol that can be used to
 establish a direct communication channel between two IP connected devices.
 
 It will work with devices behind NAT. It doesn't require homeserver administrators to deploy a separate server.
@@ -246,7 +246,7 @@ following:
 
 ## Dependencies
 
-None.
+None, although it's intended to be used with [MSC3906](https://github.com/matrix-org/matrix-spec-proposals/pull/3906).
 
 ## Credits
 

--- a/proposals/3886-simple-rendezvous-capability.md
+++ b/proposals/3886-simple-rendezvous-capability.md
@@ -76,6 +76,10 @@ HTTP response codes:
 - `429 Too Many Requests` - the request has been rate limited
 - `307 Temporary Redirect` - if the request should be served from somewhere else specified in the `Location` response header
 
+n.b. the relatively unusual [`307 Temporary Redirect`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/307) response
+code has been chosen explicitly for the behaviour of ensuring that the method and body will not change whilst the user-agent
+follows the redirect. For this reason, no other `30x` response codes are allowed.
+
 HTTP response headers for `201 Created`:
 
 - `Location` - required, the allocated rendezvous URI which can be on a different server
@@ -150,6 +154,11 @@ HTTP response codes:
 - `204 No Content` - rendezvous cancelled
 - `404 Not Found` - rendezvous URI is not valid (it could have expired)
 - `429 Too Many Requests` - the request has been rate limited
+
+### Authentication
+
+These API endpoints do not require authentication. This is because the protocol is explicitly treated as untrusted,
+with trust established at a higher level outside the scope of the present proposal.
 
 ### Maximum payload size
 

--- a/proposals/3886-simple-rendezvous-capability.md
+++ b/proposals/3886-simple-rendezvous-capability.md
@@ -61,6 +61,7 @@ Please note that it is intentional that this protocol does nothing to ensure the
 
 HTTP request headers:
 
+- `Content-Length` - required
 - `Content-Type` - optional, server should assume `application/octet-stream` if not specified
 
 HTTP request body:
@@ -96,6 +97,7 @@ Last-Modified: Wed, 07 Sep 2022 14:27:51 GMT
 
 HTTP request headers:
 
+- `Content-Length` - required
 - `Content-Type` - optional, server should assume `application/octet-stream` if not specified
 - `If-Match` - optional, as per [RFC7232](https://httpwg.org/specs/rfc7232.html#header.if-match) server will assume `*`
 if not specified

--- a/proposals/3886-simple-rendezvous-capability.md
+++ b/proposals/3886-simple-rendezvous-capability.md
@@ -69,30 +69,27 @@ HTTP request body:
 
 HTTP response codes:
 
-- `200 OK` - rendezvous created
+- `201 Accepted` - rendezvous created
 - `403 Forbidden` - forbidden by server policy
 - `413 Payload Too Large` - the supplied payload is too large
 - `429 Too Many Requests` - the request has been rate limited
 
-HTTP response headers for `200 OK`:
+HTTP response headers for `201 OK`:
 
-- `Content-Type` - required, always `application/json`
+- `Location` - required, the allocated rendezvous ID represented as a relative path
+- `X-Max-Bytes` - required, the maximum allowed bytes for the payload
 - `ETag` - required, ETag for the current payload at the rendezvous point as per [RFC7232](https://httpwg.org/specs/rfc7232.html#header.etag)
 - `Expires` - required, the expiry time of the rendezvous as per [RFC7233](https://httpwg.org/specs/rfc7234.html#header.expires)
 - `Last-Modified` - required, the last modified date of the payload as per [RFC7232](https://httpwg.org/specs/rfc7232.html#header.last-modified)
 
-HTTP response body for `200 OK`:
+Example response headers:
 
-- `id` - required, the identifier to use with subsequent requests
-- `max_bytes` - required, the maximum allowed bytes for the payload
-
-Example:
-
-```json
-{
-    "id": "<rendezvous id>",
-    "max_bytes": 102400,
-}
+```http
+Location: abcdEFG12345
+X-Max-Bytes: 10240
+ETag: VmbxF13QDusTgOCt8aoa0d2PQcnBOXeIxEqhw5aQ03o=
+Expires: Wed, 07 Sep 2022 14:28:51 GMT
+Last-Modified: Wed, 07 Sep 2022 14:27:51 GMT
 ```
 
 #### Update payload at rendezvous point: `PUT /<rendezvous id>`
@@ -168,13 +165,14 @@ distinguish between identical payloads sent by either client.
 
 ### CORS
 
-To support usage from web browsers, the server should allow CORS requests from any origin and expose the ETag header:
+To support usage from web browsers, the server should allow CORS requests from any origin and expose the `ETag` and
+`Location` headers:
 
 ```http
 Access-Control-Allow-Headers: Content-type
 Access-Control-Allow-Methods: GET,PUT,POST,DELETE
 Access-Control-Allow-Origin: *
-Access-Control-Expose-Headers: ETag
+Access-Control-Expose-Headers: ETag,Location
 ```
 
 ### Choice of server

--- a/proposals/3886-simple-rendezvous-capability.md
+++ b/proposals/3886-simple-rendezvous-capability.md
@@ -168,8 +168,8 @@ distinguish between identical payloads sent by either client.
 
 ### CORS
 
-To support usage from web browsers, the server should allow CORS requests from any origin and expose the `ETag`,
-`Location` and `X-Max-Bytes` headers as:
+To support usage from web browsers, the server should allow CORS requests to the `/rendezvous` endpoint from any
+origin and expose the `ETag`, `Location` and `X-Max-Bytes` headers as:
 
 ```http
 Access-Control-Allow-Headers: Content-Type,If-Match,If-None-Match
@@ -178,7 +178,9 @@ Access-Control-Allow-Origin: *
 Access-Control-Expose-Headers: ETag,Location,X-Max-Bytes
 ```
 
-These headers are different from the ones currently specified in the [spec](https://spec.matrix.org/v1.4/client-server-api/#web-browser-clients).
+Currently the [spec](https://spec.matrix.org/v1.4/client-server-api/#web-browser-clients) specifies a single set of
+CORS headers to be used. Therefore, care will be required to make it clear in the spec that the headers will
+vary depending on the endpoint.
 
 ### Choice of server
 

--- a/proposals/3886-simple-rendezvous-capability.md
+++ b/proposals/3886-simple-rendezvous-capability.md
@@ -32,7 +32,7 @@ sequenceDiagram
   participant B as Device B
   Note over A: Device A determines which rendezvous server to use
 
-  A->R: POST / Hello from A
+  A->R: POST /rendezvous Hello from A
   R->A: 201 Created Location: /abc-def-123-456
 
   A-->B: Rendezvous URI between clients, perhaps as QR code: e.g. https://rendzvous-server/abc-def-123-456
@@ -57,7 +57,7 @@ Please note that it is intentional that this protocol does nothing to ensure the
 
 ### Protocol
 
-#### Create a new rendezvous point: `POST /`
+#### Create a new rendezvous point: `POST /rendezvous`
 
 HTTP request headers:
 
@@ -227,7 +227,22 @@ and administrators:
 
 ## Unstable prefix
 
-None.
+While this feature is in development the new endpoint should be exposed using the following unstable prefix:
+
+- `/_matrix/client/unstable/org.matrix.msc3886/rendezvous`
+
+Additionally, the feature is to be advertised as unstable feature in the `GET /_matrix/client/versions`
+response, with the key `org.matrix.msc3886` set to `true`. So, the response could look then as
+following:
+
+```json
+{
+    "versions": ["r0.6.0"],
+    "unstable_features": {
+        "org.matrix.msc3886": true
+    }
+}
+```
 
 ## Dependencies
 

--- a/proposals/3886-simple-rendezvous-capability.md
+++ b/proposals/3886-simple-rendezvous-capability.md
@@ -164,6 +164,7 @@ HTTP response codes, and Matrix error codes:
 
 - `202 Accepted` - payload updated
 - `400 Bad Request` (`M_MISSING_PARAM`) - a required header was not provided.
+- `400 Bad Request` (`M_INVALID_PARAM`) - a malformed [`ETag`](#the-update-mechanism) header was provided.
 - `404 Not Found` (`M_NOT_FOUND`) - rendezvous URI is not valid (it could have expired)
 - `412 Precondition Failed` (`M_CONCURRENT_WRITE`, **a new error code**) - when the ETag does not match
 - `413 Payload Too Large` (`M_TOO_LARGE`) - the supplied payload is too large

--- a/proposals/3886-simple-rendezvous-capability.md
+++ b/proposals/3886-simple-rendezvous-capability.md
@@ -76,7 +76,7 @@ HTTP response codes:
 
 HTTP response headers for `201 Created`:
 
-- `Location` - required, the allocated rendezvous ID represented as a relative path
+- `Location` - required, the allocated rendezvous ID represented as a URI safe **relative path**. e.g. `Location: abc-def-1234`
 - `X-Max-Bytes` - required, the maximum allowed bytes for the payload
 - `ETag` - required, ETag for the current payload at the rendezvous point as per [RFC7232](https://httpwg.org/specs/rfc7232.html#header.etag)
 - `Expires` - required, the expiry time of the rendezvous as per [RFC7233](https://httpwg.org/specs/rfc7234.html#header.expires)

--- a/proposals/3886-simple-rendezvous-capability.md
+++ b/proposals/3886-simple-rendezvous-capability.md
@@ -1,12 +1,12 @@
 # MSC3886: Simple client rendezvous capability
 
-In MSCyyyy a proposal is made to allow a user to login on a new device using an existing device by means of scanning a
+In MSCyyyy (to be published) a proposal is made to allow a user to login on a new device using an existing device by means of scanning a
 QR code.
 
 In order to facilitate this the two devices need some bi-directional communication channel which they can use to exchange
 information such as:
 
-- the homserver being used
+- the homeserver being used
 - the user ID
 - facilitation of issuing a new access token
 - device ID for end-to-end encryption

--- a/proposals/3886-simple-rendezvous-capability.md
+++ b/proposals/3886-simple-rendezvous-capability.md
@@ -210,7 +210,42 @@ The proposed protocol requires the devices to have IP connectivity to the server
 
 ## Alternatives
 
+### Send-to-Device messaging
+
+The combination of this proposal and [MSC3903](https://github.com/matrix-org/matrix-spec-proposals/pull/3903) look similar in
+some regards to the existing [Send-to-device messaging](https://spec.matrix.org/v1.6/client-server-api/#send-to-device-messaging)
+capability.
+
+Whilst to-device messaging already provides a mechanism for secure communication
+between two Matrix clients/devices, a key consideration for the anticipated
+login with QR capability is that one of the clients is not yet authenticated with
+a Homeserver.
+
+Furthermore the client might not know which Homeserver the user wishes to
+connect to.
+
+Conceptually, one could create a new type of "guest" login that would allow the
+unauthenticated client to connect to a Homeserver for the purposes of
+communicating with an existing authenticated client via to-device messages.
+
+Some considerations for this:
+
+Where the "actual" Homeserver is not known then the "guest" Homeserver nominated
+by the new client would need to be federated with the "actual" Homeserver.
+
+The "guest" Homeserver would probably want to automatically clean up the "guest"
+accounts after a short period of time.
+
+The "actual" Homeserver operator might not want to open up full "guest" access
+so a second type of "guest" account might be required.
+
+Does the new device/client need to accept the T&Cs of the "guest" Homeserver?
+
+### Other existing protocols
+
 Try and do something with STUN or TURN or [COAP](http://coap.technology/).
+
+### Implementation details
 
 Rather than requiring the devices to poll for updates, "long-polling" could be used instead similar to `/sync`.
 

--- a/proposals/3886-simple-rendezvous-capability.md
+++ b/proposals/3886-simple-rendezvous-capability.md
@@ -33,7 +33,7 @@ sequenceDiagram
   Note over A: Device A determines which rendezvous server to use
 
   A->R: POST / Hello from A
-  R->A: 200 OK {"id": "<rendezvous ID>"}
+  R->A: 201 Created Location: <rendezvous ID>
 
   A-->B: Rendezvous URI between clients, perhaps as QR code: https://rendzvous-server/<rendezvous ID>
 
@@ -69,12 +69,12 @@ HTTP request body:
 
 HTTP response codes:
 
-- `201 Accepted` - rendezvous created
+- `201 Created` - rendezvous created
 - `403 Forbidden` - forbidden by server policy
 - `413 Payload Too Large` - the supplied payload is too large
 - `429 Too Many Requests` - the request has been rate limited
 
-HTTP response headers for `201 OK`:
+HTTP response headers for `201 Created`:
 
 - `Location` - required, the allocated rendezvous ID represented as a relative path
 - `X-Max-Bytes` - required, the maximum allowed bytes for the payload
@@ -106,7 +106,7 @@ HTTP request body:
 
 HTTP response codes:
 
-- `202 Accepted` - payload set
+- `202 Accepted` - payload updated
 - `404 Not Found` - rendezvous ID is not valid (it could have expired)
 - `413 Payload Too Large` - the supplied payload is too large
 - `412 Precondition Failed` - when `If-Match` is supplied and the ETag does not match

--- a/proposals/3886-simple-rendezvous-capability.md
+++ b/proposals/3886-simple-rendezvous-capability.md
@@ -165,14 +165,14 @@ distinguish between identical payloads sent by either client.
 
 ### CORS
 
-To support usage from web browsers, the server should allow CORS requests from any origin and expose the `ETag` and
-`Location` headers:
+To support usage from web browsers, the server should allow CORS requests from any origin and expose the `ETag`,
+`Location` and `X-Max-Bytes` headers as:
 
 ```http
-Access-Control-Allow-Headers: Content-type
+Access-Control-Allow-Headers: Content-Type,If-Match,If-None-Match
 Access-Control-Allow-Methods: GET,PUT,POST,DELETE
 Access-Control-Allow-Origin: *
-Access-Control-Expose-Headers: ETag,Location
+Access-Control-Expose-Headers: ETag,Location,X-Max-Bytes
 ```
 
 ### Choice of server

--- a/proposals/3886-simple-rendezvous-capability.md
+++ b/proposals/3886-simple-rendezvous-capability.md
@@ -16,8 +16,8 @@ information such as:
 To enable [MSC3906](https://github.com/matrix-org/matrix-spec-proposals/pull/3906) and support any future proposals this MSC proposes a simple HTTP based protocol that can be used to
 establish a direct communication channel between two IP connected devices.
 
-This channel SHOULD be considered untrusted by both devices, and SHOULD NOT be
-used to transmit sensitive data in plaintext.
+This channel [SHOULD be considered untrusted](#confidentiality-of-data)
+by both devices, and SHOULD NOT be used to transmit sensitive data in plaintext.
 
 It will work with devices behind NAT. It doesn't require homeserver administrators to deploy a separate server.
 

--- a/proposals/3886-simple-rendezvous-capability.md
+++ b/proposals/3886-simple-rendezvous-capability.md
@@ -165,7 +165,7 @@ HTTP response codes, and Matrix error codes:
 - `202 Accepted` - payload updated
 - `400 Bad Request` (`M_MISSING_PARAM`) - a required header was not provided.
 - `404 Not Found` (`M_NOT_FOUND`) - rendezvous URI is not valid (it could have expired)
-- `412 Precondition Failed` (`M_DIRTY_WRITE`, **a new error code**) - when the ETag does not match
+- `412 Precondition Failed` (`M_CONCURRENT_WRITE`, **a new error code**) - when the ETag does not match
 - `413 Payload Too Large` (`M_TOO_LARGE`) - the supplied payload is too large
 - `429 Too Many Requests` (`M_UNKNOWN`) - the request has been rate limited
 

--- a/proposals/3886-simple-rendezvous-capability.md
+++ b/proposals/3886-simple-rendezvous-capability.md
@@ -108,8 +108,8 @@ HTTP response codes:
 
 - `202 Accepted` - payload updated
 - `404 Not Found` - rendezvous URI is not valid (it could have expired)
-- `413 Payload Too Large` - the supplied payload is too large
 - `412 Precondition Failed` - when `If-Match` is supplied and the ETag does not match
+- `413 Payload Too Large` - the supplied payload is too large
 - `429 Too Many Requests` - the request has been rate limited
 
 HTTP response headers for `202 Accepted` and `412 Precondition Failed`:
@@ -128,8 +128,8 @@ only return data if given ETag does not match
 HTTP response codes:
 
 - `200 OK` - payload returned
-- `404 Not Found` - rendezvous URI is not valid (it could have expired)
 - `304 Not Modified` - when `If-None-Match` is supplied and the ETag does not match
+- `404 Not Found` - rendezvous URI is not valid (it could have expired)
 - `429 Too Many Requests` - the request has been rate limited
 
 HTTP response headers for `200 OK` and `304 Not Modified`:

--- a/proposals/3886-simple-rendezvous-capability.md
+++ b/proposals/3886-simple-rendezvous-capability.md
@@ -32,23 +32,23 @@ sequenceDiagram
   participant B as Device B
   Note over A: Device A determines which rendezvous server to use
 
-  A->R: POST /rendezvous Hello from A
-  R->A: 201 Created Location: /abc-def-123-456
+  A->>+R: POST /rendezvous Hello from A
+  R->>-A: 201 Created Location: /abc-def-123-456
 
-  A-->B: Rendezvous URI between clients, perhaps as QR code: e.g. https://rendzvous-server/abc-def-123-456
+  A-->>B: Rendezvous URI between clients, perhaps as QR code: e.g. https://rendzvous-server/abc-def-123-456
 
   Note over A: Device A starts polling for contact at the rendezvous
 
-  B->R: GET <rendezvous URI>
-  R->B: 200 OK Hello from A
+  B->>+R: GET <rendezvous URI>
+  R->>-B: 200 OK Hello from A
 
   loop Device A polls for rendezvous updates
-    A->R: GET <rendezvous URI> If-None-Match: <ETag>
-    R->A: 304 Not Modified
+    A->>+R: GET <rendezvous URI> If-None-Match: <ETag>
+    R->>-A: 304 Not Modified
   end
 
-  B->R: PUT <rendezvous URI> Hello from B
-  R->B: 202 Accepted 
+  B->>+R: PUT <rendezvous URI> Hello from B
+  R->>-B: 202 Accepted 
 
   Note over A,B: Rendezvous now established
 ```

--- a/proposals/3886-simple-rendezvous-capability.md
+++ b/proposals/3886-simple-rendezvous-capability.md
@@ -1,4 +1,4 @@
-# MSCxxxx: Simple rendezvous capability
+# MSC3886: Simple rendezvous capability
 
 In MSCyyyy a proposal is made to allow a user to login on a new device using an existing device by means of scanning a
 QR code.

--- a/proposals/3886-simple-rendezvous-capability.md
+++ b/proposals/3886-simple-rendezvous-capability.md
@@ -57,7 +57,7 @@ Please note that it is intentional that this protocol does nothing to ensure the
 
 ### Protocol
 
-#### Create a new rendezvous point: `POST /rendezvous`
+#### Create a new rendezvous point: `POST /_matrix/client/rendezvous`
 
 HTTP request headers:
 

--- a/proposals/3886-simple-rendezvous-capability.md
+++ b/proposals/3886-simple-rendezvous-capability.md
@@ -109,7 +109,8 @@ HTTP request headers:
 
 - `Content-Length` - required
 - `Content-Type` - optional, server should assume `application/octet-stream` if not specified
-- `If-Match` - optional, as per [RFC7232](https://httpwg.org/specs/rfc7232.html#header.if-match) server will assume `*`
+- `If-Match` - required. The ETag of the last payload seen by the requesting device.
+
 if not specified
 
 HTTP request body:
@@ -119,9 +120,9 @@ HTTP request body:
 HTTP response codes, and Matrix error codes:
 
 - `202 Accepted` - payload updated
-- `400 Bad Request` (`M_MISSING_PARAM`) - no `Content-Length` was provided.
+- `400 Bad Request` (`M_MISSING_PARAM`) - a required header was not provided.
 - `404 Not Found` (`M_NOT_FOUND`) - rendezvous URI is not valid (it could have expired)
-- `412 Precondition Failed` (`M_DIRTY_WRITE`, **a new error code**) - when `If-Match` is supplied and the ETag does not match
+- `412 Precondition Failed` (`M_DIRTY_WRITE`, **a new error code**) - when the ETag does not match
 - `413 Payload Too Large` (`M_TOO_LARGE`) - the supplied payload is too large
 - `429 Too Many Requests` (`M_UNKNOWN`) - the request has been rate limited
 

--- a/proposals/3886-simple-rendezvous-capability.md
+++ b/proposals/3886-simple-rendezvous-capability.md
@@ -54,6 +54,11 @@ response to immediately update the payload.) Updates will succeed only if the
 supplied `ETag` matches the server's current revision of the payload. This
 prevents concurrent writes to the payload.
 
+The `ETag` header is standard, described by
+[RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-etag). In this
+proposal we only accept strong, single-valued ETag values; anything else
+constitutes a malformed request.
+
 There is no mechanism to retrieve previous payloads after an update.
 
 #### Expiry

--- a/proposals/3886-simple-rendezvous-capability.md
+++ b/proposals/3886-simple-rendezvous-capability.md
@@ -74,6 +74,7 @@ HTTP response codes:
 - `403 Forbidden` - forbidden by server policy
 - `413 Payload Too Large` - the supplied payload is too large
 - `429 Too Many Requests` - the request has been rate limited
+- `307 Temporary Redirect` - if the request should be served from somewhere else specified in the `Location` response header
 
 HTTP response headers for `201 Created`:
 

--- a/proposals/3886-simple-rendezvous-capability.md
+++ b/proposals/3886-simple-rendezvous-capability.md
@@ -71,6 +71,7 @@ HTTP request body:
 HTTP response codes, and Matrix error codes:
 
 - `201 Created` - rendezvous created
+- `400 Bad Request` (`M_MISSING_PARAM`) - no `Content-Length` was provided.
 - `403 Forbidden` (`M_FORBIDDEN`) - forbidden by server policy
 - `413 Payload Too Large` (`M_TOO_LARGE`) - the supplied payload is too large
 - `429 Too Many Requests` (`M_UNKNOWN`) - the request has been rate limited
@@ -114,6 +115,7 @@ HTTP request body:
 HTTP response codes, and Matrix error codes:
 
 - `202 Accepted` - payload updated
+- `400 Bad Request` (`M_MISSING_PARAM`) - no `Content-Length` was provided.
 - `404 Not Found` (`M_NOT_FOUND`) - rendezvous URI is not valid (it could have expired)
 - `412 Precondition Failed` (`M_DIRTY_WRITE`, **a new error code**) - when `If-Match` is supplied and the ETag does not match
 - `413 Payload Too Large` (`M_TOO_LARGE`) - the supplied payload is too large

--- a/proposals/xxxx-simple-rendezvous-capability.md
+++ b/proposals/xxxx-simple-rendezvous-capability.md
@@ -1,0 +1,83 @@
+# MSCxxxx: Simple rendezvous capability
+
+In MSCyyyy a proposal is made to allow a user to login on a new device using an existing device by means of scanning a
+QR code.
+
+In order to facilitate this the two devices need some bi-directional communication channel which they can use to exchange
+information such as:
+
+- the homserver being used
+- the user ID
+- facilitation of issuing a new access token
+- device ID for end-to-end encryption
+- device keys for end-to-end encryption
+
+To enable MSCyyyy and support any future proposals this MSC proposes a simple HTTP based protocol that can be used to
+establish a direct communication channel between two IP connected devices.
+
+It will work with devices behind NAT. It doesn't require homeserver administrators to deploy a separate server.
+
+## Proposal
+
+### Protocol
+
+`POST /`
+
+`PUT /<channel id>`
+
+`GET /<channel id>`
+
+`DELETE /<channel id>`
+
+### CORS
+
+### Choice of server
+
+Ultimately it will be up to the Matrix client implementation to decide which rendezvous server to use.
+
+However, it is suggested that the following logic is used by the device/client to choose the rendezvous server in order
+of preference:
+
+1. If the client is already logged in: try and use current homeserver.
+1. If the client is not logged in and it is known which homeserver the user wants to connect to: try and use that homeserver.
+1. Otherwise use a default server.
+
+## Potential issues
+
+Because this is an entirely new set of functionality it should not cause issue with any existing Matrix functions or capabilities.
+
+The proposed protocol requires the devices to have IP connectivity to the server which might not be the case in P2P scenarios.
+
+## Alternatives
+
+Try and do something with STUN or TURN or [COAP](http://coap.technology/).
+
+## Security considerations
+
+### Confidentiality of data
+
+Whilst the data transmitted can be encrypted in transit via HTTP/TLS the rendezvous server does have visibility over the
+data.
+
+As such, for the purposes of authentication and end-to-end encryption the channel should be treated as untrusted and some
+form of secure layer should be used on top of the channel.
+
+### Denial of Service attack surface
+
+Because the protocol allows for the creation of arbitrary channels and storage of arbitrary data, it is possible to use
+it as a denial of service attack surface.
+
+As such, the following standard mitigations such as the following may be deemed appropriate by homeserver implementations
+and administrators:
+
+- rate limiting of requests
+- imposing a low maximum payload size (e.g. kilobytes not megabytes)
+- limiting the number of concurrent channels
+
+## Unstable prefix
+
+None.
+
+## Dependencies
+
+None.


### PR DESCRIPTION
[Rendered](https://github.com/matrix-org/matrix-spec-proposals/blob/hughns/simple-rendezvous-capability/proposals/3886-simple-rendezvous-capability.md)

- Servers:
   - [x] Standalone Rust server: https://github.com/matrix-org/rust-http-rendezvous-server
   - [x] Synapse homeserver module: https://pypi.org/project/matrix-http-rendezvous-synapse/
   - [x] Standalone prototype Node.js server: https://github.com/matrix-org/node-http-rendezvous-server
   - [x] Synapse experimental feature to delegate rendezvous to external server via an HTTP `307` redirect: https://github.com/matrix-org/synapse/pull/14018
- Clients:
   - [x] Element Web:
       - [x] matrix-js-sdk: https://github.com/matrix-org/matrix-js-sdk/pull/2747
       - [x] matrix-react-sdk: https://github.com/matrix-org/matrix-react-sdk/pull/9403
   - [x] Element iOS:
       - [x] https://github.com/vector-im/element-ios/pull/6806