### PR TITLE
MSC3903: X25519 Elliptic-curve Diffie-Hellman ephemeral for establishing secure channel between two Matrix clients

### DIFF
--- a/proposals/3903-x25519-ecdhe.md
+++ b/proposals/3903-x25519-ecdhe.md
@@ -101,4 +101,7 @@ TBD
 
 ## Dependencies
 
-None.
+Although this proposal can be used over any other insecure channel, the anticipated use case is over
+[MSC3886](https://github.com/matrix-org/matrix-spec-proposals/pull/3886)
+
+Furthermore without the (as yet unpublished) MSCyyyy proposal, there are no other implementations/uses of the proposal.

--- a/proposals/3903-x25519-ecdhe.md
+++ b/proposals/3903-x25519-ecdhe.md
@@ -20,6 +20,9 @@ The proposal is to use X25519 to agree a shared secret that is then used to perf
 All payloads are transmitted as JSON and could be done over any bidirectional transport including
 [MSC3886](https://github.com/matrix-org/matrix-spec-proposals/pull/3886) or elsewhere in Matrix.
 
+As Diffie-Hellman key agreement is a non-authenticated key-agreement protocol,
+this proposal makes use of a checksum fot the user to authenticate the key agreement.
+
 **1a.** The initiator generates a ephemeral Curve25519 private key `privateA`. This key should never be re-used.
 
 **1b.** The initiator derives the public key from `privateA` as `publicA = scalarMult(privateA, 9)`
@@ -35,9 +38,6 @@ All payloads are transmitted as JSON and could be done over any bidirectional tr
 
 The `key` is the unpadded base64-encoded value for `publicA` (the x co-ordinate of the curve).
 
-It's critical that the initiator public key `publicA` is transmitted via a trusted medium such as a QR code or some other
-already-authenticated channel, and not via the unauthenticated channel.
-
 **2.** The recipient similarly generates a private key `privateB`, derives the public key `publicB` and shares is using
 the same structure of payload:
 
@@ -47,8 +47,6 @@ the same structure of payload:
     "key": "E03zK4t29xyiXlt54kOVpIzNtGytjQSvaHXF8n8tTBs"
 }
 ```
-
-Unlike `publicA` the recipient public key `publicB` does not need to be transmitted via a trusted medium.
 
 **3.** Both sides derive the same shared secret as follows:
 
@@ -77,7 +75,12 @@ For the above example keys the info would be: `m.rendezvous.v2.curve25519-aes-sh
 
 This means that for AES-GCM implementations that require the authentication tag to be explicitly processed (e.g. CryptoKit on iOS) that it can be sourced from the last 16 bytes of the unpadded base64-decoded `ciphertext`.
 
-**7.** The user should confirm that the established channel is secure by means of a checksum derived from the shared key.
+**7.** The user should authenticate/confirm that the established channel is
+secure by means of a checksum that is shown on both devices.
+
+If the checksum shown is not the same on bothe defives then it means that the
+devices have not directly exchanged keys with one another and are subject to a man-in-the-middle.
+
 The checksum is 12 numeric digits in the form `1234-5678-9012` and should be displayed on both devices for the user to
 visually verify.
 

--- a/proposals/3903-x25519-ecdhe.md
+++ b/proposals/3903-x25519-ecdhe.md
@@ -132,7 +132,7 @@ Algorithm selection and implementation are crucial.
 
 ## Unstable prefix
 
-TBD
+WHilst in development the unstable algorithm name of `org.matrix.msc3903.rendezvous.v1.curve25519-aes-sha256` should be used.
 
 ## Dependencies
 

--- a/proposals/3903-x25519-ecdhe.md
+++ b/proposals/3903-x25519-ecdhe.md
@@ -138,7 +138,7 @@ Whilst in development the unstable algorithm name of `org.matrix.msc3903.rendezv
 
 ## Dependencies
 
-Although this proposal can be used over any other insecure channel, the anticipated use case is over
+Although this proposal could be used over any communication channel, the anticipated use case is over
 [MSC3886](https://github.com/matrix-org/matrix-spec-proposals/pull/3886).
 
 Furthermore without the [MSC3906](https://github.com/matrix-org/matrix-spec-proposals/pull/3906) proposal, there are no other implementations/uses of the proposal.

--- a/proposals/3903-x25519-ecdhe.md
+++ b/proposals/3903-x25519-ecdhe.md
@@ -1,4 +1,4 @@
-# MSCzzzz: X25519 Elliptic-curve Diffie-Hellman ephemeral for establishing secure channel between two Matrix clients
+# MSC3903: X25519 Elliptic-curve Diffie-Hellman ephemeral for establishing secure channel between two Matrix clients
 
 In MSCyyyy (to be published) a proposal is made to allow a user to login on a new device using an existing device by
 means of scanning a QR code.

--- a/proposals/3903-x25519-ecdhe.md
+++ b/proposals/3903-x25519-ecdhe.md
@@ -116,30 +116,16 @@ documents.
 
 ### Send-to-Device messaging
 
-Whilst to-device messaging already provides a mechanism for secure communication
-between two Matrix clients/devices, a key consideration for the anticipated
-login with QR capability is that one of the clients is not yet authenticated with
-a Homeserver.
+The combination of this proposal and
+[MSC3886](https://github.com/matrix-org/matrix-spec-proposals/pull/3886) look
+similar in some regards to the existing
+[Send-to-device messaging](https://spec.matrix.org/v1.6/client-server-api/#send-to-device-messaging)
+capability.
 
-Furthermore the client might not know which Homeserver the user wishes to
-connect to.
+Discussion on this as an alternative has been moved to
+[MSC3886](https://github.com/matrix-org/matrix-spec-proposals/pull/3886) as it
+has received more engagement on that proposal.
 
-Conceptually, one could create a new type of "guest" login that would allow the
-unauthenticated client to connect to a Homeserver for the purposes of
-communicating with an existing authenticated client via to-device messages.
-
-Some considerations for this:
-
-Where the "actual" Homeserver is not known then the "guest" Homeserver nominated
-by the new client would need to be federated with the "actual" Homeserver.
-
-The "guest" Homeserver would probably want to automatically clean up the "guest"
-accounts after a short period of time.
-
-The "actual" Homeserver operator might not want to open up full "guest" access
-so a second type of "guest" account might be required.
-
-Does the new device/client need to accept the T&Cs of the "guest" Homeserver?
 
 ### Naming convention
 

--- a/proposals/3903-x25519-ecdhe.md
+++ b/proposals/3903-x25519-ecdhe.md
@@ -58,7 +58,7 @@ and info of `<algorithm>|<base64-encoded initiator public key>|<base64-encoded r
 
 For the above example keys the info would be: `m.rendezvous.v1.curve25519-aes-sha256|gRr3uZSpm2qz37CkqnrhZTW3H0JQvc6l4HYOtBULNSU=|E03zK4t29xyiXlt54kOVpIzNtGytjQSvaHXF8n8tTBs=`.
 
-**5.** Subsequent payloads are then sent encrypted using 256 bit AES-GCM using a 256 bit random initialisation vector/salt.
+**5.** Subsequent payloads are then sent encrypted using 256 bit AES-GCM using a 256 bit random initialisation vector and 128 bit authentication tag.
 
 **6.** Encrypted payloads are then encoded and transmitted by either party as follows:
 
@@ -69,8 +69,10 @@ For the above example keys the info would be: `m.rendezvous.v1.curve25519-aes-sh
 }
 ```
 
-- `ciphertext` - base64-encoded AES-GCM encrypted data
-- `iv` - base64-encoded initialization vector/salt
+- `ciphertext` - base64-encoded(AES-GCM ciphertext concatenated with the authentication tag)
+- `iv` - base64-encoded(initialization vector)
+
+This means that for AES-GCM implementations that require the authentication tag to be explicitly processed (e.g. CryptoKit on iOS) that it can be sourced from the last 16 bytes of the base64-decoded `ciphertext`.
 
 Steps **1** and **2** can happen simultaneously or in any order.
 

--- a/proposals/3903-x25519-ecdhe.md
+++ b/proposals/3903-x25519-ecdhe.md
@@ -28,12 +28,12 @@ All payloads are transmitted as JSON and could be done over any bidirectional tr
 
 ```json
 {
-    "algorithm": "m.rendezvous.v1.curve25519-aes-sha256",
-    "key": "gRr3uZSpm2qz37CkqnrhZTW3H0JQvc6l4HYOtBULNSU="
+    "algorithm": "m.rendezvous.v2.curve25519-aes-sha256",
+    "key": "gRr3uZSpm2qz37CkqnrhZTW3H0JQvc6l4HYOtBULNSU"
 }
 ```
 
-The `key` is the base64-encoded value for `publicA` (the x co-ordinate of the curve).
+The `key` is the unpadded base64-encoded value for `publicA` (the x co-ordinate of the curve).
 
 It's critical that the initiator public key `publicA` is transmitted via a trusted medium such as a QR code or some other
 already-authenticated channel, and not via the unauthenticated channel.
@@ -43,8 +43,8 @@ the same structure of payload:
 
 ```json
 {
-    "algorithm": "m.rendezvous.v1.curve25519-aes-sha256",
-    "key": "E03zK4t29xyiXlt54kOVpIzNtGytjQSvaHXF8n8tTBs="
+    "algorithm": "m.rendezvous.v2.curve25519-aes-sha256",
+    "key": "E03zK4t29xyiXlt54kOVpIzNtGytjQSvaHXF8n8tTBs"
 }
 ```
 
@@ -57,9 +57,9 @@ Initiator: `sharedSecret = scalarMult(privateA, publicB) = scalarMult(privateA, 
 Recipient: `sharedSecret = scalarMult(privateB, publicA) = scalarMult(privateB, scalarMult(privateA, 9))`
 
 **4.** Both sides then derive a 256 bit AES key using HKDF SHA-256 with a salt of 8 bytes of zero (i.e. `[0,0,0,0,0,0,0,0]`)
-and info of `<algorithm>|<base64-encoded initiator public key>|<base64-encoded recipient public key>`.
+and info of `<algorithm>|<unpadded base64-encoded initiator public key>|<unpadded base64-encoded recipient public key>`.
 
-For the above example keys the info would be: `m.rendezvous.v1.curve25519-aes-sha256|gRr3uZSpm2qz37CkqnrhZTW3H0JQvc6l4HYOtBULNSU=|E03zK4t29xyiXlt54kOVpIzNtGytjQSvaHXF8n8tTBs=`.
+For the above example keys the info would be: `m.rendezvous.v2.curve25519-aes-sha256|gRr3uZSpm2qz37CkqnrhZTW3H0JQvc6l4HYOtBULNSU|E03zK4t29xyiXlt54kOVpIzNtGytjQSvaHXF8n8tTBs`.
 
 **5.** Subsequent payloads are then sent encrypted using 256 bit AES-GCM using a 256 bit random initialisation vector and 128 bit authentication tag.
 
@@ -68,14 +68,14 @@ For the above example keys the info would be: `m.rendezvous.v1.curve25519-aes-sh
 ```json
 {
     "ciphertext": "L3SHZU2DnfPxiVHVcgqe2HNq7Acdv13XCK/mC5f0JmxGqeUNQdeta8HD8qGBu3YdYrv5Bf7xl8WjlGaUOLr3uceZUuSv8amRZUghZ+/GQsi8tPZLzHk0xOePmKhRg95HUZrja7cQIgw+iKY/Vp1UoUJRqk1iQv/86RHz3c5a/GqyhGyWnXfuy16tPxmNQ4IpI/hVJof+7iiA3IucMtLHZnGH/VpNuZ1kv97GJJbUX3XfTIjyN2jmA9zFP5d/mE10YYzG7XcZ0hWj5BPhpM1jojwVyTRhMseJAX7MVvqQ7HT7LjvoJSYm5xk+0ptsWodAuol7uYjGszIu+EFvpuYmweZa6ewcnf/T5fXb6hXfqCZf43gumrXx5ACUMC4IWBOI0mFE28ITRmw9ZjL2CodxFsbTGRYp3Arb0SMcF1KUsiYBXxLasXFaEtrE244QD+oc9FEWNPLdgCDcwEhalaK9OP7MJF7jXc2y+zOPfUPCdCHoSV6F5Y/MnPkrpwprrIn/yp2E4/4QTe2VTXG7ZJa/aCGh8eAo9nBANQi7sGElr83SU0oy80MvVWUmxnaWc8UDgASkC/dGQNCfZzsZeho0+Y2smcETJlD/7+D1c8YC3LevAtYXDOOO9ApaY+SpPloKp/zdoZdkf+ggGfyytvTEw0gZUygZnBplefaIry9lASpv6XXkowVFFP5kGf0ZAhPOr2ET3DTyoBXP7u7MJrRAtBEex6OaysVaJ2DDEj8JknpdwatuWPduygMt",
-    "iv": "Fk/2eSQ2hANwpQhAI94/BQ=="
+    "iv": "Fk/2eSQ2hANwpQhAI94/BQ"
 }
 ```
 
-- `ciphertext` - base64-encoded(AES-GCM ciphertext concatenated with the authentication tag)
-- `iv` - base64-encoded(initialization vector)
+- `ciphertext` - unpadded base64-encoded(AES-GCM ciphertext concatenated with the authentication tag)
+- `iv` - unpadded base64-encoded(initialization vector)
 
-This means that for AES-GCM implementations that require the authentication tag to be explicitly processed (e.g. CryptoKit on iOS) that it can be sourced from the last 16 bytes of the base64-decoded `ciphertext`.
+This means that for AES-GCM implementations that require the authentication tag to be explicitly processed (e.g. CryptoKit on iOS) that it can be sourced from the last 16 bytes of the unpadded base64-decoded `ciphertext`.
 
 **7.** The user should confirm that the established channel is secure by means of a checksum derived from the shared key.
 The checksum is 12 numeric digits in the form `1234-5678-9012` and should be displayed on both devices for the user to
@@ -126,13 +126,15 @@ The algorithm name is arbitrary.
 Alternative key exchange algorithms to X25519 could be used. Alternative symmetric ciphers to AES-GCM could be used. The
 purpose of the `algorithm` field is allow for alternative algorithms in the future.
 
+An earlier iteration of this proposal used the algorithm name `m.rendezvous.v1.curve25519-aes-sha256` but that has been superceded.
+
 ## Security considerations
 
 Algorithm selection and implementation are crucial.
 
 ## Unstable prefix
 
-WHilst in development the unstable algorithm name of `org.matrix.msc3903.rendezvous.v1.curve25519-aes-sha256` should be used.
+Whilst in development the unstable algorithm name of `org.matrix.msc3903.rendezvous.v2.curve25519-aes-sha256` should be used.
 
 ## Dependencies
 

--- a/proposals/3903-x25519-ecdhe.md
+++ b/proposals/3903-x25519-ecdhe.md
@@ -32,7 +32,7 @@ this proposal makes use of a checksum fot the user to authenticate the key agree
 ```json
 {
     "algorithm": "m.rendezvous.v2.curve25519-aes-sha256",
-    "key": "gRr3uZSpm2qz37CkqnrhZTW3H0JQvc6l4HYOtBULNSU"
+    "key": "gRr3uZSpm2qz37CkqnrhZTW3H0JQvc6l4HY0tBULNSU"
 }
 ```
 
@@ -57,7 +57,7 @@ Recipient: `sharedSecret = scalarMult(privateB, publicA) = scalarMult(privateB, 
 **4.** Both sides then derive a 256 bit AES key using HKDF SHA-256 with a salt of 8 bytes of zero (i.e. `[0,0,0,0,0,0,0,0]`)
 and info of `<algorithm>|<unpadded base64-encoded initiator public key>|<unpadded base64-encoded recipient public key>`.
 
-For the above example keys the info would be: `m.rendezvous.v2.curve25519-aes-sha256|gRr3uZSpm2qz37CkqnrhZTW3H0JQvc6l4HYOtBULNSU|E03zK4t29xyiXlt54kOVpIzNtGytjQSvaHXF8n8tTBs`.
+For the above example keys the info would be: `m.rendezvous.v2.curve25519-aes-sha256|gRr3uZSpm2qz37CkqnrhZTW3H0JQvc6l4HY0tBULNSU|E03zK4t29xyiXlt54kOVpIzNtGytjQSvaHXF8n8tTBs`.
 
 **5.** Subsequent payloads are then sent encrypted using 256 bit AES-GCM using a 256 bit random initialisation vector and 128 bit authentication tag.
 

--- a/proposals/3903-x25519-ecdhe.md
+++ b/proposals/3903-x25519-ecdhe.md
@@ -25,7 +25,7 @@ transport including [MSC3886](https://github.com/matrix-org/matrix-spec-proposal
 or elsewhere in Matrix.
 
 As Diffie-Hellman key agreement is a non-authenticated key-agreement protocol,
-this proposal makes use of a checksum fot the user to authenticate the key agreement.
+this proposal makes use of a checksum for the user to authenticate the key agreement.
 
 **1a.** The initiator generates a ephemeral Curve25519 private key `privateA`.
 This key should never be re-used.
@@ -92,7 +92,7 @@ the last 16 bytes of the unpadded base64-decoded `ciphertext`.
 **7.** The user should authenticate/confirm that the established channel is
 secure by means of a checksum that is shown on both devices.
 
-If the checksum shown is not the same on bothe defives then it means that the
+If the checksum shown is not the same on both defives then it means that the
 devices have not directly exchanged keys with one another and are subject to a man-in-the-middle.
 
 The checksum is 12 numeric digits in the form `1234-5678-9012` and should be

--- a/proposals/3903-x25519-ecdhe.md
+++ b/proposals/3903-x25519-ecdhe.md
@@ -1,6 +1,6 @@
 # MSC3903: X25519 Elliptic-curve Diffie-Hellman ephemeral for establishing secure channel between two Matrix clients
 
-In MSCyyyy (to be published) a proposal is made to allow a user to login on a new device using an existing device by
+In [MSC3906](https://github.com/matrix-org/matrix-spec-proposals/pull/3906) a proposal is made to allow a user to login on a new device using an existing device by
 means of scanning a QR code.
 
 [MSC3886](https://github.com/matrix-org/matrix-spec-proposals/pull/3886) already proposes a simple unsecured rendezvous protocol.
@@ -139,4 +139,4 @@ TBD
 Although this proposal can be used over any other insecure channel, the anticipated use case is over
 [MSC3886](https://github.com/matrix-org/matrix-spec-proposals/pull/3886).
 
-Furthermore without the (as yet unpublished) MSCyyyy proposal, there are no other implementations/uses of the proposal.
+Furthermore without the [MSC3906](https://github.com/matrix-org/matrix-spec-proposals/pull/3906) proposal, there are no other implementations/uses of the proposal.

--- a/proposals/3903-x25519-ecdhe.md
+++ b/proposals/3903-x25519-ecdhe.md
@@ -126,7 +126,7 @@ The algorithm name is arbitrary.
 Alternative key exchange algorithms to X25519 could be used. Alternative symmetric ciphers to AES-GCM could be used. The
 purpose of the `algorithm` field is allow for alternative algorithms in the future.
 
-An earlier iteration of this proposal used the algorithm name `m.rendezvous.v1.curve25519-aes-sha256` but that has been superceded.
+An earlier iteration of this proposal used the algorithm name `m.rendezvous.v1.curve25519-aes-sha256` but that has been superseded.
 
 ## Security considerations
 

--- a/proposals/3903-x25519-ecdhe.md
+++ b/proposals/3903-x25519-ecdhe.md
@@ -8,6 +8,11 @@ means of scanning a QR code.
 In this proposal we build a secure layer on top of MSC3886 to allow for trusted out-of-bands communication between two
 Matrix clients.
 
+It is notable that the combination of this proposal and [MSC3886](https://github.com/matrix-org/matrix-spec-proposals/pull/3886)
+provides a similar capability to the existing
+[Send-to-Device messaging](https://spec.matrix.org/v1.4/client-server-api/#send-to-device-messaging) feature. See the
+alternatives section for more on this.
+
 ## Proposal
 
 The proposal is to use X25519 to agree a shared secret that is then used to perform AES.
@@ -86,6 +91,31 @@ where exactly this would fit in the spec documents.
 
 ## Alternatives
 
+### Send-to-Device messaging
+
+Whilst to-device messaging already provides a mechanism for secure communication between two Matrix clients/devices, a
+key consideration for the anticipated login with QR capability is that one of the clients is not yet authenticated with
+a Homeserver.
+
+Furthermore the client might not know which Homeserver the user wishes to connect to.
+
+Conceptually, one could create a new type of "guest" login that would allow the unauthenticated client to connect to a
+Homeserver for the purposes of communicating with an existing authenticated client via to-device messages.
+
+Some considerations for this:
+
+Where the "actual" Homeserver is not known then the "guest" Homeserver nominated by the new client would need to be federated
+with the "actual" Homeserver.
+
+The "guest" Homeserver would probably want to automatically clean up the "guest" accounts after a short period of time.
+
+The "actual" Homeserver operator might not want to open up full "guest" access so a second type of "guest" account might
+be required.
+
+Does the new device/client need to accept the T&Cs of the "guest" Homeserver?
+
+### Naming convention
+
 The algorithm name is arbitrary.
 
 Alternative key exchange algorithms to X25519 could be used. Alternative symmetric ciphers to AES-GCM could be used. The
@@ -102,6 +132,6 @@ TBD
 ## Dependencies
 
 Although this proposal can be used over any other insecure channel, the anticipated use case is over
-[MSC3886](https://github.com/matrix-org/matrix-spec-proposals/pull/3886)
+[MSC3886](https://github.com/matrix-org/matrix-spec-proposals/pull/3886).
 
 Furthermore without the (as yet unpublished) MSCyyyy proposal, there are no other implementations/uses of the proposal.

--- a/proposals/3903-x25519-ecdhe.md
+++ b/proposals/3903-x25519-ecdhe.md
@@ -1,33 +1,40 @@
 # MSC3903: X25519 Elliptic-curve Diffie-Hellman ephemeral for establishing secure channel between two Matrix clients
 
-In [MSC3906](https://github.com/matrix-org/matrix-spec-proposals/pull/3906) a proposal is made to allow a user to login on a new device using an existing device by
-means of scanning a QR code.
+In [MSC3906](https://github.com/matrix-org/matrix-spec-proposals/pull/3906) a
+proposal is made to allow a user to login on a new device using an existing
+device by means of scanning a QR code.
 
-[MSC3886](https://github.com/matrix-org/matrix-spec-proposals/pull/3886) already proposes a simple unsecured rendezvous protocol.
+[MSC3886](https://github.com/matrix-org/matrix-spec-proposals/pull/3886) already
+proposes a simple unsecured rendezvous protocol.
 
-In this proposal we build a secure layer on top of MSC3886 to allow for trusted out-of-bands communication between two
-Matrix clients.
+In this proposal we build a secure layer on top of MSC3886 to allow for trusted
+out-of-bands communication between two Matrix clients.
 
 It is notable that the combination of this proposal and [MSC3886](https://github.com/matrix-org/matrix-spec-proposals/pull/3886)
 provides a similar capability to the existing
-[Send-to-Device messaging](https://spec.matrix.org/v1.4/client-server-api/#send-to-device-messaging) feature. See the
-alternatives section for more on this.
+[Send-to-Device messaging](https://spec.matrix.org/v1.4/client-server-api/#send-to-device-messaging)
+feature. See the alternatives section for more on this.
 
 ## Proposal
 
-The proposal is to use X25519 to agree a shared secret that is then used to perform AES.
+The proposal is to use X25519 to agree a shared secret that is then used to
+perform AES.
 
-All payloads are transmitted as JSON and could be done over any bidirectional transport including
-[MSC3886](https://github.com/matrix-org/matrix-spec-proposals/pull/3886) or elsewhere in Matrix.
+All payloads are transmitted as JSON and could be done over any bidirectional
+transport including [MSC3886](https://github.com/matrix-org/matrix-spec-proposals/pull/3886)
+or elsewhere in Matrix.
 
 As Diffie-Hellman key agreement is a non-authenticated key-agreement protocol,
 this proposal makes use of a checksum fot the user to authenticate the key agreement.
 
-**1a.** The initiator generates a ephemeral Curve25519 private key `privateA`. This key should never be re-used.
+**1a.** The initiator generates a ephemeral Curve25519 private key `privateA`.
+This key should never be re-used.
 
-**1b.** The initiator derives the public key from `privateA` as `publicA = scalarMult(privateA, 9)`
+**1b.** The initiator derives the public key from `privateA` as
+`publicA = scalarMult(privateA, 9)`
 
-**1c.** The initiator shares it's key with the recipient via a trusted medium using the following payload:
+**1c.** The initiator shares it's key with the recipient via a trusted medium
+using the following payload:
 
 ```json
 {
@@ -36,10 +43,11 @@ this proposal makes use of a checksum fot the user to authenticate the key agree
 }
 ```
 
-The `key` is the unpadded base64-encoded value for `publicA` (the x co-ordinate of the curve).
+The `key` is the unpadded base64-encoded value for `publicA` (the x co-ordinate
+of the curve).
 
-**2.** The recipient similarly generates a private key `privateB`, derives the public key `publicB` and shares is using
-the same structure of payload:
+**2.** The recipient similarly generates a private key `privateB`, derives the
+public key `publicB` and shares is using the same structure of payload:
 
 ```json
 {
@@ -54,12 +62,15 @@ Initiator: `sharedSecret = scalarMult(privateA, publicB) = scalarMult(privateA, 
 
 Recipient: `sharedSecret = scalarMult(privateB, publicA) = scalarMult(privateB, scalarMult(privateA, 9))`
 
-**4.** Both sides then derive a 256 bit AES key using HKDF SHA-256 with a salt of 8 bytes of zero (i.e. `[0,0,0,0,0,0,0,0]`)
-and info of `<algorithm>|<unpadded base64-encoded initiator public key>|<unpadded base64-encoded recipient public key>`.
+**4.** Both sides then derive a 256 bit AES key using HKDF SHA-256 with a salt
+of 8 bytes of zero (i.e. `[0,0,0,0,0,0,0,0]`) and info of
+`<algorithm>|<unpadded base64-encoded initiator public key>|<unpadded base64-encoded recipient public key>`.
 
-For the above example keys the info would be: `m.rendezvous.v2.curve25519-aes-sha256|gRr3uZSpm2qz37CkqnrhZTW3H0JQvc6l4HY0tBULNSU|E03zK4t29xyiXlt54kOVpIzNtGytjQSvaHXF8n8tTBs`.
+For the above example keys the info would be:
+`m.rendezvous.v2.curve25519-aes-sha256|gRr3uZSpm2qz37CkqnrhZTW3H0JQvc6l4HY0tBULNSU|E03zK4t29xyiXlt54kOVpIzNtGytjQSvaHXF8n8tTBs`.
 
-**5.** Subsequent payloads are then sent encrypted using 256 bit AES-GCM using a 256 bit random initialisation vector and 128 bit authentication tag.
+**5.** Subsequent payloads are then sent encrypted using 256 bit AES-GCM using a
+256 bit random initialisation vector and 128 bit authentication tag.
 
 **6.** Encrypted payloads are then encoded and transmitted by either party as follows:
 
@@ -70,10 +81,13 @@ For the above example keys the info would be: `m.rendezvous.v2.curve25519-aes-sh
 }
 ```
 
-- `ciphertext` - unpadded base64-encoded(AES-GCM ciphertext concatenated with the authentication tag)
+- `ciphertext` - unpadded base64-encoded(AES-GCM ciphertext concatenated with
+the authentication tag)
 - `iv` - unpadded base64-encoded(initialization vector)
 
-This means that for AES-GCM implementations that require the authentication tag to be explicitly processed (e.g. CryptoKit on iOS) that it can be sourced from the last 16 bytes of the unpadded base64-decoded `ciphertext`.
+This means that for AES-GCM implementations that require the authentication tag
+to be explicitly processed (e.g. CryptoKit on iOS) that it can be sourced from
+the last 16 bytes of the unpadded base64-decoded `ciphertext`.
 
 **7.** The user should authenticate/confirm that the established channel is
 secure by means of a checksum that is shown on both devices.
@@ -81,44 +95,49 @@ secure by means of a checksum that is shown on both devices.
 If the checksum shown is not the same on bothe defives then it means that the
 devices have not directly exchanged keys with one another and are subject to a man-in-the-middle.
 
-The checksum is 12 numeric digits in the form `1234-5678-9012` and should be displayed on both devices for the user to
-visually verify.
+The checksum is 12 numeric digits in the form `1234-5678-9012` and should be
+displayed on both devices for the user to visually verify.
 
-The checksum should be derived in a similar manner to step **4** above, however only 40 bit should be derived this time.
-The salt and info are the same as before.
+The checksum should be derived in a similar manner to step **4** above, however
+only 40 bit should be derived this time. The salt and info are the same as before.
 
-The decimal representation of the 40 bits is calculated using the method described in
-https://spec.matrix.org/v1.4/client-server-api/#sas-method-decimal.
+The decimal representation of the 40 bits is calculated using the method
+described in https://spec.matrix.org/v1.4/client-server-api/#sas-method-decimal.
 
 Steps **1** and **2** can happen simultaneously or in any order.
 
 ## Potential issues
 
-This proposal introduces yet another key that Matrix client implementations need awareness of. It's also not clear to me
-where exactly this would fit in the spec documents.
+This proposal introduces yet another key that Matrix client implementations need
+awareness of. It's also not clear to me where exactly this would fit in the spec
+documents.
 
 ## Alternatives
 
 ### Send-to-Device messaging
 
-Whilst to-device messaging already provides a mechanism for secure communication between two Matrix clients/devices, a
-key consideration for the anticipated login with QR capability is that one of the clients is not yet authenticated with
+Whilst to-device messaging already provides a mechanism for secure communication
+between two Matrix clients/devices, a key consideration for the anticipated
+login with QR capability is that one of the clients is not yet authenticated with
 a Homeserver.
 
-Furthermore the client might not know which Homeserver the user wishes to connect to.
+Furthermore the client might not know which Homeserver the user wishes to
+connect to.
 
-Conceptually, one could create a new type of "guest" login that would allow the unauthenticated client to connect to a
-Homeserver for the purposes of communicating with an existing authenticated client via to-device messages.
+Conceptually, one could create a new type of "guest" login that would allow the
+unauthenticated client to connect to a Homeserver for the purposes of
+communicating with an existing authenticated client via to-device messages.
 
 Some considerations for this:
 
-Where the "actual" Homeserver is not known then the "guest" Homeserver nominated by the new client would need to be federated
-with the "actual" Homeserver.
+Where the "actual" Homeserver is not known then the "guest" Homeserver nominated
+by the new client would need to be federated with the "actual" Homeserver.
 
-The "guest" Homeserver would probably want to automatically clean up the "guest" accounts after a short period of time.
+The "guest" Homeserver would probably want to automatically clean up the "guest"
+accounts after a short period of time.
 
-The "actual" Homeserver operator might not want to open up full "guest" access so a second type of "guest" account might
-be required.
+The "actual" Homeserver operator might not want to open up full "guest" access
+so a second type of "guest" account might be required.
 
 Does the new device/client need to accept the T&Cs of the "guest" Homeserver?
 
@@ -126,10 +145,12 @@ Does the new device/client need to accept the T&Cs of the "guest" Homeserver?
 
 The algorithm name is arbitrary.
 
-Alternative key exchange algorithms to X25519 could be used. Alternative symmetric ciphers to AES-GCM could be used. The
-purpose of the `algorithm` field is allow for alternative algorithms in the future.
+Alternative key exchange algorithms to X25519 could be used. Alternative
+symmetric ciphers to AES-GCM could be used. The purpose of the `algorithm` field
+is allow for alternative algorithms in the future.
 
-An earlier iteration of this proposal used the algorithm name `m.rendezvous.v1.curve25519-aes-sha256` but that has been superseded.
+An earlier iteration of this proposal used the algorithm name
+`m.rendezvous.v1.curve25519-aes-sha256` but that has been superseded.
 
 ## Security considerations
 
@@ -137,11 +158,14 @@ Algorithm selection and implementation are crucial.
 
 ## Unstable prefix
 
-Whilst in development the unstable algorithm name of `org.matrix.msc3903.rendezvous.v2.curve25519-aes-sha256` should be used.
+Whilst in development the unstable algorithm name of
+`org.matrix.msc3903.rendezvous.v2.curve25519-aes-sha256` should be used.
 
 ## Dependencies
 
-Although this proposal could be used over any communication channel, the anticipated use case is over
-[MSC3886](https://github.com/matrix-org/matrix-spec-proposals/pull/3886).
+Although this proposal could be used over any communication channel, the
+anticipated use case is over [MSC3886](https://github.com/matrix-org/matrix-spec-proposals/pull/3886).
 
-Furthermore without the [MSC3906](https://github.com/matrix-org/matrix-spec-proposals/pull/3906) proposal, there are no other implementations/uses of the proposal.
+Furthermore without the
+[MSC3906](https://github.com/matrix-org/matrix-spec-proposals/pull/3906)
+proposal, there are no other implementations/uses of the proposal.

--- a/proposals/3903-x25519-ecdhe.md
+++ b/proposals/3903-x25519-ecdhe.md
@@ -21,7 +21,9 @@ All payloads are transmitted as JSON and could be done over any bidirectional tr
 [MSC3886](https://github.com/matrix-org/matrix-spec-proposals/pull/3886) or elsewhere in Matrix.
 
 **1a.** The initiator generates a ephemeral Curve25519 private key `privateA`. This key should never be re-used.
+
 **1b.** The initiator derives the public key from `privateA` as `publicA = scalarMult(privateA, 9)`
+
 **1c.** The initiator shares it's key with the recipient via a trusted medium using the following payload:
 
 ```json
@@ -47,6 +49,7 @@ the same structure of payload:
 ```
 
 Unlike `publicA` the recipient public key `publicB` does not need to be transmitted via a trusted medium.
+
 **3.** Both sides derive the same shared secret as follows:
 
 Initiator: `sharedSecret = scalarMult(privateA, publicB) = scalarMult(privateA, scalarMult(privateB, 9))`
@@ -74,8 +77,6 @@ For the above example keys the info would be: `m.rendezvous.v1.curve25519-aes-sh
 
 This means that for AES-GCM implementations that require the authentication tag to be explicitly processed (e.g. CryptoKit on iOS) that it can be sourced from the last 16 bytes of the base64-decoded `ciphertext`.
 
-Steps **1** and **2** can happen simultaneously or in any order.
-
 **7.** The user should confirm that the established channel is secure by means of a checksum derived from the shared key.
 The checksum is 12 numeric digits in the form `1234-5678-9012` and should be displayed on both devices for the user to
 visually verify.
@@ -85,6 +86,8 @@ The salt and info are the same as before.
 
 The decimal representation of the 40 bits is calculated using the method described in
 https://spec.matrix.org/v1.4/client-server-api/#sas-method-decimal.
+
+Steps **1** and **2** can happen simultaneously or in any order.
 
 ## Potential issues
 

--- a/proposals/zzzz-x25519-ecdhe.md
+++ b/proposals/zzzz-x25519-ecdhe.md
@@ -1,0 +1,104 @@
+# MSCzzzz: X25519 Elliptic-curve Diffie-Hellman ephemeral for establishing secure channel between two Matrix clients
+
+In MSCyyyy (to be published) a proposal is made to allow a user to login on a new device using an existing device by
+means of scanning a QR code.
+
+[MSC3886](https://github.com/matrix-org/matrix-spec-proposals/pull/3886) already proposes a simple unsecured rendezvous protocol.
+
+In this proposal we build a secure layer on top of MSC3886 to allow for trusted out-of-bands communication between two
+Matrix clients.
+
+## Proposal
+
+The proposal is to use X25519 to agree a shared secret that is then used to perform AES.
+
+All payloads are transmitted as JSON and could be done over any bidirectional transport including
+[MSC3886](https://github.com/matrix-org/matrix-spec-proposals/pull/3886) or elsewhere in Matrix.
+
+**1a.** The initiator generates a ephemeral Curve25519 private key `privateA`. This key should never be re-used.
+**1b.** The initiator derives the public key from `privateA` as `publicA = scalarMult(privateA, 9)`
+**1c.** The initiator shares it's key with the recipient via a trusted medium using the following payload:
+
+```json
+{
+    "algorithm": "m.rendezvous.v1.curve25519-aes-sha256",
+    "key": "gRr3uZSpm2qz37CkqnrhZTW3H0JQvc6l4HYOtBULNSU="
+}
+```
+
+The `key` is the base64-encoded value for `publicA` (the x co-ordinate of the curve).
+
+It's critical that the initiator public key `publicA` is transmitted via a trusted medium such as a QR code or some other
+already-authenticated channel, and not via the unauthenticated channel.
+
+**2.** The recipient similarly generates a private key `privateB`, derives the public key `publicB` and shares is using
+the same structure of payload:
+
+```json
+{
+    "algorithm": "m.rendezvous.v1.curve25519-aes-sha256",
+    "key": "E03zK4t29xyiXlt54kOVpIzNtGytjQSvaHXF8n8tTBs="
+}
+```
+
+Unlike `publicA` the recipient public key `publicB` does not need to be transmitted via a trusted medium.
+**3.** Both sides derive the same shared secret as follows:
+
+Initiator: `sharedSecret = scalarMult(privateA, publicB) = scalarMult(privateA, scalarMult(privateB, 9))`
+
+Recipient: `sharedSecret = scalarMult(privateB, publicA) = scalarMult(privateB, scalarMult(privateA, 9))`
+
+**4.** Both sides then derive a 256 bit AES key using HKDF SHA-256 with a salt of 8 bytes of zero (i.e. `[0,0,0,0,0,0,0,0]`)
+and info of `<algorithm>|<base64-encoded initiator public key>|<base64-encoded recipient public key>`.
+
+For the above example keys the info would be: `m.rendezvous.v1.curve25519-aes-sha256|gRr3uZSpm2qz37CkqnrhZTW3H0JQvc6l4HYOtBULNSU=|E03zK4t29xyiXlt54kOVpIzNtGytjQSvaHXF8n8tTBs=`.
+
+**5.** Subsequent payloads are then sent encrypted using 256 bit AES-GCM using a 256 bit random initialisation vector/salt.
+
+**6.** Encrypted payloads are then encoded and transmitted by either party as follows:
+
+```json
+{
+    "ciphertext": "L3SHZU2DnfPxiVHVcgqe2HNq7Acdv13XCK/mC5f0JmxGqeUNQdeta8HD8qGBu3YdYrv5Bf7xl8WjlGaUOLr3uceZUuSv8amRZUghZ+/GQsi8tPZLzHk0xOePmKhRg95HUZrja7cQIgw+iKY/Vp1UoUJRqk1iQv/86RHz3c5a/GqyhGyWnXfuy16tPxmNQ4IpI/hVJof+7iiA3IucMtLHZnGH/VpNuZ1kv97GJJbUX3XfTIjyN2jmA9zFP5d/mE10YYzG7XcZ0hWj5BPhpM1jojwVyTRhMseJAX7MVvqQ7HT7LjvoJSYm5xk+0ptsWodAuol7uYjGszIu+EFvpuYmweZa6ewcnf/T5fXb6hXfqCZf43gumrXx5ACUMC4IWBOI0mFE28ITRmw9ZjL2CodxFsbTGRYp3Arb0SMcF1KUsiYBXxLasXFaEtrE244QD+oc9FEWNPLdgCDcwEhalaK9OP7MJF7jXc2y+zOPfUPCdCHoSV6F5Y/MnPkrpwprrIn/yp2E4/4QTe2VTXG7ZJa/aCGh8eAo9nBANQi7sGElr83SU0oy80MvVWUmxnaWc8UDgASkC/dGQNCfZzsZeho0+Y2smcETJlD/7+D1c8YC3LevAtYXDOOO9ApaY+SpPloKp/zdoZdkf+ggGfyytvTEw0gZUygZnBplefaIry9lASpv6XXkowVFFP5kGf0ZAhPOr2ET3DTyoBXP7u7MJrRAtBEex6OaysVaJ2DDEj8JknpdwatuWPduygMt",
+    "iv": "Fk/2eSQ2hANwpQhAI94/BQ=="
+}
+```
+
+- `ciphertext` - base64-encoded AES-GCM encrypted data
+- `iv` - base64-encoded initialization vector/salt
+
+Steps **1** and **2** can happen simultaneously or in any order.
+
+**7.** The user should confirm that the established channel is secure by means of a checksum derived from the shared key.
+The checksum is 12 numeric digits in the form `1234-5678-9012` and should be displayed on both devices for the user to
+visually verify.
+
+The checksum should be derived in a similar manner to step **4** above, however only 40 bit should be derived this time.
+The salt and info are the same as before.
+
+The decimal representation of the 40 bits is calculated using the method described in
+https://spec.matrix.org/v1.4/client-server-api/#sas-method-decimal.
+
+## Potential issues
+
+This proposal introduces yet another key that Matrix client implementations need awareness of. It's also not clear to me
+where exactly this would fit in the spec documents.
+
+## Alternatives
+
+The algorithm name is arbitrary.
+
+Alternative key exchange algorithms to X25519 could be used. Alternative symmetric ciphers to AES-GCM could be used. The
+purpose of the `algorithm` field is allow for alternative algorithms in the future.
+
+## Security considerations
+
+Algorithm selection and implementation are crucial.
+
+## Unstable prefix
+
+TBD
+
+## Dependencies
+
+None.


### PR DESCRIPTION
[Rendered](https://github.com/matrix-org/matrix-spec-proposals/blob/hughns/x25519-secure-channel/proposals/3903-x25519-ecdhe.md)

- Clients:
   - [x] Element Web: https://github.com/matrix-org/matrix-js-sdk/pull/2747
   - [x] Element iOS: https://github.com/vector-im/element-ios/pull/6806
   - [x] Element Android: https://github.com/vector-im/element-android/pull/7369