### PR TITLE
MSC3916: Authentication for media

### DIFF
--- a/proposals/3916-authentication-for-media.md
+++ b/proposals/3916-authentication-for-media.md
@@ -1,7 +1,7 @@
 # MSC3916: Authentication for media access, and new endpoint names
 
 Currently, access to media in Matrix has a number of problems including the following:
- 
+
 * The only protection for media is the obscurity of the URL, and URLs are
   easily leaked (eg accidental sharing, access
   logs). [synapse#2150](https://github.com/matrix-org/synapse/issues/2150)
@@ -46,6 +46,12 @@ This proposal supersedes [MSC1902](https://github.com/matrix-org/matrix-spec-pro
    is **not** modified by this MSC: it is intended that it be brought into line with the other
    endpoints by a future MSC, such as [MSC3911](https://github.com/matrix-org/matrix-spec-proposals/pull/3911).
 
+   After this proposal is released in a stable version of the specification, servers
+   which support the new `download` and `thumbnail` endpoints should cease to serve
+   newly uploaded media from the unauthenticated versions. This includes media
+   uploaded by local users and requests for not-yet-cached remote media. This is
+   done with a 404 `M_NOT_FOUND` error, as though the media doesn't exist.
+
 2. Removal of `allow_remote` parameter from `/download`
 
    The current
@@ -63,7 +69,7 @@ This proposal supersedes [MSC1902](https://github.com/matrix-org/matrix-spec-pro
 
    `/_matrix/client/v1/media/download` and
    `/_matrix/client/v1/media/thumbnail` should return remote media as normal.
-   
+
 3. Authentication on all endpoints
 
    Currently, the `/download` and `/thumbnail` endpoints have no authentication
@@ -103,14 +109,14 @@ This proposal supersedes [MSC1902](https://github.com/matrix-org/matrix-spec-pro
 
      --gc0p4Jq0M2Yt08jU534c0p
      ```
-     
+
 5. Backwards compatibility mechanisms
 
    a. Backwards compatibility with older servers: if a client or requesting
    server receives a 404 error with a non-JSON response, or a 400 or 404 error with
    `{"errcode": "M_UNRECOGNIZED"}`, in response to a request to one of the new
    endpoints, they may retry the request using the original endpoint.
-   
+
    b. Backwards compatibility with older clients and federating servers:
    servers may for a short time choose to allow unauthenticated access via the
    deprecated endpoints.
@@ -193,7 +199,7 @@ specifically for access to these icon.
   the proportion of clients which have been updated, and it is a good
   opportunity to bring these endpoints into line with the rest of the
   client-server and federation APIs.
-  
+
 * There's no real need to rename `GET /_matrix/media/v3/preview_url` and `GET
   /_matrix/media/v3/config` at present, and we could just leave them in
   place. However, changing them at the same time makes the API more consistent.

--- a/proposals/3916-authentication-for-media.md
+++ b/proposals/3916-authentication-for-media.md
@@ -52,11 +52,6 @@ This proposal supersedes [MSC1902](https://github.com/matrix-org/matrix-spec-pro
    no servers request thumbnails over federation, and so it is not supported here.
    A later MSC may introduce such an endpoint.
 
-   The new `/download` and `/thumbnail` endpoints additionally drop the `?allow_redirect`
-   query parameters. Instead, the endpoints behave as though `allow_redirect=true` was
-   set, regardless of actual value. See [this comment on MSC3860](https://github.com/matrix-org/matrix-spec-proposals/pull/3860/files#r1005176480)
-   for details.
-
    After this proposal is released in a stable version of the specification, servers
    which support the new `download` and `thumbnail` endpoints SHOULD cease to serve
    newly uploaded media from the unauthenticated versions. This includes media
@@ -190,6 +185,9 @@ This proposal supersedes [MSC1902](https://github.com/matrix-org/matrix-spec-pro
    API `/download` endpoint. Servers MUST NOT respond with a 307 or 308 redirect at
    the top level for the endpoint - they can only redirect within the media part
    itself.
+
+   See [this comment on MSC3860](https://github.com/matrix-org/matrix-spec-proposals/pull/3860/files#r1005176480)
+   for further context on this change.
 
 ### Effects on client applications
 

--- a/proposals/3916-authentication-for-media.md
+++ b/proposals/3916-authentication-for-media.md
@@ -45,9 +45,8 @@ This proposal supersedes [MSC1902](https://github.com/matrix-org/matrix-spec-pro
    | [`GET /_matrix/media/v1/create`](https://spec.matrix.org/v1.10/client-server-api/#post_matrixmediav1create) | `GET /_matrix/client/v1/media/create` | - |
 
    **Note**: [`POST /_matrix/media/v3/upload`](https://spec.matrix.org/v1.6/client-server-api/#post_matrixmediav3upload)
-   is **not** modified by this MSC: it is intended that it be brought into line with the other
+   is **not** modified or deprecated by this MSC: it is intended that it be brought into line with the other
    endpoints by a future MSC, such as [MSC3911](https://github.com/matrix-org/matrix-spec-proposals/pull/3911).
-   It is subsequently **not** deprecated either.
 
    **Note**: `/thumbnail` does not have a federation endpoint. It appears as though
    no servers request thumbnails over federation, and so it is not supported here.

--- a/proposals/3916-authentication-for-media.md
+++ b/proposals/3916-authentication-for-media.md
@@ -258,11 +258,12 @@ This support would come from a different MSC.
   place. However, changing them at the same time makes the API more consistent.
 
   Conversely, we should make sure to rename `POST
-  /_matrix/media/v3/upload`. The reason to delay doing so is because MSC3911
-  will make more substantial changes to this endpoint, requiring another
-  rename, and it is expected that both proposals will be mergeed near to the same
-  time as each other (so a double rename will be confusing and unnecessary). However,
-  if MSC3911 is delayed or rejected, we should reconsider this.
+  /_matrix/media/v3/upload` and `GET /_matrix/media/v3/create`. The reason to
+  delay doing so is because MSC3911 will make more substantial changes to these
+  endpoints, requiring another rename, and it is expected that both proposals
+  will be mergeed near to the same time as each other (so a double rename will
+  be confusing and unnecessary). However, if MSC3911 is delayed or rejected, we
+  should reconsider this.
 
 * Rather than messing with multipart content, have a separate endpoint for
   servers to get the metadata for a media item. That would mean two requests,

--- a/proposals/3916-authentication-for-media.md
+++ b/proposals/3916-authentication-for-media.md
@@ -303,7 +303,7 @@ This support would come from a different MSC.
   /_matrix/media/v3/upload` and `GET /_matrix/media/v3/create`. The reason to
   delay doing so is because MSC3911 will make more substantial changes to these
   endpoints, requiring another rename, and it is expected that both proposals
-  will be mergeed near to the same time as each other (so a double rename will
+  will be merged near to the same time as each other (so a double rename will
   be confusing and unnecessary). However, if MSC3911 is delayed or rejected, we
   should reconsider this.
 

--- a/proposals/3916-authentication-for-media.md
+++ b/proposals/3916-authentication-for-media.md
@@ -36,22 +36,22 @@ This proposal supersedes [MSC1902](https://github.com/matrix-org/matrix-spec-pro
 
    | Old                                                                                                                                                              | Client-Server                                                             | Federation                                                          |
    | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------- |
-   | [`GET /_matrix/media/v3/preview_url`](https://spec.matrix.org/v1.4/client-server-api/#get_matrixmediav3preview_url) | `GET /_matrix/client/v1/media/preview_url` | - |
-   | [`GET /_matrix/media/v3/config`](https://spec.matrix.org/v1.4/client-server-api/#get_matrixmediav3config) | `GET /_matrix/client/v1/media/config` | - |
-   | [`GET /_matrix/media/v3/download/{serverName}/{mediaId}`](https://spec.matrix.org/v1.4/client-server-api/#get_matrixmediav3downloadservernamemediaid)            | `GET /_matrix/client/v1/media/download/{serverName}/{mediaId}`            | `GET /_matrix/federation/v1/media/download/{serverName}/{mediaId}`  |
-   | [`GET /_matrix/media/v3/download/{serverName}/{mediaId}/{fileName}`](https://spec.matrix.org/v1.4/client-server-api/#get_matrixmediav3downloadservernamemediaidfilename) | `GET /_matrix/client/v1/media/download/{serverName}/{mediaId}/{fileName}` | -                                                                 |
-   | [`GET /_matrix/media/v3/thumbnail/{serverName}/{mediaId}`](https://spec.matrix.org/v1.4/client-server-api/#get_matrixmediav3thumbnailservernamemediaid)          | `GET /_matrix/client/v1/media/thumbnail/{serverName}/{mediaId}`           | `GET /_matrix/federation/v1/media/thumbnail/{serverName}/{mediaId}` |
+   | [`GET /_matrix/media/v3/preview_url`](https://spec.matrix.org/v1.6/client-server-api/#get_matrixmediav3preview_url) | `GET /_matrix/client/v1/media/preview_url` | - |
+   | [`GET /_matrix/media/v3/config`](https://spec.matrix.org/v1.6/client-server-api/#get_matrixmediav3config) | `GET /_matrix/client/v1/media/config` | - |
+   | [`GET /_matrix/media/v3/download/{serverName}/{mediaId}`](https://spec.matrix.org/v1.6/client-server-api/#get_matrixmediav3downloadservernamemediaid)            | `GET /_matrix/client/v1/media/download/{serverName}/{mediaId}`            | `GET /_matrix/federation/v1/media/download/{serverName}/{mediaId}`  |
+   | [`GET /_matrix/media/v3/download/{serverName}/{mediaId}/{fileName}`](https://spec.matrix.org/v1.6/client-server-api/#get_matrixmediav3downloadservernamemediaidfilename) | `GET /_matrix/client/v1/media/download/{serverName}/{mediaId}/{fileName}` | -                                                                 |
+   | [`GET /_matrix/media/v3/thumbnail/{serverName}/{mediaId}`](https://spec.matrix.org/v1.6/client-server-api/#get_matrixmediav3thumbnailservernamemediaid)          | `GET /_matrix/client/v1/media/thumbnail/{serverName}/{mediaId}`           | `GET /_matrix/federation/v1/media/thumbnail/{serverName}/{mediaId}` |
 
-   **Note**: [`POST /_matrix/media/v3/upload`](https://spec.matrix.org/v1.4/client-server-api/#post_matrixmediav3upload)
+   **Note**: [`POST /_matrix/media/v3/upload`](https://spec.matrix.org/v1.6/client-server-api/#post_matrixmediav3upload)
    is **not** modified by this MSC: it is intended that it be brought into line with the other
    endpoints by a future MSC, such as [MSC3911](https://github.com/matrix-org/matrix-spec-proposals/pull/3911).
 
 2. Removal of `allow_remote` parameter from `/download`
 
    The current
-   [`/download`](https://spec.matrix.org/v1.4/client-server-api/#get_matrixmediav3downloadservernamemediaid)
+   [`/download`](https://spec.matrix.org/v1.6/client-server-api/#get_matrixmediav3downloadservernamemediaid)
    and
-   [`/thumbnail`]((https://spec.matrix.org/v1.4/client-server-api/#get_matrixmediav3thumbnailservernamemediaid)
+   [`/thumbnail`](https://spec.matrix.org/v1.6/client-server-api/#get_matrixmediav3thumbnailservernamemediaid)
    endpoints take an `allow_remote` query parameter, indicating whether the
    server should request remote media from other servers. This is redundant
    with the new endpoints, so will not be supported.

--- a/proposals/3916-authentication-for-media.md
+++ b/proposals/3916-authentication-for-media.md
@@ -1,0 +1,224 @@
+# MSC3916: Authentication for media access, and new endpoint names
+
+Currently, access to media in Matrix has a number of problems including the following:
+ 
+* The only protection for media is the obscurity of the URL, and URLs are
+  easily leaked (eg accidental sharing, access
+  logs). [synapse#2150](https://github.com/matrix-org/synapse/issues/2150)
+* Anybody (including non-matrix users) can cause a homeserver to copy media
+  into its local
+  store. [synapse#2133](https://github.com/matrix-org/synapse/issues/2133)
+* When a media event is redacted, the media it used remains visible to all.
+  [synapse#1263](https://github.com/matrix-org/synapse/issues/1263)
+* There is currently no way to delete
+  media. [matrix-spec#226](https://github.com/matrix-org/matrix-spec/issues/226)
+* If a user requests GDPR erasure, their media remains visible to all.
+* When all users leave a room, their media is not deleted from the server.
+
+These problems are all difficult to address currently, because access to media
+is entirely unauthenticated. The first step for a solution is to require user
+authentication. Once that is done, it will be possible to impose authorization
+requirements to address the problems mentioned above. (See, for example,
+[MSC3911](https://github.com/matrix-org/matrix-spec-proposals/pull/3911) which
+builds on top of this MSC.)
+
+This proposal supercedes [MSC1902](https://github.com/matrix-org/matrix-spec-proposals/pull/1902).
+
+## Proposal
+
+1. New endpoints
+
+   The existing `/_matrix/media/v3/` endpoints are to be deprecated, and replaced
+   by new endpoints under the `/_matrix/client` and `/_matrix/federation`
+   hierarchies.
+
+   The table below shows a mapping between old and new endpoint:
+
+   | Old                                                                                                                                                              | Client-Server                                                             | Federation                                                          |
+   | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+   | [`GET /_matrix/media/v3/preview_url`](https://spec.matrix.org/v1.4/client-server-api/#get_matrixmediav3preview_url) | `GET /_matrix/client/v1/media/preview_url` | - |
+   | [`GET /_matrix/media/v3/config`](https://spec.matrix.org/v1.4/client-server-api/#get_matrixmediav3config) | `GET /_matrix/client/v1/media/config` | - |
+   | [`GET /_matrix/media/v3/download/{serverName}/{mediaId}`](https://spec.matrix.org/v1.4/client-server-api/#get_matrixmediav3downloadservernamemediaid)            | `GET /_matrix/client/v1/media/download/{serverName}/{mediaId}`            | `GET /_matrix/federation/v1/media/download/{serverName}/{mediaId}`  |
+   | [`GET /_matrix/media/v3/download/{serverName}/{mediaId}/{fileName}`](https://spec.matrix.org/v1.4/client-server-api/#get_matrixmediav3downloadservernamemediaidfilename) | `GET /_matrix/client/v1/media/download/{serverName}/{mediaId}/{fileName}` | -                                                                 |
+   | [`GET /_matrix/media/v3/thumbnail/{serverName}/{mediaId}`](https://spec.matrix.org/v1.4/client-server-api/#get_matrixmediav3thumbnailservernamemediaid)          | `GET /_matrix/client/v1/media/thumbnail/{serverName}/{mediaId}`           | `GET /_matrix/federation/v1/media/thumbnail/{serverName}/{mediaId}` |
+
+   **Note**: [`POST /_matrix/media/v3/upload`](https://spec.matrix.org/v1.4/client-server-api/#post_matrixmediav3upload)
+   is **not** modified by this MSC: it is intended that it be brought into line with the other
+   endpoints by a future MSC, such as [[MSC3911](https://github.com/matrix-org/matrix-spec-proposals/pull/3911).
+
+2. Removal of `allow_remote` parameter from `/download`
+
+   The current `/download` and `/thumbnail` enpoints take an `allow_remote`
+   query parameter, indicating whether the server should request remote media
+   from other servers. This is redundant with the new endpoints, so will not be
+   supported.
+
+   Servers should never return remote media from `GET
+   /_matrix/federation/v1/media/download` or `GET
+   /_matrix/federation/v1/media/thumbnail`; indeed, the `serverName` is
+   included in the URI only for consistency with the CS-API.
+
+   `/_matrix/client/v1/media/download/` and
+   `/_matrix/client/v1/media/thumnbnail` should return remote media as normal.
+   
+3. Authentication on all endpoints
+
+   Currently, the `/download` and `/thumbnail` endpoints have no authentication
+   requirements. Under this proposal, the new endpoints will be authenticated
+   the same way as other endpoints: they will require an `Authorization` header
+   which must be `Bearer {accessToken}` for `/_matrix/client`, or the signature
+   for `/_matrix/federation`.
+
+4. Updated response format
+
+   * For the new `/_matrix/client` endpoints, the response format is the same as
+     the corresponding original endpoints.
+
+   * To enable future expansion, for the new `/_matrix/federation` endpoints,
+     the response is
+     [`multipart/mixed`](https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html)
+     content with two parts: the first must be a JSON object (and should have a
+     `Content-type: application/json` header), and the second is the media item
+     as per the original endpoints.
+
+     No properties are yet specified for the JSON object to be returned.
+
+     An example response:
+
+     ```
+     Content-Type: multipart/mixed; boundary=gc0p4Jq0M2Yt08jU534c0p
+
+     --gc0p4Jq0M2Yt08jU534c0p
+     Content-Type: application/json
+
+     {}
+
+     --gc0p4Jq0M2Yt08jU534c0p
+     Content-Type: text/plain
+
+     This media is plain text. Maybe somebody used it as a paste bin.
+
+     --gc0p4Jq0M2Yt08jU534c0p
+     ```
+     
+5. Backwards compatibility mechanisms
+
+   a. Backwards compatibility with older servers: if a client or requesting
+   server receives a 404 error with a non-JSON response, or a 400 or 404 error with
+   `{"errcode": "M_UNRECOGNIZED"}`, in response to a request to one of the new
+   endpoints, they may retry the request using the original endpoint.
+   
+   b. Backwards compatibility with older clients and federating servers:
+   servers may for a short time choose to allow unauthenticated access via the
+   deprecated endpoints.
+
+### Effects on client applications
+
+Naturally, implementations will be required to provide `Authorization` headers
+when accessing the new endpoints. This will be simple in some cases, but rather
+more involved in others. This section considers some of those cases.
+
+#### IRC/XMPP bridges
+
+Possibly the largest impact will be on IRC and XMPP bridges.  Since IRC and
+XMPP have no media repository of their own, these bridges currently transform
+`mxc:` URIs into `https://<server>/_matrix/media/v3/download/` URIs and forward
+those links to the remote platform. This will no longer be a viable option.
+
+One potential solution is for the bridges to provide a proxy.
+
+In this scenario, the bridge would have a secret HMAC key. When it
+receives a matrix event referencing a piece of media, it should create a new URI
+referencing the media, include an HMAC to prevent tampering. For example:
+
+```
+https://<bridge_server>/media/{originServerName}/{mediaId}?mac={hmac}
+```
+
+When the bridge later receives a request to that URI, it checks the hmac,
+and proxies the request to the homeserver, using its AS access
+token in the `Authorization` header.
+
+The bridge might also choose to embed information such as the room that
+referenced the media, and the time that the link was generated, in the URL.
+Such mechanisms would allow the bridge to impose controls such as:
+
+* Limiting the time a media link is valid for. Doing so would help prevent
+  visibility to users who weren't participating in the chat.
+
+* Rate-limiting the amount of media being shared in a particular room (in other
+  words, avoiding the use of Matrix as a Warez distribution system).
+
+#### Icons for "social login" flows
+
+When a server supports multiple login providers, it provides the client with
+icons for the login providers as `mxc:` media URIs. These must be accessible
+without authentication (because the client has no access token at the time the
+icons are displayed).
+
+This remains a somewhat unsolved problem. Possibly the clients can continue
+to call the legacy `/_matrix/media/v3/download` URI for now: ultimately this
+problem will be solved by the transition to OIDC. Alternatively, we may need
+to provide an alternative `/_matrix/client/v3/login/sso/icon/{idpId}` API
+specifically for access to these icon.
+
+(This was previously discussed in
+[MSC2858](https://github.com/matrix-org/matrix-spec-proposals/pull/2858#discussion_r543513811).)
+
+## Potential issues
+
+* Setting the `Authorization` header is going to be annoying for web clients. Service workers
+  might be needed.
+
+* Users will be unable to copy links to media from web clients to share out of
+  band. This is considered a feature, not a bug.
+
+## Alternatives
+
+* Allow clients to upload media which does not require authentication (for
+  example via a `public=true` query parameter). This might be particularly
+  useful for IRC/XMPP bridges, which could upload any media they encounter to
+  the homeserver's repository.
+
+  The danger with this is that is that there's little stopping clients
+  continuing to upload media as "public", negating all of the benefits in this
+  MSC. It might be ok if media upload it was restricted to certain privileged
+  users.
+
+* We could simply require that `Authorization` headers be given when calling
+  the existing endpoints. However, doing so would make it harder to evaluate
+  the proportion of clients which have been updated, and it is a good
+  opportunity to bring these endpoints into line with the rest of the
+  client-server and federation APIs.
+  
+* There's no real need to rename `GET /_matrix/media/v3/preview_url` and `GET
+  /_matrix/media/v3/config` at present, and we could just leave them in
+  place. However, changing them at the same time makes the API more consistent.
+
+  Conversely, we should make sure to rename `POST
+  /_matrix/media/v3/upload`. The reason to delay doing so is because MSC3911
+  will make more substantial changes to this endpoint, requiring another
+  rename, and it is expected that both proposals will be mergeed at the same
+  time (so a double rename will be confusing and unnecessary). However, if
+  MSC3911 is delayed or rejected, we should reconsider this.
+
+* Rather than messing with multipart content, have a separate endpoint for
+  servers to get the metadata for a media item. That would mean two requests,
+  but might make more sense than both `/thumbnail` and `/download` providing
+  the info.
+
+## Unstable prefix
+
+While this proposal is in development, the new endpoints should be named as follows:
+
+* GET /_matrix/client/unstable/org.matrix.msc3916/media/preview_url
+* GET /_matrix/client/unstable/org.matrix.msc3916/media/config
+* GET /_matrix/client/unstable/org.matrix.msc3916/media/download/{serverName}/{mediaId}
+* GET /_matrix/client/unstable/org.matrix.msc3916/media/download/{serverName}/{mediaId}/{fileName}
+* GET /_matrix/client/unstable/org.matrix.msc3916/media/thumbnail/{serverName}/{mediaId}
+* GET /_matrix/federation/unstable/org.matrix.msc3916/media/download/{serverName}/{mediaId}
+* GET /_matrix/federation/unstable/org.matrix.msc3916/media/thumbnail/{serverName}/{mediaId}
+
+## Dependencies
+
+None at present.

--- a/proposals/3916-authentication-for-media.md
+++ b/proposals/3916-authentication-for-media.md
@@ -44,7 +44,7 @@ This proposal supersedes [MSC1902](https://github.com/matrix-org/matrix-spec-pro
    | [`GET /_matrix/media/v3/thumbnail/{serverName}/{mediaId}`](https://spec.matrix.org/v1.6/client-server-api/#get_matrixmediav3thumbnailservernamemediaid)          | `GET /_matrix/client/v1/media/thumbnail/{serverName}/{mediaId}`           | - |
 
    **Note**: [`POST /_matrix/media/v3/upload`](https://spec.matrix.org/v1.6/client-server-api/#post_matrixmediav3upload)
-   and [`GET /_matrix/media/v1/create`](https://spec.matrix.org/v1.10/client-server-api/#post_matrixmediav1create)
+   and [`POST /_matrix/media/v1/create`](https://spec.matrix.org/v1.10/client-server-api/#post_matrixmediav1create)
    are **not** modified or deprecated by this MSC: it is intended that they be brought into line with the other
    endpoints by a future MSC, such as [MSC3911](https://github.com/matrix-org/matrix-spec-proposals/pull/3911).
 

--- a/proposals/3916-authentication-for-media.md
+++ b/proposals/3916-authentication-for-media.md
@@ -92,8 +92,10 @@ This proposal supersedes [MSC1902](https://github.com/matrix-org/matrix-spec-pro
      the response is
      [`multipart/mixed`](https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html)
      content with exactly two parts: the first MUST be a JSON object (and should have a
-     `Content-type: application/json` header), and the second MUST be the media item
-     as per the original endpoints.
+     `Content-type: application/json` header), and the second MUST be the media item.
+     The media item may be served inline, as shown in the first example below, or
+     be a pointer to a URL containing the media item's bytes instead, represented
+     by the `Location` header described further below.
 
      No properties are yet specified for the JSON object to be returned. One
      possible use is described by [MSC3911](https://github.com/matrix-org/matrix-spec-proposals/pull/3911).
@@ -127,6 +129,11 @@ This proposal supersedes [MSC1902](https://github.com/matrix-org/matrix-spec-pro
      typically be served by a CDN or other non-matrix server (thus being unable
      to verify any `X-Matrix` signatures, for example).
 
+     Note that all other headers besides `Location` for the media item part are
+     ignored when `Location` is present. The `Content-Type`, `Content-Disposition`,
+     etc headers will be served from the `Location`'s URL instead. Similarly,
+     the body for the media item part is ignored and SHOULD be empty.
+
      An example response with a `Location` redirect would be:
 
      ```
@@ -138,16 +145,17 @@ This proposal supersedes [MSC1902](https://github.com/matrix-org/matrix-spec-pro
      {}
 
      --gc0p4Jq0M2Yt08jU534c0p
-     Content-Type: text/plain
      Location: https://cdn.example.org/ab/c1/2345.txt
 
      --gc0p4Jq0M2Yt08jU534c0p
      ```
 
      If the server were to `curl https://cdn.example.org/ab/c1/2345.txt`, it'd
-     get:
+     get something similar to the following:
 
      ```
+     Content-Type: text/plain
+
      This media is plain text. Maybe somebody used it as a paste bin.
      ```
 

--- a/proposals/3916-authentication-for-media.md
+++ b/proposals/3916-authentication-for-media.md
@@ -42,10 +42,10 @@ This proposal supersedes [MSC1902](https://github.com/matrix-org/matrix-spec-pro
    | [`GET /_matrix/media/v3/download/{serverName}/{mediaId}`](https://spec.matrix.org/v1.6/client-server-api/#get_matrixmediav3downloadservernamemediaid)            | `GET /_matrix/client/v1/media/download/{serverName}/{mediaId}`            | `GET /_matrix/federation/v1/media/download/{mediaId}`  |
    | [`GET /_matrix/media/v3/download/{serverName}/{mediaId}/{fileName}`](https://spec.matrix.org/v1.6/client-server-api/#get_matrixmediav3downloadservernamemediaidfilename) | `GET /_matrix/client/v1/media/download/{serverName}/{mediaId}/{fileName}` | -                                                                 |
    | [`GET /_matrix/media/v3/thumbnail/{serverName}/{mediaId}`](https://spec.matrix.org/v1.6/client-server-api/#get_matrixmediav3thumbnailservernamemediaid)          | `GET /_matrix/client/v1/media/thumbnail/{serverName}/{mediaId}`           | - |
-   | [`GET /_matrix/media/v1/create`](https://spec.matrix.org/v1.10/client-server-api/#post_matrixmediav1create) | `GET /_matrix/client/v1/media/create` | - |
 
    **Note**: [`POST /_matrix/media/v3/upload`](https://spec.matrix.org/v1.6/client-server-api/#post_matrixmediav3upload)
-   is **not** modified or deprecated by this MSC: it is intended that it be brought into line with the other
+   and [`GET /_matrix/media/v1/create`](https://spec.matrix.org/v1.10/client-server-api/#post_matrixmediav1create)
+   are **not** modified or deprecated by this MSC: it is intended that it be brought into line with the other
    endpoints by a future MSC, such as [MSC3911](https://github.com/matrix-org/matrix-spec-proposals/pull/3911).
 
    **Note**: `/thumbnail` does not have a federation endpoint. It appears as though

--- a/proposals/3916-authentication-for-media.md
+++ b/proposals/3916-authentication-for-media.md
@@ -42,6 +42,7 @@ This proposal supersedes [MSC1902](https://github.com/matrix-org/matrix-spec-pro
    | [`GET /_matrix/media/v3/download/{serverName}/{mediaId}`](https://spec.matrix.org/v1.6/client-server-api/#get_matrixmediav3downloadservernamemediaid)            | `GET /_matrix/client/v1/media/download/{serverName}/{mediaId}`            | `GET /_matrix/federation/v1/media/download/{serverName}/{mediaId}`  |
    | [`GET /_matrix/media/v3/download/{serverName}/{mediaId}/{fileName}`](https://spec.matrix.org/v1.6/client-server-api/#get_matrixmediav3downloadservernamemediaidfilename) | `GET /_matrix/client/v1/media/download/{serverName}/{mediaId}/{fileName}` | -                                                                 |
    | [`GET /_matrix/media/v3/thumbnail/{serverName}/{mediaId}`](https://spec.matrix.org/v1.6/client-server-api/#get_matrixmediav3thumbnailservernamemediaid)          | `GET /_matrix/client/v1/media/thumbnail/{serverName}/{mediaId}`           | - |
+   | [`GET /_matrix/media/v1/create`](https://spec.matrix.org/v1.10/client-server-api/#post_matrixmediav1create) | `GET /_matrix/client/v1/media/create` | - |
 
    **Note**: [`POST /_matrix/media/v3/upload`](https://spec.matrix.org/v1.6/client-server-api/#post_matrixmediav3upload)
    is **not** modified by this MSC: it is intended that it be brought into line with the other

--- a/proposals/3916-authentication-for-media.md
+++ b/proposals/3916-authentication-for-media.md
@@ -22,7 +22,7 @@ requirements to address the problems mentioned above. (See, for example,
 [MSC3911](https://github.com/matrix-org/matrix-spec-proposals/pull/3911) which
 builds on top of this MSC.)
 
-This proposal supercedes [MSC1902](https://github.com/matrix-org/matrix-spec-proposals/pull/1902).
+This proposal supersedes [MSC1902](https://github.com/matrix-org/matrix-spec-proposals/pull/1902).
 
 ## Proposal
 
@@ -44,22 +44,25 @@ This proposal supercedes [MSC1902](https://github.com/matrix-org/matrix-spec-pro
 
    **Note**: [`POST /_matrix/media/v3/upload`](https://spec.matrix.org/v1.4/client-server-api/#post_matrixmediav3upload)
    is **not** modified by this MSC: it is intended that it be brought into line with the other
-   endpoints by a future MSC, such as [[MSC3911](https://github.com/matrix-org/matrix-spec-proposals/pull/3911).
+   endpoints by a future MSC, such as [MSC3911](https://github.com/matrix-org/matrix-spec-proposals/pull/3911).
 
 2. Removal of `allow_remote` parameter from `/download`
 
-   The current `/download` and `/thumbnail` enpoints take an `allow_remote`
-   query parameter, indicating whether the server should request remote media
-   from other servers. This is redundant with the new endpoints, so will not be
-   supported.
+   The current
+   [`/download`](https://spec.matrix.org/v1.4/client-server-api/#get_matrixmediav3downloadservernamemediaid)
+   and
+   [`/thumbnail`]((https://spec.matrix.org/v1.4/client-server-api/#get_matrixmediav3thumbnailservernamemediaid)
+   endpoints take an `allow_remote` query parameter, indicating whether the
+   server should request remote media from other servers. This is redundant
+   with the new endpoints, so will not be supported.
 
    Servers should never return remote media from `GET
    /_matrix/federation/v1/media/download` or `GET
    /_matrix/federation/v1/media/thumbnail`; indeed, the `serverName` is
    included in the URI only for consistency with the CS-API.
 
-   `/_matrix/client/v1/media/download/` and
-   `/_matrix/client/v1/media/thumnbnail` should return remote media as normal.
+   `/_matrix/client/v1/media/download` and
+   `/_matrix/client/v1/media/thumbnail` should return remote media as normal.
    
 3. Authentication on all endpoints
 
@@ -211,13 +214,13 @@ specifically for access to these icon.
 
 While this proposal is in development, the new endpoints should be named as follows:
 
-* GET /_matrix/client/unstable/org.matrix.msc3916/media/preview_url
-* GET /_matrix/client/unstable/org.matrix.msc3916/media/config
-* GET /_matrix/client/unstable/org.matrix.msc3916/media/download/{serverName}/{mediaId}
-* GET /_matrix/client/unstable/org.matrix.msc3916/media/download/{serverName}/{mediaId}/{fileName}
-* GET /_matrix/client/unstable/org.matrix.msc3916/media/thumbnail/{serverName}/{mediaId}
-* GET /_matrix/federation/unstable/org.matrix.msc3916/media/download/{serverName}/{mediaId}
-* GET /_matrix/federation/unstable/org.matrix.msc3916/media/thumbnail/{serverName}/{mediaId}
+* `GET /_matrix/client/unstable/org.matrix.msc3916/media/preview_url`
+* `GET /_matrix/client/unstable/org.matrix.msc3916/media/config`
+* `GET /_matrix/client/unstable/org.matrix.msc3916/media/download/{serverName}/{mediaId}`
+* `GET /_matrix/client/unstable/org.matrix.msc3916/media/download/{serverName}/{mediaId}/{fileName}`
+* `GET /_matrix/client/unstable/org.matrix.msc3916/media/thumbnail/{serverName}/{mediaId}`
+* `GET /_matrix/federation/unstable/org.matrix.msc3916/media/download/{serverName}/{mediaId}`
+* `GET /_matrix/federation/unstable/org.matrix.msc3916/media/thumbnail/{serverName}/{mediaId}`
 
 ## Dependencies
 

--- a/proposals/3916-authentication-for-media.md
+++ b/proposals/3916-authentication-for-media.md
@@ -39,7 +39,7 @@ This proposal supersedes [MSC1902](https://github.com/matrix-org/matrix-spec-pro
    | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------- |
    | [`GET /_matrix/media/v3/preview_url`](https://spec.matrix.org/v1.6/client-server-api/#get_matrixmediav3preview_url) | `GET /_matrix/client/v1/media/preview_url` | - |
    | [`GET /_matrix/media/v3/config`](https://spec.matrix.org/v1.6/client-server-api/#get_matrixmediav3config) | `GET /_matrix/client/v1/media/config` | - |
-   | [`GET /_matrix/media/v3/download/{serverName}/{mediaId}`](https://spec.matrix.org/v1.6/client-server-api/#get_matrixmediav3downloadservernamemediaid)            | `GET /_matrix/client/v1/media/download/{serverName}/{mediaId}`            | `GET /_matrix/federation/v1/media/download/{serverName}/{mediaId}`  |
+   | [`GET /_matrix/media/v3/download/{serverName}/{mediaId}`](https://spec.matrix.org/v1.6/client-server-api/#get_matrixmediav3downloadservernamemediaid)            | `GET /_matrix/client/v1/media/download/{serverName}/{mediaId}`            | `GET /_matrix/federation/v1/media/download/{mediaId}`  |
    | [`GET /_matrix/media/v3/download/{serverName}/{mediaId}/{fileName}`](https://spec.matrix.org/v1.6/client-server-api/#get_matrixmediav3downloadservernamemediaidfilename) | `GET /_matrix/client/v1/media/download/{serverName}/{mediaId}/{fileName}` | -                                                                 |
    | [`GET /_matrix/media/v3/thumbnail/{serverName}/{mediaId}`](https://spec.matrix.org/v1.6/client-server-api/#get_matrixmediav3thumbnailservernamemediaid)          | `GET /_matrix/client/v1/media/thumbnail/{serverName}/{mediaId}`           | - |
    | [`GET /_matrix/media/v1/create`](https://spec.matrix.org/v1.10/client-server-api/#post_matrixmediav1create) | `GET /_matrix/client/v1/media/create` | - |
@@ -76,8 +76,9 @@ This proposal supersedes [MSC1902](https://github.com/matrix-org/matrix-spec-pro
    server should request remote media from other servers. This is redundant
    with the new endpoints, so will not be supported.
 
-   Servers MUST never return remote media from `GET /_matrix/federation/v1/media/download`;
-   indeed, the `serverName` is included in the URI only for consistency with the CS-API.
+   Servers MUST NOT return remote media from `GET /_matrix/federation/v1/media/download`. The
+   `serverName` is omitted from the endpoint's path to strongly enforce this - the `mediaId` in
+   a request is assumed to be scoped to the target server.
 
    `/_matrix/client/v1/media/download` and
    `/_matrix/client/v1/media/thumbnail` return remote media as normal.
@@ -291,7 +292,13 @@ While this proposal is in development, the new endpoints should be named as foll
 * `GET /_matrix/client/unstable/org.matrix.msc3916/media/download/{serverName}/{mediaId}`
 * `GET /_matrix/client/unstable/org.matrix.msc3916/media/download/{serverName}/{mediaId}/{fileName}`
 * `GET /_matrix/client/unstable/org.matrix.msc3916/media/thumbnail/{serverName}/{mediaId}`
-* `GET /_matrix/federation/unstable/org.matrix.msc3916/media/download/{serverName}/{mediaId}`
+* `GET /_matrix/federation/unstable/org.matrix.msc3916.v2/media/download/{mediaId}`
+  * **Note**: This endpoint has a `.v2` in its unstable identifier due to the MSC changing after
+    initial implementation. The original unstable endpoint has a `serverName` and may still be
+    supported by some servers: `GET /_matrix/federation/unstable/org.matrix.msc3916/media/download/{serverName}/{mediaId}`
+
+    The `serverName` was later dropped in favour of explicit scoping. See `allow_remote` details
+    in the MSC body for details.
 
 In a prior version of this proposal, the federation API included a thumbnail endpoint.
 It was removed due to lack of perceived usage. Servers which implemented the unstable

--- a/proposals/3916-authentication-for-media.md
+++ b/proposals/3916-authentication-for-media.md
@@ -90,6 +90,11 @@ This proposal supersedes [MSC1902](https://github.com/matrix-org/matrix-spec-pro
    which must be `Bearer {accessToken}` for `/_matrix/client`, or the signature
    for `/_matrix/federation`.
 
+   The query string `?access_token` approach is not supported on the new endpoints,
+   as it is [deprecated](https://github.com/matrix-org/matrix-spec-proposals/blob/main/proposals/4126-deprecate-query-string-auth.md)
+   and [pending removal](https://github.com/matrix-org/matrix-spec-proposals/pull/4127).
+   See those MSCs for details.
+
    **Note**: This fixes [matrix-spec#313](https://github.com/matrix-org/matrix-spec/issues/313).
 
 4. Updated response format

--- a/proposals/3916-authentication-for-media.md
+++ b/proposals/3916-authentication-for-media.md
@@ -257,6 +257,26 @@ specifically for access to these icon.
   servers to get the metadata for a media item. That would mean two requests,
   but might make more sense than `/download` providing the info directly.
 
+### Compared to MSC3796 (MSC701)
+
+[MSC701/3796](https://github.com/matrix-org/matrix-spec-proposals/issues/3796)
+introduces a concept of "content tokens" which have authentication tie-in to
+prevent anonymous users from accessing media. This is a similar problem space
+to this proposal, though deals more in the event-to-media linking space instead.
+Although the MSC is an early sketch, it's unclear if the problems noted on the
+MSC itself are feasibly resolvable.
+
+### Compared to MSC2461
+
+[MSC2461](https://github.com/matrix-org/matrix-spec-proposals/pull/2461) adds
+authentication to the existing media endpoints, which as noted here in the
+Alternatives is not likely to roll out quickly and leaves an inconsistency in
+the spec. MSC2461 also introduces a client-visible flag for which kinds of media
+may require authentication, making it similar to the alternative listed above
+where on the federation side we could have two endpoints: one for information
+and one for the media itself. MSC2461 simply makes the information client-visible
+instead of server-visible.
+
 ## Unstable prefix
 
 While this proposal is in development, the new endpoints should be named as follows:

--- a/proposals/3916-authentication-for-media.md
+++ b/proposals/3916-authentication-for-media.md
@@ -191,9 +191,9 @@ icons are displayed).
 
 This remains a somewhat unsolved problem. Possibly the clients can continue
 to call the legacy `/_matrix/media/v3/download` URI for now: ultimately this
-problem will be solved by the transition to OIDC. Alternatively, we may need
-to provide an alternative `/_matrix/client/v3/login/sso/icon/{idpId}` API
-specifically for access to these icon.
+problem will be solved by the transition to OIDC. Alternatively, a dedicated
+API could be provided or permission to use HTTP(S) URLs to access the icons.
+This support would come from a different MSC.
 
 (This was previously discussed in
 [MSC2858](https://github.com/matrix-org/matrix-spec-proposals/pull/2858#discussion_r543513811).)
@@ -300,4 +300,4 @@ The client-server thumbnail endpoint is unaffected by this change.
 
 ## Dependencies
 
-None at present.
+None.

--- a/proposals/3916-authentication-for-media.md
+++ b/proposals/3916-authentication-for-media.md
@@ -41,12 +41,16 @@ This proposal supersedes [MSC1902](https://github.com/matrix-org/matrix-spec-pro
    | [`GET /_matrix/media/v3/config`](https://spec.matrix.org/v1.6/client-server-api/#get_matrixmediav3config) | `GET /_matrix/client/v1/media/config` | - |
    | [`GET /_matrix/media/v3/download/{serverName}/{mediaId}`](https://spec.matrix.org/v1.6/client-server-api/#get_matrixmediav3downloadservernamemediaid)            | `GET /_matrix/client/v1/media/download/{serverName}/{mediaId}`            | `GET /_matrix/federation/v1/media/download/{serverName}/{mediaId}`  |
    | [`GET /_matrix/media/v3/download/{serverName}/{mediaId}/{fileName}`](https://spec.matrix.org/v1.6/client-server-api/#get_matrixmediav3downloadservernamemediaidfilename) | `GET /_matrix/client/v1/media/download/{serverName}/{mediaId}/{fileName}` | -                                                                 |
-   | [`GET /_matrix/media/v3/thumbnail/{serverName}/{mediaId}`](https://spec.matrix.org/v1.6/client-server-api/#get_matrixmediav3thumbnailservernamemediaid)          | `GET /_matrix/client/v1/media/thumbnail/{serverName}/{mediaId}`           | `GET /_matrix/federation/v1/media/thumbnail/{serverName}/{mediaId}` |
+   | [`GET /_matrix/media/v3/thumbnail/{serverName}/{mediaId}`](https://spec.matrix.org/v1.6/client-server-api/#get_matrixmediav3thumbnailservernamemediaid)          | `GET /_matrix/client/v1/media/thumbnail/{serverName}/{mediaId}`           | - |
 
    **Note**: [`POST /_matrix/media/v3/upload`](https://spec.matrix.org/v1.6/client-server-api/#post_matrixmediav3upload)
    is **not** modified by this MSC: it is intended that it be brought into line with the other
    endpoints by a future MSC, such as [MSC3911](https://github.com/matrix-org/matrix-spec-proposals/pull/3911).
    It is subsequently **not** deprecated either.
+
+   **Note**: `/thumbnail` does not have a federation endpoint. It appears as though
+   no servers request thumbnails over federation, and so it is not supported here.
+   A later MSC may introduce such an endpoint.
 
    The new `/download` and `/thumbnail` endpoints additionally drop the `?allow_redirect`
    query parameters. Instead, the endpoints behave as though `allow_redirect=true` was
@@ -72,13 +76,11 @@ This proposal supersedes [MSC1902](https://github.com/matrix-org/matrix-spec-pro
    server should request remote media from other servers. This is redundant
    with the new endpoints, so will not be supported.
 
-   Servers should never return remote media from `GET
-   /_matrix/federation/v1/media/download` or `GET
-   /_matrix/federation/v1/media/thumbnail`; indeed, the `serverName` is
-   included in the URI only for consistency with the CS-API.
+   Servers MUST never return remote media from `GET /_matrix/federation/v1/media/download`;
+   indeed, the `serverName` is included in the URI only for consistency with the CS-API.
 
    `/_matrix/client/v1/media/download` and
-   `/_matrix/client/v1/media/thumbnail` should return remote media as normal.
+   `/_matrix/client/v1/media/thumbnail` return remote media as normal.
 
 3. Authentication on all endpoints
 
@@ -253,8 +255,7 @@ specifically for access to these icon.
 
 * Rather than messing with multipart content, have a separate endpoint for
   servers to get the metadata for a media item. That would mean two requests,
-  but might make more sense than both `/thumbnail` and `/download` providing
-  the info.
+  but might make more sense than `/download` providing the info directly.
 
 ## Unstable prefix
 
@@ -266,7 +267,11 @@ While this proposal is in development, the new endpoints should be named as foll
 * `GET /_matrix/client/unstable/org.matrix.msc3916/media/download/{serverName}/{mediaId}/{fileName}`
 * `GET /_matrix/client/unstable/org.matrix.msc3916/media/thumbnail/{serverName}/{mediaId}`
 * `GET /_matrix/federation/unstable/org.matrix.msc3916/media/download/{serverName}/{mediaId}`
-* `GET /_matrix/federation/unstable/org.matrix.msc3916/media/thumbnail/{serverName}/{mediaId}`
+
+In a prior version of this proposal, the federation API included a thumbnail endpoint.
+It was removed due to lack of perceived usage. Servers which implemented the unstable
+version will have done so under `GET /_matrix/federation/unstable/org.matrix.msc3916/media/thumbnail/{serverName}/{mediaId}`.
+The client-server thumbnail endpoint is unaffected by this change.
 
 ## Dependencies
 

--- a/proposals/3916-authentication-for-media.md
+++ b/proposals/3916-authentication-for-media.md
@@ -77,10 +77,9 @@ This proposal supersedes [MSC1902](https://github.com/matrix-org/matrix-spec-pro
    which must be `Bearer {accessToken}` for `/_matrix/client`, or the signature
    for `/_matrix/federation`.
 
-   The query string `?access_token` approach is not supported on the new endpoints,
-   as it is [deprecated](https://github.com/matrix-org/matrix-spec-proposals/blob/main/proposals/4126-deprecate-query-string-auth.md)
-   and [pending removal](https://github.com/matrix-org/matrix-spec-proposals/pull/4127).
-   See those MSCs for details.
+   Clients SHOULD NOT use the [deprecated](https://github.com/matrix-org/matrix-spec-proposals/blob/main/proposals/4126-deprecate-query-string-auth.md)
+   `?access_token` query string authentication mechanism. The method is [pending removal](https://github.com/matrix-org/matrix-spec-proposals/pull/4127)
+   and is generally unsafe. See those MSCs for further details.
 
    **Note**: This fixes [matrix-spec#313](https://github.com/matrix-org/matrix-spec/issues/313).
 

--- a/proposals/3916-authentication-for-media.md
+++ b/proposals/3916-authentication-for-media.md
@@ -207,6 +207,11 @@ This support would come from a different MSC.
   to significant memory usage, particularly for large media. Service workers by
   comparison allow for proxy-like behaviour.
 
+  Cookies are a plausible mechanism for sharing session information between
+  requests without having to set headers, though would be a relatively bespoke
+  authentication method for Matrix. Additionally, many Matrix users have cookies
+  disabled due to the advertising and tracking use cases common across the web.
+
 * Users will be unable to copy links to media from web clients to share out of
   band. This is considered a feature, not a bug.
 

--- a/proposals/3916-authentication-for-media.md
+++ b/proposals/3916-authentication-for-media.md
@@ -264,11 +264,14 @@ icons for the login providers as `mxc:` media URIs. These must be accessible
 without authentication (because the client has no access token at the time the
 icons are displayed).
 
-This remains a somewhat unsolved problem. Possibly the clients can continue
-to call the legacy `/_matrix/media/v3/download` URI for now: ultimately this
-problem will be solved by the transition to OIDC. Alternatively, a dedicated
-API could be provided or permission to use HTTP(S) URLs to access the icons.
-This support would come from a different MSC.
+Servers MAY flag the media as exceptions to the freeze described in part 5 of
+this proposal ("Backwards compatibility mechanisms"). Clients SHOULD continue to
+use the unauthenticated media download/thumbnail endpoints to access these icons
+until a future MSC can improve the situation.
+
+The proposal author expects that the spec's transition to OIDC will ultimately
+replace this mechanism, or that an MSC could be opened to allow HTTP(S) URLs in
+place of `mxc:` URIs.
 
 (This was previously discussed in
 [MSC2858](https://github.com/matrix-org/matrix-spec-proposals/pull/2858#discussion_r543513811).)

--- a/proposals/3916-authentication-for-media.md
+++ b/proposals/3916-authentication-for-media.md
@@ -45,7 +45,7 @@ This proposal supersedes [MSC1902](https://github.com/matrix-org/matrix-spec-pro
 
    **Note**: [`POST /_matrix/media/v3/upload`](https://spec.matrix.org/v1.6/client-server-api/#post_matrixmediav3upload)
    and [`GET /_matrix/media/v1/create`](https://spec.matrix.org/v1.10/client-server-api/#post_matrixmediav1create)
-   are **not** modified or deprecated by this MSC: it is intended that it be brought into line with the other
+   are **not** modified or deprecated by this MSC: it is intended that they be brought into line with the other
    endpoints by a future MSC, such as [MSC3911](https://github.com/matrix-org/matrix-spec-proposals/pull/3911).
 
    **Note**: `/thumbnail` does not have a federation endpoint. It appears as though


### PR DESCRIPTION
A rewrite and update of MSC1902, and a precursor to MSC3911.

[Rendered](https://github.com/matrix-org/matrix-spec-proposals/blob/rav/authentication-for-media/proposals/3916-authentication-for-media.md)

Implementations:
* Server: https://github.com/turt2live/matrix-media-repo/pull/509
* Another server: https://github.com/element-hq/synapse/pull/17172
* Web client: https://github.com/element-hq/element-web/pull/27326

[FCP tickyboxes](https://github.com/matrix-org/matrix-spec-proposals/pull/3916#issuecomment-2110908554)