### PR TITLE
MSC3923: Bringing Matrix into the IETF process

### DIFF
--- a/proposals/3923-ietf-spec-process.md
+++ b/proposals/3923-ietf-spec-process.md
@@ -46,13 +46,12 @@ better segmentation.
 
 ## Proposal
 
-With consideration for how Matrix is split into major domains, a small portion of Matrix's core need
-only be specified for MIMI. Specifically, the areas covered by
+With consideration for how Matrix is split into major domains, only a small portion of Matrix's core needs to be specified for MIMI. Specifically, the areas covered by
 [I-D.ralston-mimi-matrix-framework](https://datatracker.ietf.org/doc/draft-ralston-mimi-matrix-framework/)
 ([MSC3977](https://github.com/matrix-org/matrix-spec-proposals/pull/3977)): a single room version,
 definitions for what a homeserver, event, room, and user are, loose descriptions for what is needed
 of a federation transport API, and noting the importance of end-to-end encryption in the messaging
-sphere. The client-server API, appservice API, identity service API, and push gateway API are all
+sphere. The Client-Server API, Application Service API, Identity Service API, and Push Gateway API are all
 entirely out of scope because they're simply not needed for MIMI.
 
 Proposing these areas through the IETF process as-is would normally mean that they get transferred

--- a/proposals/3923-ietf-spec-process.md
+++ b/proposals/3923-ietf-spec-process.md
@@ -48,8 +48,8 @@ better segmentation.
 
 With consideration for how Matrix is split into major domains, a small portion of Matrix's core need
 only be specified for MIMI. Specifically, the areas covered by
-[I-D.ralston-mimi-matrix-framework](https://turt2live.github.io/ietf-mimi-matrix-framework/draft-ralston-mimi-matrix-framework.html)
-([MSC0001](https://github.com/matrix-org/matrix-spec-proposals/pull/0001)): a single room version,
+[I-D.ralston-mimi-matrix-framework](https://datatracker.ietf.org/doc/draft-ralston-mimi-matrix-framework/)
+([MSC3977](https://github.com/matrix-org/matrix-spec-proposals/pull/3977)): a single room version,
 definitions for what a homeserver, event, room, and user are, loose descriptions for what is needed
 of a federation transport API, and noting the importance of end-to-end encryption in the messaging
 sphere. The client-server API, appservice API, identity service API, and push gateway API are all

--- a/proposals/3923-ietf-spec-process.md
+++ b/proposals/3923-ietf-spec-process.md
@@ -117,4 +117,5 @@ carefully considered than usual are appreciated.
 This MSC ends up affecting the future of the following MSCs, though is not dependent itself:
 * https://github.com/matrix-org/matrix-spec-proposals/pull/3918
 * https://github.com/matrix-org/matrix-spec-proposals/pull/3919
-* MSC0001 (TODO)
+* https://github.com/matrix-org/matrix-spec-proposals/pull/3977
+* Future MSCs/I-Ds for Matrix-as-MIMI

--- a/proposals/3923-ietf-spec-process.md
+++ b/proposals/3923-ietf-spec-process.md
@@ -37,12 +37,12 @@ API without ever attempting to support appservices or the specified Client-Serve
 the case when a project is adding support for Matrix: they are most interested in interoperating with
 other Matrix homeservers and already have their own client-server API to work with.
 
-**Note**: Historically, a lot of server-specific behaviour has ended up in Matrix's Client-Server API.
-It is a goal of the Spec Core Team (SCT) to move the remaining behaviours to a more correct place,
-therefore reinforcing the original intent mentioned above more concretely. This MSC describes a world
-where the SCT's goal has been achieved, not the current state. A natural consequence of going through
-the IETF process is that Matrix's own specification will improve as areas are identified as needing
-better segmentation.
+**Note**: Historically, a lot of the behaviours a server needs to implement have ended up in Matrix's
+Client-Server API. It is a goal of the Spec Core Team (SCT) to move the remaining behaviours to a more
+correct place, therefore reinforcing the original intent mentioned above more concretely. This MSC
+describes a world where the SCT's goal has been achieved, not the current state. A natural consequence
+of going through the IETF process is that Matrix's own specification will improve as areas are identified
+as needing better segmentation.
 
 ## Proposal
 

--- a/proposals/3923-ietf-spec-process.md
+++ b/proposals/3923-ietf-spec-process.md
@@ -1,84 +1,98 @@
 # MSC3923: Bringing Matrix into the IETF process
 
-With the formation of the More Instant Messaging Interoperability (MIMI) working group within the
-IETF, Matrix has a strong interest in getting involved to describe the federation API and event
-schema as core pieces for solving the working group's area of concern. This interest raises concerns
-about how rapid prototyping and development would work in relation to a naturally slower IETF process,
-namely whether moving parts of Matrix into the IETF space would cause Matrix to be "frozen" or unable
-to change. 
+The More Instant Messaging Interoperability ([MIMI](https://datatracker.ietf.org/wg/mimi/about/))
+working group aims to specify the minimal set of mechanisms required to support modern messaging
+in an interoperable way, and Matrix is an example of how that can be accomplished by acting as a
+generic and openly specified communications layer. Matrix currently uses a specification process
+that allows for rapid prototyping, which the ecosystem relies on: it is important to Matrix to
+maintain this highly dynamic approach to specification while still being able to participate in
+venues such as IETF for interoperable messaging.
 
-This proposal aims to cover an approach where we support a version of Matrix which can be slower to
-make progress on, alongside a version that can make more invasive or experimental changes, without
-forking. This proposal additionally covers how the Matrix spec process is affected, particularly as
-it relates to the areas being proposed for MIMI's area of concern.
+This proposal covers the process approach on the Matrix side to support a venture into the IETF
+process, largely as it relates to being able to rapidly build/test features without going through
+a naturally-lengthy IETF review.
+
+## Background
+
+Matrix is currently specified at https://spec.matrix.org/v1.6 and split into several coarse domains:
+
+1. The Client-Server API (or "CS API"), covering the communication between a client and server.
+2. The Server-Server API (or "Federation API"), covering communication (transport) between servers.
+3. The Room Version specifications, which define how servers (and sometimes clients) are expected to
+   behave in a given room. This is the core feature of Matrix: how a room actually works.
+4. The Application Service API (or "Appservice API"), which defines an interface for high-traffic bots
+   and bridges to communicate with a homeserver.
+5. The Identity Service API, covering how clients and servers interact with an identity server. Identity
+   servers store mappings of third party identifiers to Matrix IDs, and are not part of the authentication
+   or user infrastructure in Matrix: you can use Matrix without ever touching an identity server.
+6. The Push Gateway API, which enables mobile app developers to use push notifications in a decentralized
+   environment.
+7. Supporting documents such as the introduction page and appendices, largely covering grammar and
+   general descriptions of Matrix.
+
+The intention of splitting Matrix into these domains is to allow for implementations of Matrix's core
+principles without having to be tied unnecessarily to writing APIs that won't be used. For example, it's
+entirely reasonable that a purpose-built homeserver only implement some room versions and the federation
+API without ever attempting to support appservices or the specified Client-Server API. This is often
+the case when a project is adding support for Matrix: they are most interested in interoperating with
+other Matrix homeservers and already have their own client-server API to work with.
+
+**Note**: Historically, a lot of server-specific behaviour has ended up in Matrix's Client-Server API.
+It is a goal of the Spec Core Team (SCT) to move the remaining behaviours to a more correct place,
+therefore reinforcing the original intent mentioned above more concretely. This MSC describes a world
+where the SCT's goal has been achieved, not the current state. A natural consequence of going through
+the IETF process is that Matrix's own specification will improve as areas are identified as needing
+better segmentation.
 
 ## Proposal
 
-Currently the only areas in scope for proposing for MIMI are the Federation API (server-server spec),
-a selected Room Version, and schema of an event (using [MSC1767: Extensible Events](https://github.com/matrix-org/matrix-spec-proposals/pull/1767)). 
-All other areas, such as the Client-Server API, Identity Service API, Application Service API, etc 
-are *not* in scope and would remain with the Matrix.org Foundation entirely.
+With consideration for how Matrix is split into major domains, a small portion of Matrix's core need
+only be specified for MIMI. Specifically, the areas covered by
+[I-D.ralston-mimi-matrix-framework](https://turt2live.github.io/ietf-mimi-matrix-framework/draft-ralston-mimi-matrix-framework.html)
+([MSC0001](https://github.com/matrix-org/matrix-spec-proposals/pull/0001)): a single room version,
+definitions for what a homeserver, event, room, and user are, loose descriptions for what is needed
+of a federation transport API, and noting the importance of end-to-end encryption in the messaging
+sphere. The client-server API, appservice API, identity service API, and push gateway API are all
+entirely out of scope because they're simply not needed for MIMI.
 
-The Federation API would be split into two parts: The Matrix Federation API and the Matrix HTTP Federation
-Transport. The new Federation API would describe a series of RPC-like calls that servers must support
-while the HTTP Transport would be similar to what is currently found in the Server-Server API specification:
-a set of endpoints which map to those RPC calls, describing how JSON and similar algorithms work, etc.
+Proposing these areas through the IETF process as-is would normally mean that they get transferred
+to the IETF, using the IETF process instead of MSCs for any future changes after being accepted.
+This could put a damper on Matrix's ability to experiment with features, though. In order to avoid
+this damper, we instead use an LTS (Long-Term Stable) approach where the core of Matrix is versioned
+as an LTS within the IETF process and regular/non-LTS Matrix continues as-is.
 
-This split can be hard to reason about, but is demonstrated by [I-D.ralston-mimi-matrix-api] (TODO)
-([MSC0001] (TODO)) and [I-D.ralston-mimi-matrix-http] (TODO) ([MSC0002] (TODO)).
+Logistically, this means room versions (as the primary area of concern) will get an "LTS stable"
+designation and associated identifier. Room versions in non-LTS Matrix will continue to get created,
+though not all of them will end up in the IETF process: when it makes sense to do, such as when a
+given room version "feels" stable enough, that room version will get proposed to the IETF through
+the normal Internet-Draft process.
 
-Similarly, only the event schema would be proposed rather than the event types specifically. As a more
-simple model than the Federation API, what describes an arbitrary event's format would be specified
-with the IETF, though the event types would be available through a "registrar"-like process, namely
-the Matrix.org Foundation and the existing Matrix Spec Change (MSC) proposal process. In future,
-this would be expanded to 3rd party vendor specifications once available at the Matrix.org Foundation
-level.
+For example, if given room versions 10, 11, 12, and 13 from Matrix, room version 13 might be proposed
+to the IETF while the others simply aren't. While 13 works through the IETF process (being renamed
+as `I.2` in the proposal), changes might happen to it and other non-LTS room versions get created.
+Like with Matrix->LTS intent, anything which makes sense to bring to the other process gets raised
+as such in the traditional ways (an MSC in the case of non-LTS, and an Internet-Draft in the case
+of IETF).
 
-The event model is described as [I-D.ralston-mimi-matrix-events] (TODO) ([MSC0003] (TODO)).
+Room versions typically hold the core of Matrix, however anything which needs to enter the IETF
+process would do so just the same as room versions: anything which makes sense, and when it makes
+sense, would go through the IETF process and carry any useful changes back to Matrix as MSCs.
 
-Finally, there's Room Versions. Not all room versions would be sent up to the IETF, instead only
-considering a stable version every so often. This could mean divergence of numbering from the "IETF
-room version" and "Matrix.org room version" though, which [I-D.ralston-mimi-matrix-api] (TODO) 
-([MSC0001] (TODO)) attempts to solve. Much of the Federation API and parts of the event schema
-would defer to the room version, like how a DAG might work, any applicable authorization rules,
-structures for event IDs within the room version, etc. This opens up an opportunity for a different
-kind of storage other than a DAG, if the usecase calls for it (and is no different from Matrix
-today: if needed, we'd just move the DAG out of the SS API and into the existing room versions, just
-as we've done for redaction rules, authorization rules, event ID format, and more in the past).
+Similarly, it's entirely possible that an IETF Internet-Draft gets raised without an accompanying
+MSC to change how the LTS version of Matrix works: if that change makes sense to bring over, it
+would be.
 
-The room version proposed for inclusion is described by [I-D.ralston-mimi-matrix-room-version-1] (TODO)
-([MSC0004] (TODO)).
+In practice, the Matrix.org Foundation would be the ones ensuring both backwards compatibility
+between LTS and non-LTS Matrix as well as ferrying changes back and forth as needed. This would
+fall under the Spec Core Team's remit.
 
-**Author's Note**: While the draft's TODO state implies room version 1, we're not actually proposing
-v1 for IETF. Instead, we'd likely be aiming for v11 or v12 to be defined instead (with extensible events,
-faster room joins, etc). The version strings would change slightly with the IETF model in the mix.
+### Handling backwards-incompatible changes
 
-### Impact on the Matrix.org process
-
-The above describes how the pieces get cut up, but not how those pieces are expected to adopt changes
-that will be needed over time. In the proposed model, the IETF gets a "long-term stable" (LTS) version
-of the pieces it can amend using its own process - changes made to the IETF version get ported to the
-Matrix.org edition (the original edition) of Matrix through MSCs. These MSCs would not be fait accompli, 
-however: if the MSC process were to reject a change, it simply would not be included in the Matrix.org 
-edition of Matrix. Generally, however, it would be likely that IETF changes are improvements or useful 
-additions to the protocol and therefore be extremely well thought through solutions to a real problem, 
-thus likely to be accepted.
-
-Meanwhile, the Matrix.org edition keeps powering along at its normal pace. MSCs still get landed, and 
-implementations still get written. Every so often, as deemed useful, the Matrix.org Foundation brings
-any relevant changes to the IETF through the IETF's processes. This could, for example, mean proposing
-every 3rd room version to the IETF (using its specific versioning scheme), or updating fundamental concepts
-on an as-needed basis.
-
-This approach has some potential for the two editions of Matrix to become incompatible, thus appearing
-as a fork, however with careful consideration for how to structure Matrix in terms of IETF proposals, it 
-should be possible to contain the riskiest parts to a room version. This would allow massively breaking 
-changes (like not using a DAG) to be entirely kept within a room version that is gated by implementation 
-effort (not all servers need to implement all room versions). With further involvement of the Matrix.org
-Foundation throughout the lifetime of Matrix at the IETF level, it should be relatively easy to navigate
-any potential disruptions to the protocol and its compatibility. It is also likely that both Matrix.org
-and the IETF will want backwards compatibility in their invasive changes, providing a path for the other
-affected party in case of conflict.
+Given the IETF and Matrix processes can both modify their copy of the protocol without involving the
+other process, it's very possible that one doesn't work with the other anymore. This should be quite
+easy to mitigate, however: because we're using room versions to contain the core protocol, servers
+intending to support both LTS and non-LTS versions simply implement both room versions and they'll
+be covered.
 
 ## Alternatives
 
@@ -93,17 +107,14 @@ like to:
 * keep the layers which aren't needed out of the IETF, for sake of implementation effort for Matrix-compatible
   implementations from the IETF level
 
-... and other points along those same sentiments. 
+... and other points along those same sentiments.
 
 Suggestions for alternative approaches are welcome, though unlike other MSCs, solutions which are more
 carefully considered than usual are appreciated.
 
 ## Dependent MSCs
 
-This MSC ends up affecting the future of the following MSCs:
+This MSC ends up affecting the future of the following MSCs, though is not dependent itself:
 * https://github.com/matrix-org/matrix-spec-proposals/pull/3918
 * https://github.com/matrix-org/matrix-spec-proposals/pull/3919
 * MSC0001 (TODO)
-* MSC0002 (TODO)
-* MSC0003 (TODO)
-* MSC0004 (TODO)

--- a/proposals/3923-ietf-spec-process.md
+++ b/proposals/3923-ietf-spec-process.md
@@ -1,0 +1,109 @@
+# MSC3923: Bringing Matrix into the IETF process
+
+With the formation of the More Instant Messaging Interoperability (MIMI) working group within the
+IETF, Matrix has a strong interest in getting involved to describe the federation API and event
+schema as core pieces for solving the working group's area of concern. This interest raises concerns
+about how rapid prototyping and development would work in relation to a naturally slower IETF process,
+namely whether moving parts of Matrix into the IETF space would cause Matrix to be "frozen" or unable
+to change. 
+
+This proposal aims to cover an approach where we support a version of Matrix which can be slower to
+make progress on, alongside a version that can make more invasive or experimental changes, without
+forking. This proposal additionally covers how the Matrix spec process is affected, particularly as
+it relates to the areas being proposed for MIMI's area of concern.
+
+## Proposal
+
+Currently the only areas in scope for proposing for MIMI are the Federation API (server-server spec),
+a selected Room Version, and schema of an event (using [MSC1767: Extensible Events](https://github.com/matrix-org/matrix-spec-proposals/pull/1767)). 
+All other areas, such as the Client-Server API, Identity Service API, Application Service API, etc 
+are *not* in scope and would remain with the Matrix.org Foundation entirely.
+
+The Federation API would be split into two parts: The Matrix Federation API and the Matrix HTTP Federation
+Transport. The new Federation API would describe a series of RPC-like calls that servers must support
+while the HTTP Transport would be similar to what is currently found in the Server-Server API specification:
+a set of endpoints which map to those RPC calls, describing how JSON and similar algorithms work, etc.
+
+This split can be hard to reason about, but is demonstrated by [I-D.ralston-mimi-matrix-api] (TODO)
+([MSC0001] (TODO)) and [I-D.ralston-mimi-matrix-http] (TODO) ([MSC0002] (TODO)).
+
+Similarly, only the event schema would be proposed rather than the event types specifically. As a more
+simple model than the Federation API, what describes an arbitrary event's format would be specified
+with the IETF, though the event types would be available through a "registrar"-like process, namely
+the Matrix.org Foundation and the existing Matrix Spec Change (MSC) proposal process. In future,
+this would be expanded to 3rd party vendor specifications once available at the Matrix.org Foundation
+level.
+
+The event model is described as [I-D.ralston-mimi-matrix-events] (TODO) ([MSC0003] (TODO)).
+
+Finally, there's Room Versions. Not all room versions would be sent up to the IETF, instead only
+considering a stable version every so often. This could mean divergence of numbering from the "IETF
+room version" and "Matrix.org room version" though, which [I-D.ralston-mimi-matrix-api] (TODO) 
+([MSC0001] (TODO)) attempts to solve. Much of the Federation API and parts of the event schema
+would defer to the room version, like how a DAG might work, any applicable authorization rules,
+structures for event IDs within the room version, etc. This opens up an opportunity for a different
+kind of storage other than a DAG, if the usecase calls for it (and is no different from Matrix
+today: if needed, we'd just move the DAG out of the SS API and into the existing room versions, just
+as we've done for redaction rules, authorization rules, event ID format, and more in the past).
+
+The room version proposed for inclusion is described by [I-D.ralston-mimi-matrix-room-version-1] (TODO)
+([MSC0004] (TODO)).
+
+**Author's Note**: While the draft's TODO state implies room version 1, we're not actually proposing
+v1 for IETF. Instead, we'd likely be aiming for v11 or v12 to be defined instead (with extensible events,
+faster room joins, etc). The version strings would change slightly with the IETF model in the mix.
+
+### Impact on the Matrix.org process
+
+The above describes how the pieces get cut up, but not how those pieces are expected to adopt changes
+that will be needed over time. In the proposed model, the IETF gets a "long-term stable" (LTS) version
+of the pieces it can amend using its own process - changes made to the IETF version get ported to the
+Matrix.org edition (the original edition) of Matrix through MSCs. These MSCs would not be fait accompli, 
+however: if the MSC process were to reject a change, it simply would not be included in the Matrix.org 
+edition of Matrix. Generally, however, it would be likely that IETF changes are improvements or useful 
+additions to the protocol and therefore be extremely well thought through solutions to a real problem, 
+thus likely to be accepted.
+
+Meanwhile, the Matrix.org edition keeps powering along at its normal pace. MSCs still get landed, and 
+implementations still get written. Every so often, as deemed useful, the Matrix.org Foundation brings
+any relevant changes to the IETF through the IETF's processes. This could, for example, mean proposing
+every 3rd room version to the IETF (using its specific versioning scheme), or updating fundamental concepts
+on an as-needed basis.
+
+This approach has some potential for the two editions of Matrix to become incompatible, thus appearing
+as a fork, however with careful consideration for how to structure Matrix in terms of IETF proposals, it 
+should be possible to contain the riskiest parts to a room version. This would allow massively breaking 
+changes (like not using a DAG) to be entirely kept within a room version that is gated by implementation 
+effort (not all servers need to implement all room versions). With further involvement of the Matrix.org
+Foundation throughout the lifetime of Matrix at the IETF level, it should be relatively easy to navigate
+any potential disruptions to the protocol and its compatibility. It is also likely that both Matrix.org
+and the IETF will want backwards compatibility in their invasive changes, providing a path for the other
+affected party in case of conflict.
+
+## Alternatives
+
+Other ideas have been discussed with some members of the Spec Core Team, with the combination of them
+appearing in the above proposal. Taking elements of the proposal and creating a new proposal around them
+is feasible, though those approaches do not independently solve the concerns the SCT has. Namely, we'd
+like to:
+
+* have a compatible version of Matrix specified at the IETF level (specifically for federation)
+* be free to experiment without the burden of process, and rapidly respond to shifts in the larger,
+  external, ecosystem as needed
+* keep the layers which aren't needed out of the IETF, for sake of implementation effort for Matrix-compatible
+  implementations from the IETF level
+
+... and other points along those same sentiments. 
+
+Suggestions for alternative approaches are welcome, though unlike other MSCs, solutions which are more
+carefully considered than usual are appreciated.
+
+## Dependent MSCs
+
+This MSC ends up affecting the future of the following MSCs:
+* https://github.com/matrix-org/matrix-spec-proposals/pull/3918
+* https://github.com/matrix-org/matrix-spec-proposals/pull/3919
+* MSC0001 (TODO)
+* MSC0002 (TODO)
+* MSC0003 (TODO)
+* MSC0004 (TODO)


### PR DESCRIPTION
[Rendered](https://github.com/matrix-org/matrix-spec-proposals/blob/travis/msc/mimi/proposals/3923-ietf-spec-process.md)

**Note**: This MSC does not require an implementation, as one is not possible. This MSC exists for discussion purposes relating to  the governance of the Matrix.org Foundation and the surrounding specification.

[FCP tickyboxes](https://github.com/matrix-org/matrix-spec-proposals/pull/3923#issuecomment-1466467152)
[What does FCP mean on this?](https://github.com/matrix-org/matrix-spec-proposals/pull/3923#issuecomment-1466465011)