### PR TITLE
MSC3930: Polls push rules/notifications

### DIFF
--- a/proposals/0000-polls-notifications.md
+++ b/proposals/0000-polls-notifications.md
@@ -1,0 +1,103 @@
+
+# MSC0000: Polls push rules/notifications
+
+[MSC3381](https://github.com/matrix-org/matrix-spec-proposals/pull/3381) describes how chat polls can work,
+though deliberately leaves out details on how push rules or notifications could work for such a feature.
+This proposal aims to address that specific feature gap.
+
+Readers should review MSC3381 to better understand how polls are intended to operate in a room.
+
+## Proposal
+
+In order to have polls behave similar to message events, the following underride push rules are defined.
+Note that the push rules are mirrored from those available to `m.room.message` events.
+
+```json
+{
+  "rule_id": ".m.rule.poll_start_one_to_one",
+  "default": true,
+  "enabled": true,
+  "conditions": [
+    {"kind": "room_member_count", "is": "2"},
+    {"kind": "event_match", "key": "type", "pattern": "m.poll.start"}
+  ],
+  "actions": [
+    "notify",
+    {"set_tweak": "sound", "value": "default"}
+  ]
+}
+```
+
+```json
+{
+  "rule_id": ".m.rule.poll_start",
+  "default": true,
+  "enabled": true,
+  "conditions": [
+    {"kind": "event_match", "key": "type", "pattern": "m.poll.start"}
+  ],
+  "actions": [
+    "notify"
+  ]
+}
+```
+
+```json
+{
+  "rule_id": ".m.rule.poll_end_one_to_one",
+  "default": true,
+  "enabled": true,
+  "conditions": [
+    {"kind": "room_member_count", "is": "2"},
+    {"kind": "event_match", "key": "type", "pattern": "m.poll.end"}
+  ],
+  "actions": [
+    "notify",
+    {"set_tweak": "sound", "value": "default"}
+  ]
+}
+```
+
+```json
+{
+  "rule_id": ".m.rule.poll_end",
+  "default": true,
+  "enabled": true,
+  "conditions": [
+    {"kind": "event_match", "key": "type", "pattern": "m.poll.end"}
+  ],
+  "actions": [
+    "notify"
+  ]
+}
+```
+
+Servers should keep these rules in sync with the `m.room.message` rules they are based upon. For
+example, if the `m.room.message` rule gets muted in a room then the associated rules for polls would
+also get muted. Similarly, if either of the two poll rules were to be muted in a room then the other
+poll rule and the `m.room.message` rule would be muted as well.
+
+Clients are expected to not require any specific change in order to support these rules. Their user
+experience typically already considers an entry for "messages in the room", which is what a typical
+user would expect to control notifications caused by polls.
+
+The server-side syncing of the rules additionally means that clients won't have to manually add support
+for the new rules. Servers as part of implementation will update and incorporate the rules on behalf
+of the users and simply send them down `/sync` per normal - clients which parse the push rules manually
+shouldn't have to do anything as the rule will execute normally.
+
+## Potential issues
+
+The push rules for this feature are complex and not ideal. The author believes that it solves a short
+term need while other MSCs work on improving the notifications system. Most importantly, the author
+believes future MSCs which aim to fix notifications for extensible events in general will be a more
+preferred approach over this MSC's (hopefully) short-term solution.
+
+## Security considerations
+
+None applicable - no new considerations need to be made with this proposal.
+
+## Unstable prefix
+
+While this MSC is not considered stable, implementations should use `org.matrix.msc0000.*` as a prefix
+in place of `m.*`.

--- a/proposals/3930-polls-notifications.md
+++ b/proposals/3930-polls-notifications.md
@@ -74,7 +74,7 @@ Note that the push rules are mirrored from those available to `m.room.message` e
 }
 ```
 
-Additionally, a new override rule is defined to supress poll responses by default:
+Additionally, a new override rule is defined to suppress poll responses by default:
 
 ```json
 {

--- a/proposals/3930-polls-notifications.md
+++ b/proposals/3930-polls-notifications.md
@@ -27,7 +27,7 @@ order presented by this MSC.
     {"kind": "room_member_count", "is": "2"},
 
     // Note: `.` is escaped once, but for valid JSON we need to escape the escape.
-    {"kind": "event_property_is", "key": "type", "pattern": "m\\.poll\\.start"}
+    {"kind": "event_property_is", "key": "type", "value": "m\\.poll\\.start"}
   ],
   "actions": [
     "notify",
@@ -43,7 +43,7 @@ order presented by this MSC.
   "enabled": true,
   "conditions": [
     // Note: `.` is escaped once, but for valid JSON we need to escape the escape.
-    {"kind": "event_property_is", "key": "type", "pattern": "m\\.poll\\.start"}
+    {"kind": "event_property_is", "key": "type", "value": "m\\.poll\\.start"}
   ],
   "actions": [
     "notify"
@@ -60,7 +60,7 @@ order presented by this MSC.
     {"kind": "room_member_count", "is": "2"},
 
     // Note: `.` is escaped once, but for valid JSON we need to escape the escape.
-    {"kind": "event_property_is", "key": "type", "pattern": "m\\.poll\\.end"}
+    {"kind": "event_property_is", "key": "type", "value": "m\\.poll\\.end"}
   ],
   "actions": [
     "notify",
@@ -76,7 +76,7 @@ order presented by this MSC.
   "enabled": true,
   "conditions": [
     // Note: `.` is escaped once, but for valid JSON we need to escape the escape.
-    {"kind": "event_property_is", "key": "type", "pattern": "m\\.poll\\.end"}
+    {"kind": "event_property_is", "key": "type", "value": "m\\.poll\\.end"}
   ],
   "actions": [
     "notify"
@@ -127,6 +127,9 @@ preferred approach over this MSC's (hopefully) short-term solution.
 While the order within the MSC is deliberate for the new rules, the positioning relative to other rules
 already in the spec is fairly arbitrary. The new rules are placed at the end of each list (underride and
 override) for simplicity, but could realistically go anywhere in the list.
+
+See ["Dot-separated property paths"](https://spec.matrix.org/v1.7/appendices/#dot-separated-property-paths)
+for more information on why we escape the `event_property_is` condition values.
 
 ## Security considerations
 

--- a/proposals/3930-polls-notifications.md
+++ b/proposals/3930-polls-notifications.md
@@ -18,14 +18,16 @@ Note that [order matters](https://github.com/matrix-org/matrix-spec/issues/1406)
 underride rules are to be inserted immediately after the `.m.rule.encrypted` underride push rule, in the
 order presented by this MSC.
 
-```json
+```jsonc
 {
   "rule_id": ".m.rule.poll_start_one_to_one",
   "default": true,
   "enabled": true,
   "conditions": [
     {"kind": "room_member_count", "is": "2"},
-    {"kind": "event_match", "key": "type", "pattern": "m.poll.start"}
+
+    // Note: `.` is escaped once, but for valid JSON we need to escape the escape.
+    {"kind": "event_property_is", "key": "type", "pattern": "m\\.poll\\.start"}
   ],
   "actions": [
     "notify",
@@ -34,13 +36,14 @@ order presented by this MSC.
 }
 ```
 
-```json
+```jsonc
 {
   "rule_id": ".m.rule.poll_start",
   "default": true,
   "enabled": true,
   "conditions": [
-    {"kind": "event_match", "key": "type", "pattern": "m.poll.start"}
+    // Note: `.` is escaped once, but for valid JSON we need to escape the escape.
+    {"kind": "event_property_is", "key": "type", "pattern": "m\\.poll\\.start"}
   ],
   "actions": [
     "notify"
@@ -48,14 +51,16 @@ order presented by this MSC.
 }
 ```
 
-```json
+```jsonc
 {
   "rule_id": ".m.rule.poll_end_one_to_one",
   "default": true,
   "enabled": true,
   "conditions": [
     {"kind": "room_member_count", "is": "2"},
-    {"kind": "event_match", "key": "type", "pattern": "m.poll.end"}
+
+    // Note: `.` is escaped once, but for valid JSON we need to escape the escape.
+    {"kind": "event_property_is", "key": "type", "pattern": "m\\.poll\\.end"}
   ],
   "actions": [
     "notify",
@@ -64,13 +69,14 @@ order presented by this MSC.
 }
 ```
 
-```json
+```jsonc
 {
   "rule_id": ".m.rule.poll_end",
   "default": true,
   "enabled": true,
   "conditions": [
-    {"kind": "event_match", "key": "type", "pattern": "m.poll.end"}
+    // Note: `.` is escaped once, but for valid JSON we need to escape the escape.
+    {"kind": "event_property_is", "key": "type", "pattern": "m\\.poll\\.end"}
   ],
   "actions": [
     "notify"
@@ -81,13 +87,14 @@ order presented by this MSC.
 Additionally, a new override rule is defined to suppress poll responses by default, inserted immediately
 after the `.m.rule.room.server_acl` override rule.
 
-```json
+```jsonc
 {
   "rule_id": ".m.rule.poll_response",
   "default": true,
   "enabled": true,
   "conditions": [
-    {"kind": "event_match", "key": "type", "pattern": "m.poll.response"}
+    // Note: `.` is escaped once, but for valid JSON we need to escape the escape.
+    {"kind": "event_property_is", "key": "type", "value": "m\\.poll\\.response"}
   ],
   "actions": []
 }

--- a/proposals/3930-polls-notifications.md
+++ b/proposals/3930-polls-notifications.md
@@ -117,4 +117,4 @@ None applicable - no new considerations need to be made with this proposal.
 ## Unstable prefix
 
 While this MSC is not considered stable, implementations should use `org.matrix.msc3930.*` as a prefix
-in place of `m.*`.
+in place of `m.*` for the push rule IDs. As of writing, polls are only implemented using the legacy `org.matrix.msc3381.poll.*` prefix rather than the newer `v2` prefix - implementations of this MSC should be aware of which version of MSC3381 they plan to support.

--- a/proposals/3930-polls-notifications.md
+++ b/proposals/3930-polls-notifications.md
@@ -6,13 +6,17 @@ This proposal aims to address that specific feature gap.
 
 Readers should review MSC3381 to better understand how polls are intended to operate in a room.
 
-Push rules are currently defined [here](https://spec.matrix.org/v1.5/client-server-api/#push-rules) in
+Push rules are currently defined [here](https://spec.matrix.org/v1.7/client-server-api/#push-rules) in
 specification.
 
 ## Proposal
 
-In order to have polls behave similar to message events, the following underride push rules are defined.
-Note that the push rules are mirrored from those available to `m.room.message` events.
+Polls should behave similar to message events. To achieve this effect, we define the following underride
+push rules which mimic their `m.room.message` partners.
+
+Note that [order matters](https://github.com/matrix-org/matrix-spec/issues/1406) for push rules - these
+underride rules are to be inserted immediately after the `.m.rule.encrypted` underride push rule, in the
+order presented by this MSC.
 
 ```json
 {
@@ -74,7 +78,8 @@ Note that the push rules are mirrored from those available to `m.room.message` e
 }
 ```
 
-Additionally, a new override rule is defined to suppress poll responses by default:
+Additionally, a new override rule is defined to suppress poll responses by default, inserted immediately
+after the `.m.rule.room.server_acl` override rule.
 
 ```json
 {
@@ -110,6 +115,12 @@ term need while other MSCs work on improving the notifications system. Most impo
 believes future MSCs which aim to fix notifications for extensible events in general will be a more
 preferred approach over this MSC's (hopefully) short-term solution.
 
+## General considerations
+
+While the order within the MSC is deliberate for the new rules, the positioning relative to other rules
+already in the spec is fairly arbitary. The new rules are placed at the end of each list (underride and
+override) for simplicty, but could realistically go anywhere in the list.
+
 ## Security considerations
 
 None applicable - no new considerations need to be made with this proposal.
@@ -117,4 +128,6 @@ None applicable - no new considerations need to be made with this proposal.
 ## Unstable prefix
 
 While this MSC is not considered stable, implementations should use `org.matrix.msc3930.*` as a prefix
-in place of `m.*` for the push rule IDs. As of writing, polls are only implemented using the legacy `org.matrix.msc3381.poll.*` prefix rather than the newer `v2` prefix - implementations of this MSC should be aware of which version of MSC3381 they plan to support.
+in place of `m.*` for the push rule IDs. As of writing, polls are only implemented using the legacy
+`org.matrix.msc3381.poll.*` prefix rather than the newer `v2` prefix - implementations of this MSC
+should be aware of which version of MSC3381 they plan to support.

--- a/proposals/3930-polls-notifications.md
+++ b/proposals/3930-polls-notifications.md
@@ -1,5 +1,5 @@
 
-# MSC0000: Polls push rules/notifications
+# MSC3930: Polls push rules/notifications
 
 [MSC3381](https://github.com/matrix-org/matrix-spec-proposals/pull/3381) describes how chat polls can work,
 though deliberately leaves out details on how push rules or notifications could work for such a feature.
@@ -99,5 +99,5 @@ None applicable - no new considerations need to be made with this proposal.
 
 ## Unstable prefix
 
-While this MSC is not considered stable, implementations should use `org.matrix.msc0000.*` as a prefix
+While this MSC is not considered stable, implementations should use `org.matrix.msc3930.*` as a prefix
 in place of `m.*`.

--- a/proposals/3930-polls-notifications.md
+++ b/proposals/3930-polls-notifications.md
@@ -1,4 +1,3 @@
-
 # MSC3930: Polls push rules/notifications
 
 [MSC3381](https://github.com/matrix-org/matrix-spec-proposals/pull/3381) describes how chat polls can work,

--- a/proposals/3930-polls-notifications.md
+++ b/proposals/3930-polls-notifications.md
@@ -118,8 +118,8 @@ preferred approach over this MSC's (hopefully) short-term solution.
 ## General considerations
 
 While the order within the MSC is deliberate for the new rules, the positioning relative to other rules
-already in the spec is fairly arbitary. The new rules are placed at the end of each list (underride and
-override) for simplicty, but could realistically go anywhere in the list.
+already in the spec is fairly arbitrary. The new rules are placed at the end of each list (underride and
+override) for simplicity, but could realistically go anywhere in the list.
 
 ## Security considerations
 


### PR DESCRIPTION
[Rendered](https://github.com/matrix-org/matrix-spec-proposals/blob/travis/msc/polls-notifs/proposals/3930-polls-notifications.md)

Implementations:
* Synapse: https://github.com/matrix-org/synapse/pull/14787
* Syncing behaviour (an implementation detail under this MSC):
  * Element Web/react-sdk: https://github.com/matrix-org/matrix-react-sdk/pull/10287
  * Element Android: https://github.com/vector-im/element-android/pull/8114 & https://github.com/vector-im/element-android/pull/8130

Note: implementation for this MSC was done before `event_property_is` was specified/adopted. The only difference between the implementations above and the current version of the MSC is the condition kind - the meaning and purpose is otherwise the same.

----

[FCP tickyboxes](https://github.com/matrix-org/matrix-spec-proposals/pull/3930#issuecomment-1659574910)