### PR TITLE
MSC3958: Suppress notifications from message edits

### DIFF
--- a/proposals/3958-suppress-notifications-of-message-edits.md
+++ b/proposals/3958-suppress-notifications-of-message-edits.md
@@ -89,6 +89,31 @@ when we generate notifications.
 If an event is edited and the new event (but not the original event) matches a keyword
 then the notification would erroneously be suppressed.
 
+### Edits of rooms set to "all messages"
+
+A room can be configured to be notify for "all messages" by creating the earliest
+[override push rule](https://spec.matrix.org/v1.7/client-server-api/#push-rules)
+possible which matches the room ID & has `actions` set to "notify" [^1][^2], e.g.:
+
+```json
+{
+    "rule_id" : "!abcdef:example.com",
+    "conditions" : [
+       {
+          "key" : "room_id",
+          "kind" : "event_match",
+          "pattern" : "!abcdef:example.com"
+       }
+    ],
+    "default" : false,
+    "enabled" : true,
+    "actions" : ["notify"]
+}
+```
+
+Since this push rule would be evaluated before the new `.m.rule.suppress_edits` it would
+still result in duplicate notifications for those rooms.
+
 ## Alternatives
 
 An alternative solution would be to add a push rule with no actions and a condition to
@@ -123,3 +148,9 @@ A previous version of this MSC used `.com.beeper.suppress_edits` with a differen
 ## Dependencies
 
 N/A
+
+[^1]: The [`.m.rule.master`](https://spec.matrix.org/v1.7/client-server-api/#default-override-rules)
+is *always* first, so this rule gets created right after it.
+
+[^2]: See the [Element Web](https://github.com/matrix-org/matrix-react-sdk/blob/da7aa4055e04f291be9b5141b704bd12aec03d0c/src/RoomNotifs.ts#L162-L170)
+implementation.

--- a/proposals/3958-suppress-notifications-of-message-edits.md
+++ b/proposals/3958-suppress-notifications-of-message-edits.md
@@ -11,7 +11,7 @@ is re-notified). This contributes to notification fatigue as the additional
 notifications contain no new information.
 
 Additionally for users which have a room set to "all messages" then every event
-edit results in a new notification.
+edit results in an additional notification.[^1]
 
 ## Proposal
 
@@ -89,31 +89,6 @@ when we generate notifications.
 If an event is edited and the new event (but not the original event) matches a keyword
 then the notification would erroneously be suppressed.
 
-### Edits of rooms set to "all messages"
-
-A room can be configured to be notify for "all messages" by creating the earliest
-[override push rule](https://spec.matrix.org/v1.7/client-server-api/#push-rules)
-possible which matches the room ID & has `actions` set to "notify" [^1][^2], e.g.:
-
-```json
-{
-    "rule_id" : "!abcdef:example.com",
-    "conditions" : [
-       {
-          "key" : "room_id",
-          "kind" : "event_match",
-          "pattern" : "!abcdef:example.com"
-       }
-    ],
-    "default" : false,
-    "enabled" : true,
-    "actions" : ["notify"]
-}
-```
-
-Since this push rule would be evaluated before the new `.m.rule.suppress_edits` it would
-still result in duplicate notifications for those rooms.
-
 ## Alternatives
 
 An alternative solution would be to add a push rule with no actions and a condition to
@@ -149,8 +124,19 @@ A previous version of this MSC used `.com.beeper.suppress_edits` with a differen
 
 N/A
 
-[^1]: The [`.m.rule.master`](https://spec.matrix.org/v1.7/client-server-api/#default-override-rules)
-is *always* first, so this rule gets created right after it.
+<!-- Footnotes below -->
 
-[^2]: See the [Element Web](https://github.com/matrix-org/matrix-react-sdk/blob/da7aa4055e04f291be9b5141b704bd12aec03d0c/src/RoomNotifs.ts#L162-L170)
-implementation.
+[^1]: A room can be configured to be notify for "all messages" by creating a [room-specific push rule](https://spec.matrix.org/v1.7/client-server-api/#push-rules)
+with an `rule_id` of the room ID & has `actions` set to "notify" , e.g.:
+
+    ```json
+    {
+        "rule_id" : "!abcdef:example.com",
+        "default" : false,
+        "enabled" : true,
+        "actions" : ["notify"]
+    }
+    ```
+
+    See the [Element Web](https://github.com/matrix-org/matrix-react-sdk/blob/da7aa4055e04f291be9b5141b704bd12aec03d0c/src/RoomNotifs.ts#L162-L170)
+    implementation.

--- a/proposals/3958-suppress-notifications-of-message-edits.md
+++ b/proposals/3958-suppress-notifications-of-message-edits.md
@@ -12,7 +12,7 @@ notifications contain no new information.
 
 ## Proposal
 
-A new default push rule is added to suppress notifications [due to edits](https://spec.matrix.org/v1.5/client-server-api/#event-replacements).
+A new default push rule is added to suppress notifications due to [edits](https://spec.matrix.org/v1.5/client-server-api/#event-replacements).
 
 ```json
 {

--- a/proposals/3958-suppress-notifications-of-message-edits.md
+++ b/proposals/3958-suppress-notifications-of-message-edits.md
@@ -30,7 +30,8 @@ A new default push rule is added to suppress notifications [due to edits](https:
 }
 ```
 
-This rule should be placed as the [first override rule](https://spec.matrix.org/v1.5/client-server-api/#default-override-rules).
+This rule should be placed before the [`.m.rule.suppress_notices` rule](https://spec.matrix.org/v1.5/client-server-api/#default-override-rules)
+as the first non-master, non-user added override rule.
 
 It would match events such as those given in [event replacements](https://spec.matrix.org/v1.5/client-server-api/#event-replacements)
 portion of the spec:

--- a/proposals/3958-suppress-notifications-of-message-edits.md
+++ b/proposals/3958-suppress-notifications-of-message-edits.md
@@ -1,0 +1,80 @@
+# MSC3958: Suppress notifications of message edits
+
+[Event replacement](https://spec.matrix.org/v1.5/client-server-api/#event-replacements)
+(more commonly known as message edits) signals that a message is intended to
+be replaced with new content.
+
+This works well for fixing typos or correcting information, but tends to cause
+spurious notifications if the event mentions a user. This contributes to notification
+fatigue as the additional notifications contain no new information.
+
+
+## Proposal
+
+A new default push rule is added to suppress notifications [due to edits](https://spec.matrix.org/v1.5/client-server-api/#event-replacements).
+
+```json
+{
+    "rule_id": ".m.rule.suppress_edits",
+    "default": true,
+    "enabled": true,
+    "conditions": [
+        {
+            "kind": "event_match",
+            "key": "content.m.relates_to.rel_type",
+            "pattern": "m.replace"
+        }
+    ],
+    "actions": []
+}
+```
+
+This rule should be placed as the [first override rule](https://spec.matrix.org/v1.5/client-server-api/#default-override-rules).
+
+It would match events such as those given in [event replacements](https://spec.matrix.org/v1.5/client-server-api/#event-replacements)
+portion of the spec:
+
+```json5
+{
+    "type": "m.room.message",
+    "content": {
+        "body": "* Hello! My name is bar",
+        "msgtype": "m.text",
+        "m.new_content": {
+            "body": "Hello! My name is bar",
+            "msgtype": "m.text"
+        },
+        "m.relates_to": {
+            "rel_type": "m.replace",
+            "event_id": "$some_event_id"
+        }
+    },
+    // ... other fields required by events
+}
+```
+
+## Potential issues
+
+Some users may be depending on notifications of edits. If a user would like to
+revert to the old behavior they can disable the `.m.rule.suppress_edits` push rule.
+
+If the message edits were alloewd by other senders than it would be useful to
+know that your own message was edited, but this
+[is not currently allowed](https://spec.matrix.org/v1.5/client-server-api/#validity-of-replacement-events).
+
+## Alternatives
+
+None explored.
+
+## Security considerations
+
+None forseen.
+
+## Unstable prefix
+
+The unstable prefix of `.com.beeper.suppress_edits` should be used in place of
+`.m.rule.suppress_edits`.
+
+## Dependencies
+
+N/A

--- a/proposals/3958-suppress-notifications-of-message-edits.md
+++ b/proposals/3958-suppress-notifications-of-message-edits.md
@@ -4,10 +4,11 @@
 (more commonly known as message edits) signals that a message is intended to
 be replaced with new content.
 
-This works well for fixing typos or correcting information, but tends to cause
-spurious notifications if the event mentions a user. This contributes to notification
-fatigue as the additional notifications contain no new information.
-
+This works well for fixing typos or other minor correction, but can cause
+spurious notifications if the event mentions a user's display name / localpart or
+if it includes `@room` (which is particularly bad in large rooms as every user
+is re-notified). This contributes to notification fatigue as the additional
+notifications contain no new information.
 
 ## Proposal
 

--- a/proposals/3958-suppress-notifications-of-message-edits.md
+++ b/proposals/3958-suppress-notifications-of-message-edits.md
@@ -90,6 +90,13 @@ due to the `.` in `m.relates_to` and could also match other, unrelated, events:
 
 (Note that `relates_to` being embedded inside of the `m`.)
 
+Another issues is that mobile clients would no longer receive push notifications for
+message edits, which are currently used to update the text of on-screen notifications
+to show the updated content. The proposed push rule would mean that mobile clients would
+no longer receive this update, but showing slightly outdated text on a notification screen
+is only a minor impact and it would be better to separate when (& why) we send pushes vs.
+when we generate notifications.
+
 ## Alternatives
 
 None explored.

--- a/proposals/3958-suppress-notifications-of-message-edits.md
+++ b/proposals/3958-suppress-notifications-of-message-edits.md
@@ -58,7 +58,7 @@ portion of the spec:
 Some users may be depending on notifications of edits. If a user would like to
 revert to the old behavior they can disable the `.m.rule.suppress_edits` push rule.
 
-If the message edits were alloewd by other senders than it would be useful to
+If the message edits were allowed by other senders than it would be useful to
 know that your own message was edited, but this
 [is not currently allowed](https://spec.matrix.org/v1.5/client-server-api/#validity-of-replacement-events).
 

--- a/proposals/3958-suppress-notifications-of-message-edits.md
+++ b/proposals/3958-suppress-notifications-of-message-edits.md
@@ -1,6 +1,6 @@
 # MSC3958: Suppress notifications from message edits
 
-[Event replacement](https://spec.matrix.org/v1.5/client-server-api/#event-replacements)
+[Event replacement](https://spec.matrix.org/v1.7/client-server-api/#event-replacements)
 (more commonly known as message edits) signals that a message is intended to
 be replaced with new content.
 
@@ -95,7 +95,7 @@ An alternative solution would be to add a push rule with no actions and a condit
 check whether a notification was generated for the original message.
 
 This would be placed as an override rule before the `.m.rule.contains_display_name`
-and the `.m.rule.roomnotif` [push rules](https://spec.matrix.org/v1.5/client-server-api/#push-rules).
+and the `.m.rule.roomnotif` [push rules](https://spec.matrix.org/v1.7/client-server-api/#push-rules).
 
 This would suppress duplicate notifications, while still allow for new notifications due
 to new mentions or keywords changing.
@@ -108,7 +108,7 @@ None forseen.
 
 If message edits by other senders were allowed than it would be useful to
 know when your own message was edited, but this
-[is not currently allowed](https://spec.matrix.org/v1.5/client-server-api/#validity-of-replacement-events).
+[is not currently allowed](https://spec.matrix.org/v1.7/client-server-api/#validity-of-replacement-events).
 A future MSC to define this behavior should take into account notifying
 users in this situation.
 

--- a/proposals/3958-suppress-notifications-of-message-edits.md
+++ b/proposals/3958-suppress-notifications-of-message-edits.md
@@ -55,14 +55,21 @@ portion of the spec:
 }
 ```
 
-## Potential issues
-
 Some users may be depending on notifications of edits. If a user would like to
 revert to the old behavior they can disable the `.m.rule.suppress_edits` push rule.
 
-If the message edits were allowed by other senders than it would be useful to
-know that your own message was edited, but this
-[is not currently allowed](https://spec.matrix.org/v1.5/client-server-api/#validity-of-replacement-events).
+## Potential issues
+
+### Editing mentions
+
+With this MSC it would no longer possible to edit a message to change who is going
+to be notified. For instance, if you write a message and then edit it to put another
+user pill in it, in this case the user would not be notified. Socially it seems more
+likely for the sender to send another message instead of editing:
+
+> @alice:example.com see above ^
+
+### Rule Ambiguity
 
 The rule is ambiguous (see [MSC3873](https://github.com/matrix-org/matrix-spec-proposals/pull/3873))
 due to the `.` in `m.relates_to` and could also match other, unrelated, events:
@@ -90,6 +97,8 @@ due to the `.` in `m.relates_to` and could also match other, unrelated, events:
 
 (Note that `relates_to` being embedded inside of the `m`.)
 
+### Keeping notifications up-to-date
+
 Another issues is that mobile clients would no longer receive push notifications for
 message edits, which are currently used to update the text of on-screen notifications
 to show the updated content. The proposed push rule would mean that mobile clients would
@@ -99,11 +108,27 @@ when we generate notifications.
 
 ## Alternatives
 
-None explored.
+An alternative solution would be to add a push rule with no actions and a condition to
+check whether a notification should have been generated for the user in the original
+message.
+
+This should be placed as an override rule before the `.m.rule.contains_display_name`
+and the `.m.rule.roomnotif` [push rules](https://spec.matrix.org/v1.5/client-server-api/#push-rules).
+
+This would suppress duplicate notifications, while still allow for new notifications due
+to new mentions or keywords changing.
 
 ## Security considerations
 
 None forseen.
+
+## Future extensions
+
+If message edits by other senders were allowed than it would be useful to
+know when your own message was edited, but this
+[is not currently allowed](https://spec.matrix.org/v1.5/client-server-api/#validity-of-replacement-events).
+A future MSC to define this behavior should take into account notifying
+users in this situation.
 
 ## Unstable prefix
 

--- a/proposals/3958-suppress-notifications-of-message-edits.md
+++ b/proposals/3958-suppress-notifications-of-message-edits.md
@@ -1,4 +1,4 @@
-# MSC3958: Suppress notifications of message edits
+# MSC3958: Suppress notifications from message edits
 
 [Event replacement](https://spec.matrix.org/v1.5/client-server-api/#event-replacements)
 (more commonly known as message edits) signals that a message is intended to

--- a/proposals/3958-suppress-notifications-of-message-edits.md
+++ b/proposals/3958-suppress-notifications-of-message-edits.md
@@ -64,7 +64,7 @@ If the message edits were allowed by other senders than it would be useful to
 know that your own message was edited, but this
 [is not currently allowed](https://spec.matrix.org/v1.5/client-server-api/#validity-of-replacement-events).
 
-The rule is ambiguous (see [MSC3873](https://github.com/matrix-org/matrix-spec-proposals/pull/3873)
+The rule is ambiguous (see [MSC3873](https://github.com/matrix-org/matrix-spec-proposals/pull/3873))
 due to the `.` in `m.relates_to` and could also match other, unrelated, events:
 
 ```json5

--- a/proposals/3958-suppress-notifications-of-message-edits.md
+++ b/proposals/3958-suppress-notifications-of-message-edits.md
@@ -63,6 +63,32 @@ If the message edits were allowed by other senders than it would be useful to
 know that your own message was edited, but this
 [is not currently allowed](https://spec.matrix.org/v1.5/client-server-api/#validity-of-replacement-events).
 
+The rule is ambiguous (see [MSC3873](https://github.com/matrix-org/matrix-spec-proposals/pull/3873)
+due to the `.` in `m.relates_to` and could also match other, unrelated, events:
+
+```json5
+{
+    "type": "m.room.message",
+    "content": {
+        "body": "* Hello! My name is bar",
+        "msgtype": "m.text",
+        "m.new_content": {
+            "body": "Hello! My name is bar",
+            "msgtype": "m.text"
+        },
+        "m": {
+            "relates_to": {
+                "rel_type": "m.replace",
+                "event_id": "$some_event_id"
+            }
+        }
+    },
+    // ... other fields required by events
+}
+```
+
+(Note that `relates_to` being embedded inside of the `m`.)
+
 ## Alternatives
 
 None explored.

--- a/proposals/3958-suppress-notifications-of-message-edits.md
+++ b/proposals/3958-suppress-notifications-of-message-edits.md
@@ -80,7 +80,7 @@ are edited. Both of those are state events and
 
 Mobile clients currently depend on the push notifications of edited events to update the
 text of on-screen notifications. The proposed push rule would result in mobile clients no
-longer receiving these edits; but showing slightly outdated text on a notification screen
+longer receiving these edits; but showing slightly outdated text on a notification screen. That
 is only a minor impact and it would be better to separate when (& why) we send pushes vs.
 when we generate notifications.
 


### PR DESCRIPTION
[Rendered](https://github.com/matrix-org/matrix-spec-proposals/blob/clokep/suppress-message-edits/proposals/3958-suppress-notifications-of-message-edits.md)

Implementation:

* Beeper's Synapse fork: https://github.com/beeper/synapse/blame/beeper/rust/src/push/base_rules.rs#L98-L114
* Mainline Synapse: https://github.com/matrix-org/synapse/pull/14960
* Updated implementation: matrix-org/synapse#15992

[FCP tickyboxes](https://github.com/matrix-org/matrix-spec-proposals/pull/3958#issuecomment-1651847253)