### PR TITLE
MSC3989: Redact `origin` property on events

### DIFF
--- a/proposals/3989-redact-origin-field.md
+++ b/proposals/3989-redact-origin-field.md
@@ -10,7 +10,7 @@ and have [tried to do so](https://github.com/matrix-org/matrix-spec/pull/998) in
 malformed examples are even [known to us](https://github.com/matrix-org/matrix-spec/issues/1480).
 
 What's not clear, and mentioned in [a comment](https://github.com/matrix-org/matrix-spec/issues/1480#issuecomment-1495183789),
-is whether the `origin` field is *acutally* used. There do not appear to be any auth rules or similar
+is whether the `origin` field is *actually* used. There do not appear to be any auth rules or similar
 which would use the field, however it'd hardly be the first time that the spec was wrong about an
 ancient room version like v1. What is clear is that Synapse, where this question would be asked,
 wants to [drop support](https://github.com/matrix-org/synapse/issues/3816) for the field and has

--- a/proposals/3989-redact-origin-field.md
+++ b/proposals/3989-redact-origin-field.md
@@ -1,9 +1,9 @@
 # MSC3989: Redact `origin` field on events
 
 The [current redaction algorithm](https://spec.matrix.org/v1.6/rooms/v10/#redactions) *keeps* the
-top-level `origin` field on events during redaction, however the only use of it within the spec
-as of writing is a malformed example of event format. The field has no significant meaning in
-modern room versions.
+top-level `origin` property on events during redaction, however, as of this writing, the only use within the 
+spec of  `origin` as a top-level event property is a malformed example of event format. The field has no 
+significant meaning in modern room versions.
 
 Within the ecosystem, it's clear that we'd [prefer the field to disappear](https://github.com/matrix-org/matrix-spec/issues/374),
 and have [tried to do so](https://github.com/matrix-org/matrix-spec/pull/998) in the past. The
@@ -18,7 +18,7 @@ taken [steps](https://github.com/matrix-org/synapse/pull/8324) towards that miss
 in the area. In a [quick audit](https://github.com/matrix-org/matrix-spec-proposals/pull/3989#issuecomment-1497659507)
 of the Synapse codebase during implementation of this MSC, the `origin` field appears unused.
 
-Given the above context, this proposal removes the `origin` field from the redaction algorithm in
+Given the above context, this proposal removes the `origin` field from the [redaction algorithm](https://spec.matrix.org/v1.7/rooms/v10/#redactions) in
 future room versions, leaving it as-is for existing versions (not that an MSC can change the behaviour
 of an already-stable room version).
 

--- a/proposals/3989-redact-origin-field.md
+++ b/proposals/3989-redact-origin-field.md
@@ -1,0 +1,48 @@
+# MSC3989: Redact `origin` field on events
+
+The [current redaction algorithm](https://spec.matrix.org/v1.6/rooms/v10/#redactions) *keeps* the
+top-level `origin` field on events during redaction, however the only use of it as of writing is
+a malformed example of event format. The field has no significant meaning in modern room versions.
+
+Note: some other fields are additionally useless in modern room versions, however they are already
+adapted by [MSC2176](https://github.com/matrix-org/matrix-spec-proposals/pull/2176).
+
+This proposal's scope includes *removing* other fields which are useless in modern room versions,
+however makes no effort or consideration for *adding* protected fields to the redaction algorithm.
+Given MSC2176, the only useless field appears to be `origin`, however the author kindly asks that
+reviewers point out other examples as they arise.
+
+## Proposal
+
+In a future room version, the `origin` field is *removed* from the list of *event* keys which are
+kept during redaction. Note that this requires a new room version because changing the redaction
+algorithm changes how [event IDs](https://spec.matrix.org/v1.6/rooms/v10/#event-ids) are calculated,
+as they are [reference hashes](https://spec.matrix.org/v1.6/server-server-api/#calculating-the-reference-hash-for-an-event)
+which redact the event during calculation.
+
+## Potential issues
+
+No major concerns.
+
+## Alternatives
+
+No significant alternatives.
+
+## Security considerations
+
+No major concerns.
+
+## Unstable prefix
+
+While this MSC is not considered stable, implementations should use `org.matrix.msc3989` as the room
+version identifier, using v10 as a base.
+
+## Dependencies
+
+No blocking dependencies.
+
+This MSC would partner well with the following MSCs, however:
+* [MSC2176](https://github.com/matrix-org/matrix-spec-proposals/pull/2176)
+* [MSC2175](https://github.com/matrix-org/matrix-spec-proposals/pull/2175)
+* [MSC2174](https://github.com/matrix-org/matrix-spec-proposals/pull/2174)
+* [MSC3821](https://github.com/matrix-org/matrix-spec-proposals/pull/3821)

--- a/proposals/3989-redact-origin-field.md
+++ b/proposals/3989-redact-origin-field.md
@@ -1,33 +1,33 @@
-# MSC3989: Redact `origin` field on events
+# MSC3989: Redact `origin` property on events
 
 The [current redaction algorithm](https://spec.matrix.org/v1.6/rooms/v10/#redactions) *keeps* the
 top-level `origin` property on events during redaction, however, as of this writing, the only use within the
-spec of `origin` as a top-level event property is a malformed example of event format. The field has no
+spec of `origin` as a top-level event property is a malformed example of event format. The property has no
 significant meaning in modern room versions.
 
-Within the ecosystem, it's clear that we'd [prefer the field to disappear](https://github.com/matrix-org/matrix-spec/issues/374),
+Within the ecosystem, it's clear that we'd [prefer the property to disappear](https://github.com/matrix-org/matrix-spec/issues/374),
 and have [tried to do so](https://github.com/matrix-org/matrix-spec/pull/998) in the past. The
 malformed examples are even [known to us](https://github.com/matrix-org/matrix-spec/issues/1480).
 
 What's not clear, and mentioned in [a comment](https://github.com/matrix-org/matrix-spec/issues/1480#issuecomment-1495183789),
-is whether the `origin` field is *actually* used. There do not appear to be any auth rules or similar
-which would use the field, however it'd hardly be the first time that the spec was wrong about an
+is whether the `origin` property is *actually* used. There do not appear to be any auth rules or similar
+which would use the property, however it'd hardly be the first time that the spec was wrong about an
 ancient room version like v1. What is clear is that Synapse, where this question would be asked,
-wants to [drop support](https://github.com/matrix-org/synapse/issues/3816) for the field and has
+wants to [drop support](https://github.com/matrix-org/synapse/issues/3816) for the property and has
 taken [steps](https://github.com/matrix-org/synapse/pull/8324) towards that mission by fixing bugs
 in the area. In a [quick audit](https://github.com/matrix-org/matrix-spec-proposals/pull/3989#issuecomment-1497659507)
-of the Synapse codebase during implementation of this MSC, the `origin` field appears unused.
+of the Synapse codebase during implementation of this MSC, the `origin` property appears unused.
 
-Given the above context, this proposal removes the `origin` field from the [redaction algorithm](https://spec.matrix.org/v1.7/rooms/v10/#redactions)
+Given the above context, this proposal removes the `origin` property from the [redaction algorithm](https://spec.matrix.org/v1.7/rooms/v10/#redactions)
 in a future room version, leaving it as-is for existing versions (not that an MSC can change the behaviour
 of an already-stable room version anyways).
 
-Some other fields are additionally useless in modern room versions, however they are already adapted
+Some other properties are additionally useless in modern room versions, however they are already adapted
 by [MSC2176](https://github.com/matrix-org/matrix-spec-proposals/pull/2176).
 
 ## Proposal
 
-In a future room version, the `origin` field is *removed* from the list of *event* keys which are
+In a future room version, the `origin` property is *removed* from the list of *event* keys which are
 kept during redaction. Note that this requires a new room version because changing the redaction
 algorithm changes how [event IDs](https://spec.matrix.org/v1.6/rooms/v10/#event-ids) are calculated,
 as they are [reference hashes](https://spec.matrix.org/v1.6/server-server-api/#calculating-the-reference-hash-for-an-event)

--- a/proposals/3989-redact-origin-field.md
+++ b/proposals/3989-redact-origin-field.md
@@ -1,16 +1,29 @@
 # MSC3989: Redact `origin` field on events
 
 The [current redaction algorithm](https://spec.matrix.org/v1.6/rooms/v10/#redactions) *keeps* the
-top-level `origin` field on events during redaction, however the only use of it as of writing is
-a malformed example of event format. The field has no significant meaning in modern room versions.
+top-level `origin` field on events during redaction, however the only use of it within the spec
+as of writing is a malformed example of event format. The field has no significant meaning in
+modern room versions.
 
-Note: some other fields are additionally useless in modern room versions, however they are already
-adapted by [MSC2176](https://github.com/matrix-org/matrix-spec-proposals/pull/2176).
+Within the ecosystem, it's clear that we'd [prefer the field to disappear](https://github.com/matrix-org/matrix-spec/issues/374),
+and have [tried to do so](https://github.com/matrix-org/matrix-spec/pull/998) in the past. The
+malformed examples are even [known to us](https://github.com/matrix-org/matrix-spec/issues/1480).
 
-This proposal's scope includes *removing* other fields which are useless in modern room versions,
-however makes no effort or consideration for *adding* protected fields to the redaction algorithm.
-Given MSC2176, the only useless field appears to be `origin`, however the author kindly asks that
-reviewers point out other examples as they arise.
+What's not clear, and mentioned in [a comment](https://github.com/matrix-org/matrix-spec/issues/1480#issuecomment-1495183789),
+is whether the `origin` field is *acutally* used. There do not appear to be any auth rules or similar
+which would use the field, however it'd hardly be the first time that the spec was wrong about an
+ancient room version like v1. What is clear is that Synapse, where this question would be asked,
+wants to [drop support](https://github.com/matrix-org/synapse/issues/3816) for the field and has
+taken [steps](https://github.com/matrix-org/synapse/pull/8324) towards that mission by fixing bugs
+in the area. In a [quick audit](https://github.com/matrix-org/matrix-spec-proposals/pull/3989#issuecomment-1497659507)
+of the Synapse codebase during implementation of this MSC, the `origin` field appears unused.
+
+Given the above context, this proposal removes the `origin` field from the redaction algorithm in
+future room versions, leaving it as-is for existing versions (not that an MSC can change the behaviour
+of an already-stable room version).
+
+Some other fields are additionally useless in modern room versions, however they are already adapted
+by [MSC2176](https://github.com/matrix-org/matrix-spec-proposals/pull/2176).
 
 ## Proposal
 

--- a/proposals/3989-redact-origin-field.md
+++ b/proposals/3989-redact-origin-field.md
@@ -1,8 +1,8 @@
 # MSC3989: Redact `origin` field on events
 
 The [current redaction algorithm](https://spec.matrix.org/v1.6/rooms/v10/#redactions) *keeps* the
-top-level `origin` property on events during redaction, however, as of this writing, the only use within the 
-spec of  `origin` as a top-level event property is a malformed example of event format. The field has no 
+top-level `origin` property on events during redaction, however, as of this writing, the only use within the
+spec of `origin` as a top-level event property is a malformed example of event format. The field has no
 significant meaning in modern room versions.
 
 Within the ecosystem, it's clear that we'd [prefer the field to disappear](https://github.com/matrix-org/matrix-spec/issues/374),
@@ -18,9 +18,9 @@ taken [steps](https://github.com/matrix-org/synapse/pull/8324) towards that miss
 in the area. In a [quick audit](https://github.com/matrix-org/matrix-spec-proposals/pull/3989#issuecomment-1497659507)
 of the Synapse codebase during implementation of this MSC, the `origin` field appears unused.
 
-Given the above context, this proposal removes the `origin` field from the [redaction algorithm](https://spec.matrix.org/v1.7/rooms/v10/#redactions) in
-future room versions, leaving it as-is for existing versions (not that an MSC can change the behaviour
-of an already-stable room version).
+Given the above context, this proposal removes the `origin` field from the [redaction algorithm](https://spec.matrix.org/v1.7/rooms/v10/#redactions)
+in a future room version, leaving it as-is for existing versions (not that an MSC can change the behaviour
+of an already-stable room version anyways).
 
 Some other fields are additionally useless in modern room versions, however they are already adapted
 by [MSC2176](https://github.com/matrix-org/matrix-spec-proposals/pull/2176).


### PR DESCRIPTION
[Rendered](https://github.com/matrix-org/matrix-spec-proposals/blob/travis/msc/redact-origin-field/proposals/3989-redact-origin-field.md)

Implementations:
* Synapse: https://github.com/matrix-org/synapse/pull/15393

[FCP tickyboxes](https://github.com/matrix-org/matrix-spec-proposals/pull/3989#issuecomment-1562039040)