### PR TITLE
Clarify how to make use of unstable prefixes in your MSC

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,27 +184,29 @@ like help with writing spec PRs, feel free to join and ask questions in the
 
 #### Stable and unstable prefixes
 
-*Unstable* prefixes are the namespaces which are used by implementations while
-an MSC is not yet accepted. For instance, an MSC can propose that a `m.space`
+"Unstable prefixes" are the namespaces which are used by implementations while
+an MSC is not yet accepted.
+
+For instance, an MSC might propose that a `m.space`
 event type or an `/_matrix/client/v1/account/whoami` endpoint should exist.
-However, an implementation of that same MSC cannot use a *stable* prefix (in the
-case, `/_matrix/client/` or `m.`) until the MSC has been accepted, as the
-underlying design may change at any time; the design is
+However, implementations cannot use these *stable* identifiers until the MSC
+has been accepted, as the underlying design may change at any time; the design is
 *unstable*.
 
-Typically MSCs will define `org.matrix.msc1234` (using the real MSC number once
-known) as an *unstable* prefix. For the above examples, this would mean using
-`org.matrix.msc1234.space` and
-`/_matrix/client/unstable/org.matrix.msc1234/account/whoami` to allow for
-breaking changes between edits of the MSC itself, or to not clash with another
-MSC that's attempting to add the same stable identifiers. The unstable
-prefixes, in this case, are `org.matrix.msc1234` and `/_matrix/client/unstable`
-respectively. It is also fine to use more traditional forms of namespace
-prefixes, such as `com.example.*` (e.g. `com.example.space`).
+Instead, an MSC can define a namespace such as `org.matrix.msc1234` (using the real
+MSC number once known) which is added to the stable identifier, allowing for
+breaking changes between edits of the MSC itself, and preventing clashes with other
+MSCs that might attempt to add the same stable identifiers. 
 
-Note: not all MSCs need to make use of unstable prefixes. They are only needed
-when defining new endpoints, field names, etc. in your MSC, and serve to allow
-implementations of your MSC to exist in the wild before your MSC is accepted.
+For the above examples, this would mean using `org.matrix.msc1234.space` and
+`/_matrix/client/unstable/org.matrix.msc1234/account/whoami`. It is also fine to
+use more traditional forms of namespace prefixes, such as `com.example.*` (e.g. `com.example.space`).
+
+Note: not all MSCs need to make use of unstable prefixes. They are only needed if
+implementations of your MSC need to exist in the wild before your MSC is accepted,
+*and* the MSC defines new endpoints, field names, etc.
+
+#### Unstable feature flags
 
 It is common when implementing support for an MSC that a client may wish to check
 if the homeserver it is communicating with supports an MSC.
@@ -245,10 +247,8 @@ At this point, it may be best to wait until a new spec version is released with
 your changes. Homeservers that support the changes will eventually advertise
 that spec version under `/versions`, and your client can check for that.
 
-But if you really can't wait, then there is another option.
-
-This is often solved by having the homeserver tell clients that it supports
-stable prefixes, using yet another `unstable_features` flag:
+But if you really can't wait, then there is another option: the homeserver can
+tell clients that it supports *stable* indentifiers for the new MSC, using yet another `unstable_features` flag:
 
 ```json5
 {
@@ -260,12 +260,12 @@ stable prefixes, using yet another `unstable_features` flag:
 ```
 
 If a client sees that `org.matrix.msc1234.stable` is `true`, it knows that it
-can start using stable prefixes, and the homeserver will accept and act on
+can start using stable identifiers for the new MSC, and the homeserver will accept and act on
 them accordingly.
 
 While the general pattern of using the text ".stable" has emerged from previous
 MSCs, you can pick any name you like. You need only to clearly state their
-meaning, usually udner an "Unstable prefixes" header in your MSC.
+meaning, usually under an "Unstable prefixes" header in your MSC.
 
 See
 [MSC3827](https://github.com/matrix-org/matrix-spec-proposals/blob/main/proposals/3827-space-explore.md#unstable-prefix)

--- a/README.md
+++ b/README.md
@@ -182,20 +182,81 @@ like help with writing spec PRs, feel free to join and ask questions in the
 
 ### Other useful information
 
-#### Unstable prefixes
+#### Stable and unstable prefixes
 
-*Unstable* prefixes are the namespaces which are used before an MSC has
-completed FCP (see above). While the MSC might propose that a `m.space` or
-`/_matrix/client/v1/account/whoami` endpoint should exist, the implementation
-cannot use a *stable* identifier such as `/v1/` or `m.space` prior to the MSC
-being accepted: it needs unstable prefixes.
+*Unstable* prefixes are the namespaces which are used by implementations while
+an MSC is not yet accepted. For instance, an MSC can propose an a `m.space`
+event type or an `/_matrix/client/v1/account/whoami` endpoint should exist.
+However, an implementation of that same MSC cannot use a *stable* prefix (in the
+case, `/_matrix/client/` or `m.`) until the MSC has been accepted, as the
+underlying design may change at any time; the design is
+*unstable*.
 
-Typically for MSCs, one will use `org.matrix.msc0000` (using the real MSC
-number once known) as a prefix. For the above examples, this would mean
-`org.matrix.msc0000.space` and
-`/_matrix/client/unstable/org.matrix.msc0000/account/whoami` to allow for
-breaking compatibility changes between edits of the MSC itself, or indeed
-another competing MSC that's attempting to add the same identifiers.
+Typically MSCs will define `org.matrix.msc1234` (using the real MSC number once
+known) as an *unstable* prefix. For the above examples, this would mean using
+`org.matrix.msc1234.space` and
+`/_matrix/client/unstable/org.matrix.msc1234/account/whoami` to allow for
+breaking changes between edits of the MSC itself, or to not clash with another
+MSC that's attempting to add the same stable identifiers. The unstable prefixes
+in this case of `org.matrix.msc1234` and `/_matrix/client/unstable`
+respectively.
+
+Note: not all MSCs need to make use of unstable prefixes. They are only needed
+when defining new endpoints, field names, etc. in your MSC, and serve to allow
+implementations of your MSC to exist in the wild before your MSC is accepted.
+
+In the case of some MSCs, implementation types may need a way to check that another
+implementation type supports this feature. A common case is when a client that has
+implemented an MSC needs to check whether the homeserver it is talking to has
+also implemented support. Typically, this is handled by the MSC defining an
+entry in the `unstable_features` dictionary of the
+[`/_matrix/client/versions`](https://spec.matrix.org/v1.6/client-server-api/#get_matrixclientversions)
+endpoint, in the form of a new entry:
+
+```json5
+{
+  "unstable_features": {
+    "org.matrix.msc1234": true
+  }
+}
+```
+
+With a value of `true` indicating that the feature is supported, and `false`
+or lack of the field altogether indicating the feature is not supported.
+
+According to the spec process, once an MSC has been accepted, implementations
+are allowed to switch to *stable* prefixes (i.e. `m.`). However, the MSC is
+still not yet part of a released spec version. How can a homeserver advertise to
+clients that they can start using *stable* prefixes, before the homeserver
+advertises support for a spec release which contains the new endpoint? One case
+where this poses a problem is when an MSC proposes new event types or fields.
+
+Events are immutable data. A client may wish to introduce your new feature, but
+if it sending events with unstable prefixes, eventually those events won't
+be supported by future clients, and thus that data will be effectively lost!
+
+This is often solved by having the homeserver telling clients that it supports
+stable prefixes for an MSC with yet another `unstable_features` flag:
+
+```json5
+{
+  "unstable_features": {
+    "org.matrix.msc1234": true,
+    "org.matrix.msc1234.stable": true
+  }
+}
+```
+
+If a client sees `org.matrix.msc1234.stable` is `true`, it knows that it can
+start sending events with stable prefixes, and the homeserver will accept them
+accordingly.
+
+While the general pattern of adding a new `*.stable` flag has emerged from
+previous MSCs (see
+[MSC3827](https://github.com/matrix-org/matrix-spec-proposals/blob/main/proposals/3827-space-explore.md#unstable-prefix)
+for a good example of how to include this information in your MSC), you can pick
+any name you like for your unstable prefixes. You need only to clearly state
+their meaning, usually under an "Unstable prefixes" header in your MSC.
 
 
 #### Room versions

--- a/README.md
+++ b/README.md
@@ -200,7 +200,8 @@ MSCs that might attempt to add the same stable identifiers.
 
 For the above examples, this would mean using `org.matrix.msc1234.space` and
 `/_matrix/client/unstable/org.matrix.msc1234/account/whoami`. It is also fine to
-use more traditional forms of namespace prefixes, such as `com.example.*` (e.g. `com.example.space`).
+use more traditional forms of namespace prefixes, such as `com.example.*` (e.g.
+`com.example.space`).
 
 Note: not all MSCs need to make use of unstable prefixes. They are only needed if
 implementations of your MSC need to exist in the wild before your MSC is accepted,
@@ -226,13 +227,12 @@ endpoint, in the form of a new entry:
 With a value of `true` indicating that the feature is supported, and `false`
 or lack of the field altogether indicating the feature is not supported.
 
-#### When can I use stable prefixes?
+#### When can I use stable identifiers?
 
 [According to the spec
 process](https://spec.matrix.org/proposals/#early-release-of-an-mscidea): once
 an MSC has been accepted, implementations are allowed to switch to *stable*
-prefixes (i.e. `m.`). However, the MSC is still not yet part of a released spec
-version.
+identifiers. However, the MSC is still not yet part of a released spec version.
 
 In most cases, this is not an issue. For instance, if your MSC specifies a new
 event type, you can now start sending events with those types!
@@ -248,7 +248,8 @@ your changes. Homeservers that support the changes will eventually advertise
 that spec version under `/versions`, and your client can check for that.
 
 But if you really can't wait, then there is another option: the homeserver can
-tell clients that it supports *stable* indentifiers for the new MSC, using yet another `unstable_features` flag:
+tell clients that it supports *stable* indentifiers for your MSC before it
+enters a spec version, using yet another `unstable_features` flag:
 
 ```json5
 {
@@ -260,12 +261,12 @@ tell clients that it supports *stable* indentifiers for the new MSC, using yet a
 ```
 
 If a client sees that `org.matrix.msc1234.stable` is `true`, it knows that it
-can start using stable identifiers for the new MSC, and the homeserver will accept and act on
-them accordingly.
+can start using stable identifiers for the new MSC, and the homeserver will
+accept and act on them accordingly.
 
-While the general pattern of using the text ".stable" has emerged from previous
-MSCs, you can pick any name you like. You need only to clearly state their
-meaning, usually under an "Unstable prefixes" header in your MSC.
+Note: While the general pattern of using the text ".stable" has emerged from
+previous MSCs, you can pick any name you like. You need only to clearly state
+their meaning, usually under an "Unstable prefixes" header in your MSC.
 
 See
 [MSC3827](https://github.com/matrix-org/matrix-spec-proposals/blob/main/proposals/3827-space-explore.md#unstable-prefix)

--- a/README.md
+++ b/README.md
@@ -224,19 +224,31 @@ endpoint, in the form of a new entry:
 With a value of `true` indicating that the feature is supported, and `false`
 or lack of the field altogether indicating the feature is not supported.
 
-According to the spec process, once an MSC has been accepted, implementations
-are allowed to switch to *stable* prefixes (i.e. `m.`). However, the MSC is
-still not yet part of a released spec version. How can a homeserver advertise to
-clients that they can start using *stable* prefixes, before the homeserver
-advertises support for a spec release which contains the new endpoint? One case
-where this poses a problem is when an MSC proposes new event types or fields.
+#### When can I use stable prefixes?
 
-Events are immutable data. A client may wish to introduce your new feature, but
-if it sending events with unstable prefixes, eventually those events won't
-be supported by future clients, and thus that data will be effectively lost!
+[According to the spec
+process](https://spec.matrix.org/proposals/#early-release-of-an-mscidea): once
+an MSC has been accepted, implementations are allowed to switch to *stable*
+prefixes (i.e. `m.`). However, the MSC is still not yet part of a released spec
+version.
 
-This is often solved by having the homeserver telling clients that it supports
-stable prefixes for an MSC with yet another `unstable_features` flag:
+In most cases, this is not an issue. For instance, if your MSC specifies a new
+event type, you can now start sending events with those types!
+
+Some MSCs introduce functionality where coordination between implementations is
+needed. For instance, a client may want to know whether a homeserver supports
+the stable version of a new endpoint before actually attempting to request it.
+Or perhaps the new event type you're trying to send relies on the homeserver
+recognising that new event type, and doing some work when it sees it.
+
+At this point, it may be best to wait until a new spec version is released with
+your changes. Homeservers that support the changes will eventually advertise
+that spec version under `/versions`, and your client can check for that.
+
+But if you really can't wait, then there is another option.
+
+This is often solved by having the homeserver tell clients that it supports
+stable prefixes, using yet another `unstable_features` flag:
 
 ```json5
 {
@@ -247,17 +259,18 @@ stable prefixes for an MSC with yet another `unstable_features` flag:
 }
 ```
 
-If a client sees `org.matrix.msc1234.stable` is `true`, it knows that it can
-start sending events with stable prefixes, and the homeserver will accept them
-accordingly.
+If a client sees that `org.matrix.msc1234.stable` is `true`, it knows that it
+can start using stable prefixes, and the homeserver will accept and act on
+them accordingly.
 
-While the general pattern of adding a new `*.stable` flag has emerged from
-previous MSCs (see
+While the general pattern of using the text ".stable" has emerged from previous
+MSCs, you can pick any name you like. You need only to clearly state their
+meaning, usually udner an "Unstable prefixes" header in your MSC.
+
+See
 [MSC3827](https://github.com/matrix-org/matrix-spec-proposals/blob/main/proposals/3827-space-explore.md#unstable-prefix)
-for a good example of how to include this information in your MSC), you can pick
-any name you like for your unstable prefixes. You need only to clearly state
-their meaning, usually under an "Unstable prefixes" header in your MSC.
-
+for a good example of an MSC that wanted to use such a flag to speed up
+implementation rollout, and how it did so.
 
 #### Room versions
 

--- a/README.md
+++ b/README.md
@@ -205,10 +205,9 @@ Note: not all MSCs need to make use of unstable prefixes. They are only needed
 when defining new endpoints, field names, etc. in your MSC, and serve to allow
 implementations of your MSC to exist in the wild before your MSC is accepted.
 
-In the case of some MSCs, implementation types may need a way to check that another
-implementation type supports this feature. A common case is when a client that has
-implemented an MSC needs to check whether the homeserver it is talking to has
-also implemented support. Typically, this is handled by the MSC defining an
+It is common when implementing support for an MSC that a client may wish to check
+if the homeserver it is communicating with supports an MSC.
+Typically, this is handled by the MSC defining an
 entry in the `unstable_features` dictionary of the
 [`/_matrix/client/versions`](https://spec.matrix.org/v1.6/client-server-api/#get_matrixclientversions)
 endpoint, in the form of a new entry:

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ like help with writing spec PRs, feel free to join and ask questions in the
 
 ### Other useful information
 
-#### Stable and unstable prefixes
+#### Unstable prefixes
 
 "Unstable prefixes" are the namespaces which are used by implementations while
 an MSC is not yet accepted.

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ endpoint, in the form of a new entry:
 }
 ```
 
-With a value of `true` indicating that the feature is supported, and `false`
+... with a value of `true` indicating that the feature is supported, and `false`
 or lack of the field altogether indicating the feature is not supported.
 
 #### When can I use stable identifiers?

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ like help with writing spec PRs, feel free to join and ask questions in the
 #### Stable and unstable prefixes
 
 *Unstable* prefixes are the namespaces which are used by implementations while
-an MSC is not yet accepted. For instance, an MSC can propose an a `m.space`
+an MSC is not yet accepted. For instance, an MSC can propose that a `m.space`
 event type or an `/_matrix/client/v1/account/whoami` endpoint should exist.
 However, an implementation of that same MSC cannot use a *stable* prefix (in the
 case, `/_matrix/client/` or `m.`) until the MSC has been accepted, as the
@@ -197,9 +197,10 @@ known) as an *unstable* prefix. For the above examples, this would mean using
 `org.matrix.msc1234.space` and
 `/_matrix/client/unstable/org.matrix.msc1234/account/whoami` to allow for
 breaking changes between edits of the MSC itself, or to not clash with another
-MSC that's attempting to add the same stable identifiers. The unstable prefixes
-in this case of `org.matrix.msc1234` and `/_matrix/client/unstable`
-respectively.
+MSC that's attempting to add the same stable identifiers. The unstable
+prefixes, in this case, are `org.matrix.msc1234` and `/_matrix/client/unstable`
+respectively. It is also fine to use more traditional forms of namespace
+prefixes, such as `com.example.*` (e.g. `com.example.space`).
 
 Note: not all MSCs need to make use of unstable prefixes. They are only needed
 when defining new endpoints, field names, etc. in your MSC, and serve to allow


### PR DESCRIPTION
This PR adds a section to the simple spec guide that gives some background to MSC authors on how to effectively make use of unstable and stable prefixes.