### PR TITLE
MSC4037: Thread root is not in the thread

### DIFF
--- a/proposals/4037-thread-root-is-not-in-thread.md
+++ b/proposals/4037-thread-root-is-not-in-thread.md
@@ -83,6 +83,26 @@ We propose that thread roots are in the main timeline, making the definition:
 > thread roots, and other events with non-thread relations to a thread root are
 > in the main timeline.
 
+## How we got here
+
+The MSC that introduced read receipts for threads is
+[MSC3771](https://github.com/matrix-org/matrix-spec-proposals/pull/3771).
+
+The relevant wording is in the
+[Proposal](https://github.com/matrix-org/matrix-spec-proposals/blob/main/proposals/3771-read-receipts-for-threads.md#proposal)
+section:
+
+> notifications generated from events with a thread relation matching the
+> receipt’s thread ID prior to and including that event which are MUST be marked
+> as read
+
+Notably it only mentions things "**with a thread relation**", so it appears to
+match the wording of this proposal.
+
+It comes tantalisingly close to covering these issues in the example it uses,
+but unfortunately does not cover what would happen if we received a receipt for
+a thread root or for e.g. an edit of a thread root.
+
 ## Potential issues
 
 None known.

--- a/proposals/4037-thread-root-is-not-in-thread.md
+++ b/proposals/4037-thread-root-is-not-in-thread.md
@@ -39,8 +39,8 @@ This is problematic because:
   they have only read the thread root.
 
 In practice, Synapse
-[ignores any request to mark the thread root as read](https://github.com/matrix-org/synapse/blob/v1.87.0/synapse/rest/client/receipts.py#L116-L154)
-within the thread, and accepts requests to mark it as read in the main timeline.
+[returns an error for any request to mark the thread root as read within the thread](https://github.com/matrix-org/synapse/blob/v1.87.0/synapse/rest/client/receipts.py#L116-L154),
+and accepts requests to mark it as read in the main timeline.
 When it reports thread notifications, it excludes thread roots (and e.g. edits
 to thread roots) from the thread count, only showing them in the main timeline
 count.

--- a/proposals/4037-thread-root-is-not-in-thread.md
+++ b/proposals/4037-thread-root-is-not-in-thread.md
@@ -64,6 +64,9 @@ We propose that thread roots are in the main timeline, making the definition:
 >
 > Events not in a thread but still in the room are considered to be part of the
 > "main timeline": a special thread with an ID of `main`.
+>
+> Note: thread roots (events that are referred to in a `m.thread` relationship)
+> are in the main timeline.
 
 ## Potential issues
 

--- a/proposals/4037-thread-root-is-not-in-thread.md
+++ b/proposals/4037-thread-root-is-not-in-thread.md
@@ -9,7 +9,7 @@ This is important for creating and interpreting read receipts.
 ## Motivation
 
 The current spec, in
-[11.6.2.2 Threaded read receipts](https://spec.matrix.org/unstable/client-server-api/#threaded-read-receipts)
+[11.6.2.2 Threaded read receipts](https://spec.matrix.org/v1.7/client-server-api/#threaded-read-receipts)
 says:
 
 > An event is considered to be "in a thread" if it meets any of the following

--- a/proposals/4037-thread-root-is-not-in-thread.md
+++ b/proposals/4037-thread-root-is-not-in-thread.md
@@ -50,6 +50,9 @@ timeline: any message can become a thread root at any time, when a user creates
 a new threaded message pointing at it, so suddenly switching which receipts are
 allowed to apply to it would not be sensible.
 
+Similarly, it does not make sense for reactions to the thread root (or other
+related events such as edits) to be outside the main timeline.
+
 ## Proposal
 
 We propose that thread roots are in the main timeline, making the definition:

--- a/proposals/4037-thread-root-is-not-in-thread.md
+++ b/proposals/4037-thread-root-is-not-in-thread.md
@@ -67,6 +67,7 @@ We propose that thread roots are in the main timeline, making the definition:
 
 ## Potential issues
 
+None known.
 
 ## Alternatives
 
@@ -77,10 +78,12 @@ been read. A thread cannot exist without at least one additional message.
 
 ## Security considerations
 
+Unlikely to have any security impact.
 
 ## Unstable prefix
 
+None needed.
 
 ## Dependencies
 
-
+No dependencies.

--- a/proposals/4037-thread-root-is-not-in-thread.md
+++ b/proposals/4037-thread-root-is-not-in-thread.md
@@ -83,7 +83,7 @@ We propose that thread roots are in the main timeline, making the definition:
 >
 > Note: thread roots (events that are referred to in a `m.thread` relationship)
 > are in the main timeline. Similarly, reactions to thread roots, edits of
-> thread root, and other events with non-thread relations to a thread root are
+> thread roots, and other events with non-thread relations to a thread root are
 > in the main timline.
 
 ## Potential issues

--- a/proposals/4037-thread-root-is-not-in-thread.md
+++ b/proposals/4037-thread-root-is-not-in-thread.md
@@ -43,7 +43,7 @@ the thread, and accepts requests to mark it as read in the main timeline.
 
 In consequence, Element Web exhibited bugs relating to unread rooms while its
 underlying library used spec-compliant behaviour, many of which were fixed by
-[adoptingthe behaviour recommended by this proposal](https://github.com/matrix-org/matrix-js-sdk/pull/3600).
+[adopting the behaviour recommended by this proposal](https://github.com/matrix-org/matrix-js-sdk/pull/3600).
 
 It really does not make sense to treat thread roots as outside the main
 timeline: any message can become a thread root at any time, when a user creates

--- a/proposals/4037-thread-root-is-not-in-thread.md
+++ b/proposals/4037-thread-root-is-not-in-thread.md
@@ -52,7 +52,13 @@ a new threaded message pointing at it, so suddenly switching which receipts are
 allowed to apply to it would not be sensible.
 
 Similarly, it does not make sense for reactions to the thread root (or other
-related events such as edits) to be outside the main timeline.
+related events such as edits) to be outside the main timeline, for similar
+reasons: the message we are reacting to can become a thread root at any time,
+making our previous receipt invalid retrospectively. (We could conceivably allow
+receipts to exist both within a thread and the main timeline, but this does not
+match the expected user mental model: I have either read a reaction/edit/reply,
+or I have not - I don't want to have to read it twice just because it appears in
+two places in the UI.)
 
 ## Proposal
 

--- a/proposals/4037-thread-root-is-not-in-thread.md
+++ b/proposals/4037-thread-root-is-not-in-thread.md
@@ -82,7 +82,9 @@ We propose that thread roots are in the main timeline, making the definition:
 > "main timeline": a special thread with an ID of `main`.
 >
 > Note: thread roots (events that are referred to in a `m.thread` relationship)
-> are in the main timeline.
+> are in the main timeline. Similarly, reactions to thread roots, edits of
+> thread root, and other events with non-thread relations to a thread root are
+> in the main timline.
 
 ## Potential issues
 

--- a/proposals/4037-thread-root-is-not-in-thread.md
+++ b/proposals/4037-thread-root-is-not-in-thread.md
@@ -4,15 +4,75 @@ The current spec implies that a thread root is considered within the thread, but
 we argue that this does not make sense, and a thread root is not "in" it the
 thread branching from it.
 
+This is important for creating and interpreting read receipts.
+
+## Motivation
+
+The current spec, in
+[11.6.2.2 Threaded read receipts](https://spec.matrix.org/unstable/client-server-api/#threaded-read-receipts)
+says:
+
+> An event is considered to be "in a thread" if it meets any of the following
+> criteria:
+>
+> * It has a `rel_type` of `m.thread`.
+> * It has child events with a `rel_type` of `m.thread` (in which case it’d be
+>   the thread root).
+> * Following the event relationships, it has a parent event which qualifies for
+>   one of the above. Implementations should not recurse infinitely, though: a
+>   maximum of 3 hops is recommended to cover indirect relationships.
+>
+> Events not in a thread but still in the room are considered to be part of the
+> "main timeline", or a special thread with an ID of `main`.
+
+This explicitly includes thread roots in the thread which branches off them, and
+implicitly _excludes_ those messages from being in the `main` thread.
+
+This is problematic because:
+
+* It seems natural for messages that are displayed in the main timeline (as
+  thread roots are in most clients) to be considered read/unread when the user
+  reads them in the main timeline.
+
+* It normally does not make sense for a threaded read receipt to point at the
+  thread root, since the user has not really read anything in that thread if
+  they have only read the thread root.
+
+In practice, Synapse ignores any request to mark the thread root as read within
+the thread, and accepts requests to mark it as read in the main timeline.
+
+In consequence, Element Web displayed bugs relating to unread rooms while its
+underlying library used spec-compliant behaviour, many of which were fixed by
+[reverting to the behaviour recommended by this proposal](https://github.com/matrix-org/matrix-js-sdk/pull/3600).
+
+It really does not make sense to treat thread roots as outside the main
+timeline: any message can become a thread root at any time, when a user creates
+a new threaded message pointing at it.
+
 ## Proposal
 
+We propose this definition:
 
+> An event is considered to be "in a thread" if:
+>
+> * It has a `rel_type` of `m.thread`, or it has an ancestor event with this
+>   `rel_type`.
+>
+> Implementations should limit recursion to find ancestors: a maximum of 3 hops
+> is recommended.
+>
+> Events not in a thread but still in the room are considered to be part of the
+> "main timeline": a special thread with an ID of `main`.
 
 ## Potential issues
 
 
 ## Alternatives
 
+We could treat thread roots as being in *both* their thread and the `main`
+timeline, but it does not offer much benefit because a thread where only the
+root message has been read is almost identical to one where the no messages have
+been read. A thread cannot exist without at least one additional message.
 
 ## Security considerations
 

--- a/proposals/4037-thread-root-is-not-in-thread.md
+++ b/proposals/4037-thread-root-is-not-in-thread.md
@@ -55,10 +55,16 @@ Similarly, it does not make sense for reactions to the thread root (or other
 related events such as edits) to be outside the main timeline, for similar
 reasons: the message we are reacting to can become a thread root at any time,
 making our previous receipt invalid retrospectively. (We could conceivably allow
-receipts to exist both within a thread and the main timeline, but this does not
+receipts to exist both within a thread and the main timeline[^1], but this does not
 match the expected user mental model: I have either read a reaction/edit/reply,
 or I have not - I don't want to have to read it twice just because it appears in
 two places in the UI.)
+
+[^1]: In fact, observation of Synapse's behaviour shows that it does appear to
+  track two read/unread statuses for edits of thread roots, but not for thread
+  roots themselves. The code for this is in
+  [receipts.py](https://github.com/matrix-org/synapse/blob/v1.87.0/synapse/rest/client/receipts.py#L116-L154).
+  We still argue that this behaviour does not match the user's mental model.
 
 ## Proposal
 

--- a/proposals/4037-thread-root-is-not-in-thread.md
+++ b/proposals/4037-thread-root-is-not-in-thread.md
@@ -1,8 +1,8 @@
 # MSC4037: Thread root is not in the thread
 
 The current spec implies that a thread root is considered within the thread, but
-we argue that this does not make sense, and a thread root is not "in" it the
-thread branching from it.
+we argue that this does not make sense, and a thread root is not "in" the thread
+branching from it.
 
 This is important for creating and interpreting read receipts.
 
@@ -41,17 +41,18 @@ This is problematic because:
 In practice, Synapse ignores any request to mark the thread root as read within
 the thread, and accepts requests to mark it as read in the main timeline.
 
-In consequence, Element Web displayed bugs relating to unread rooms while its
+In consequence, Element Web exhibited bugs relating to unread rooms while its
 underlying library used spec-compliant behaviour, many of which were fixed by
-[reverting to the behaviour recommended by this proposal](https://github.com/matrix-org/matrix-js-sdk/pull/3600).
+[adoptingthe behaviour recommended by this proposal](https://github.com/matrix-org/matrix-js-sdk/pull/3600).
 
 It really does not make sense to treat thread roots as outside the main
 timeline: any message can become a thread root at any time, when a user creates
-a new threaded message pointing at it.
+a new threaded message pointing at it, so suddenly switching which receipts are
+allowed to apply to it would not be sensible.
 
 ## Proposal
 
-We propose this definition:
+We propose that thread roots are in the main timeline, making the definition:
 
 > An event is considered to be "in a thread" if:
 >

--- a/proposals/4037-thread-root-is-not-in-thread.md
+++ b/proposals/4037-thread-root-is-not-in-thread.md
@@ -84,7 +84,7 @@ We propose that thread roots are in the main timeline, making the definition:
 > Note: thread roots (events that are referred to in a `m.thread` relationship)
 > are in the main timeline. Similarly, reactions to thread roots, edits of
 > thread roots, and other events with non-thread relations to a thread root are
-> in the main timline.
+> in the main timeline.
 
 ## Potential issues
 

--- a/proposals/4037-thread-root-is-not-in-thread.md
+++ b/proposals/4037-thread-root-is-not-in-thread.md
@@ -2,7 +2,7 @@
 
 The current spec implies that a thread root is considered within the thread, but
 we argue that this does not make sense, and a thread root is not "in" the thread
-branching from it.
+branching from it, and neither are its non-thread children (e.g. edits).
 
 This is important for creating and interpreting read receipts.
 
@@ -25,8 +25,9 @@ says:
 > Events not in a thread but still in the room are considered to be part of the
 > "main timeline", or a special thread with an ID of `main`.
 
-This explicitly includes thread roots in the thread which branches off them, and
-implicitly _excludes_ those messages from being in the `main` thread.
+This explicitly includes thread roots (and their non-thread children) in the
+thread which branches off them, and implicitly _excludes_ those messages from
+being in the `main` thread.
 
 This is problematic because:
 
@@ -65,7 +66,8 @@ two places in the UI.)
 
 ## Proposal
 
-We propose that thread roots are in the main timeline, making the definition:
+We propose that thread roots and their non-thread children are in the main
+timeline, making the definition:
 
 > An event is considered to be "in a thread" if:
 >

--- a/proposals/4037-thread-root-is-not-in-thread.md
+++ b/proposals/4037-thread-root-is-not-in-thread.md
@@ -41,6 +41,9 @@ This is problematic because:
 In practice, Synapse
 [ignores any request to mark the thread root as read](https://github.com/matrix-org/synapse/blob/v1.87.0/synapse/rest/client/receipts.py#L116-L154)
 within the thread, and accepts requests to mark it as read in the main timeline.
+When it reports thread notifications, it excludes thread roots (and e.g. edits
+to thread roots) from the thread count, only showing them in the main timeline
+count.
 
 In consequence, Element Web exhibited bugs relating to unread rooms while its
 underlying library used spec-compliant behaviour, many of which were fixed by
@@ -55,16 +58,10 @@ Similarly, it does not make sense for reactions to the thread root (or other
 related events such as edits) to be outside the main timeline, for similar
 reasons: the message we are reacting to can become a thread root at any time,
 making our previous receipt invalid retrospectively. (We could conceivably allow
-receipts to exist both within a thread and the main timeline[^1], but this does not
+receipts to exist both within a thread and the main timeline, but this does not
 match the expected user mental model: I have either read a reaction/edit/reply,
 or I have not - I don't want to have to read it twice just because it appears in
 two places in the UI.)
-
-[^1]: In fact, observation of Synapse's behaviour shows that it does appear to
-  track two read/unread statuses for edits of thread roots, but not for thread
-  roots themselves. The code for this is in
-  [receipts.py](https://github.com/matrix-org/synapse/blob/v1.87.0/synapse/rest/client/receipts.py#L116-L154).
-  We still argue that this behaviour does not match the user's mental model.
 
 ## Proposal
 

--- a/proposals/4037-thread-root-is-not-in-thread.md
+++ b/proposals/4037-thread-root-is-not-in-thread.md
@@ -38,8 +38,9 @@ This is problematic because:
   thread root, since the user has not really read anything in that thread if
   they have only read the thread root.
 
-In practice, Synapse ignores any request to mark the thread root as read within
-the thread, and accepts requests to mark it as read in the main timeline.
+In practice, Synapse
+[ignores any request to mark the thread root as read](https://github.com/matrix-org/synapse/blob/v1.87.0/synapse/rest/client/receipts.py#L116-L154)
+within the thread, and accepts requests to mark it as read in the main timeline.
 
 In consequence, Element Web exhibited bugs relating to unread rooms while its
 underlying library used spec-compliant behaviour, many of which were fixed by

--- a/proposals/4037-thread-root-is-not-in-thread.md
+++ b/proposals/4037-thread-root-is-not-in-thread.md
@@ -1,0 +1,25 @@
+# MSC4037: Thread root is not in the thread
+
+The current spec implies that a thread root is considered within the thread, but
+we argue that this does not make sense, and a thread root is not "in" it the
+thread branching from it.
+
+## Proposal
+
+
+
+## Potential issues
+
+
+## Alternatives
+
+
+## Security considerations
+
+
+## Unstable prefix
+
+
+## Dependencies
+
+


### PR DESCRIPTION
[Rendered](https://github.com/matrix-org/matrix-spec-proposals/blob/andybalaam/thread-root-is-not-in-thread/proposals/4037-thread-root-is-not-in-thread.md)

Implementations:

* [Synapse](https://github.com/matrix-org/synapse/blob/v1.87.0/synapse/rest/client/receipts.py#L116-L154) has the behaviour specified in this proposal [^1]

[^1]: although it is slightly inconsistent in that it rejects receipts for thread roots that claim to be in the thread, but it accepts receipts for reactions/edits to thread roots that claim to be in the thread, although they do not affect the notification count in the thread.

* [matrix-js-sdk](https://github.com/matrix-org/matrix-js-sdk/blob/develop/src/client.ts#L5004) was recently fixed to match the behaviour required by this proposal, as a bug fix for stuck notifications bugs resulting from inconsistency between Synapse and Element Web.