### PR TITLE
MSC4041: http header Retry-After for http code 429

### DIFF
--- a/proposals/0000-retry-after-header-rate-limiting.md
+++ b/proposals/0000-retry-after-header-rate-limiting.md
@@ -1,0 +1,51 @@
+# MSC0000: Use http header Retry-After to enable library-assisted retry handling
+
+The current Matrix Client-Server API (v1.7) recommends that home servers should protect themselves from
+being overloaded by enforcing rate-limits to selected API calls.
+If home servers limit access to an API they respond with an http error code 429 and a response body
+that includes a property `retry_after_ms` to indicate how long a client has to wait before retrying.
+
+Some http libraries (like [Ky](https://github.com/sindresorhus/ky), [got](https://github.com/sindresorhus/got
+and [urllib3](https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html#urllib3.util.Retry)) ease
+the burden of handling retries by honoring the http header `Retry-After`. As explained in 
+[RFC 9119 - HTTP Semantics](https://www.rfc-editor.org/rfc/rfc9110#field.retry-after) this header is optional
+and contains either a (relative) value for the delay in seconds or an (absolute) date.
+
+The current Matrix Client Server API specification does not take this header into account. This wastes the 
+potential that current http libraries offer in terms of automated retry handling.
+
+## Proposal
+
+In order to allow developers to make use of the automated retry handling capabilities of http libraries
+home servers should add an http header `Retry-After` in case they respond with an http error 429.
+Since the body of the response already contains a property `retry_after_ms` (in miliseconds) the value 
+of `Retry-After` should be the calculated by rounding up `retry_after_ms * 1000` to the next integer. 
+Doing so would correspond to a (relative) delay (in seconds) as defined in 
+[RFC 9119 - HTTP Semantics](https://www.rfc-editor.org/rfc/rfc9110#field.retry-after).
+
+## Potential issues
+
+Existing SDKs may use client libraries that migth be able to honor the http header `Retry-After`. Since 
+this header is currently not part of the response developers might have created purpose-built functions
+in order to handle rate-limiting correctly.
+
+If the http header `Retry-After` is introduced existing SDKs might behave differently thus leading to an
+unexpected behaviour.
+
+
+## Alternatives
+
+N/A
+
+
+## Security considerations
+
+N/A
+
+## Unstable prefix
+
+N/A
+
+## Dependencies
+
+N/A

--- a/proposals/4041-retry-after-header-rate-limiting.md
+++ b/proposals/4041-retry-after-header-rate-limiting.md
@@ -24,26 +24,23 @@ of `Retry-After` (in __seconds__) should be the calculated in order to comply wi
 
 ## Potential issues
 
+With the introduction of the http header `Retry-After` the usage of the `retry_after_ms` property in the response body becomes deprecated.
+
 Existing SDKs may use client libraries that might be able to honor the http header `Retry-After`. Since 
 this header is currently not part of the response developers might have created purpose-built functions
 in order to handle rate-limiting correctly.
 
-If the http header `Retry-After` is introduced existing SDKs might behave differently thus leading to an
-unexpected behaviour.
-
 In order to maintain backward compatibility home servers should use both the `Retry-After` header and the
-`retry_after_ms` property in the response body. 
+`retry_after_ms` property in the response body.
 
-In this case, client libraries are advised to use the values in this order:
+Client libraries are advised to use the values in this order:
 
 1) `Retry-After` http header.
 2) `retry_after_ms` property in the response body.
 
-
 ## Alternatives
 
 N/A
-
 
 ## Security considerations
 

--- a/proposals/4041-retry-after-header-rate-limiting.md
+++ b/proposals/4041-retry-after-header-rate-limiting.md
@@ -32,6 +32,14 @@ in order to handle rate-limiting correctly.
 If the http header `Retry-After` is introduced existing SDKs might behave differently thus leading to an
 unexpected behaviour.
 
+In order to maintain backward compatibility home servers should use both the `Retry-After` header and the
+`retry-after-ms` property in the response body. 
+
+In this case, client libraries are advised to use the values in this order:
+
+1) `Retry-After` http header.
+2) `retry-after-ms` property in the response body.
+
 
 ## Alternatives
 

--- a/proposals/4041-retry-after-header-rate-limiting.md
+++ b/proposals/4041-retry-after-header-rate-limiting.md
@@ -17,20 +17,15 @@ potential that current http libraries offer in terms of automated retry handling
 ## Proposal
 
 In order to allow developers to make use of the automated retry handling capabilities of http libraries
-home servers should add an http header `Retry-After` in case they respond with an http error 429.
-Since the body of the response already contains a property `retry_after_ms` (in __milliseconds__) the value 
-of `Retry-After` (in __seconds__) should be the calculated in order to comply with the specification in 
-[RFC 9119 - HTTP Semantics](https://www.rfc-editor.org/rfc/rfc9110#field.retry-after).
+home servers shall use the http header `Retry-After` in case they respond with an http error 429.
+The value of `Retry-After` (in __seconds__) is meant to be a delay after receiving the response and must be 
+calculated in order to comply with the specification in [RFC 9119 - HTTP Semantics](https://www.rfc-editor.org/rfc/rfc9110#field.retry-after).
+
+With the introduction of the http header `Retry-After` the usage of the existing `retry_after_ms` property in the response body becomes deprecated.
 
 ## Potential issues
 
-With the introduction of the http header `Retry-After` the usage of the `retry_after_ms` property in the response body becomes deprecated.
-
-Existing SDKs may use client libraries that might be able to honor the http header `Retry-After`. Since 
-this header is currently not part of the response developers might have created purpose-built functions
-in order to handle rate-limiting correctly.
-
-In order to maintain backward compatibility with existing client libraries home servers must use both the `Retry-After` header and the
+In order to maintain backward compatibility with existing client libraries home servers shall use both the `Retry-After` header and the
 `retry_after_ms` property in the response body.
 
 Client libraries shall use the values in this order:

--- a/proposals/4041-retry-after-header-rate-limiting.md
+++ b/proposals/4041-retry-after-header-rate-limiting.md
@@ -18,9 +18,8 @@ potential that current http libraries offer in terms of automated retry handling
 
 In order to allow developers to make use of the automated retry handling capabilities of http libraries
 home servers should add an http header `Retry-After` in case they respond with an http error 429.
-Since the body of the response already contains a property `retry_after_ms` (in milliseconds) the value 
-of `Retry-After` should be the calculated by rounding up `retry_after_ms / 1000` to the next integer. 
-Doing so would correspond to a (relative) delay (in seconds) as defined in 
+Since the body of the response already contains a property `retry_after_ms` (in __milliseconds__) the value 
+of `Retry-After` (in __seconds__) should be the calculated in order to comply with the specification in 
 [RFC 9119 - HTTP Semantics](https://www.rfc-editor.org/rfc/rfc9110#field.retry-after).
 
 ## Potential issues

--- a/proposals/4041-retry-after-header-rate-limiting.md
+++ b/proposals/4041-retry-after-header-rate-limiting.md
@@ -1,4 +1,4 @@
-# MSC0000: Use http header Retry-After to enable library-assisted retry handling
+# MSC4041: Use http header Retry-After to enable library-assisted retry handling
 
 The current Matrix Client-Server API (v1.7) recommends that home servers should protect themselves from
 being overloaded by enforcing rate-limits to selected API calls.

--- a/proposals/4041-retry-after-header-rate-limiting.md
+++ b/proposals/4041-retry-after-header-rate-limiting.md
@@ -30,10 +30,10 @@ Existing SDKs may use client libraries that might be able to honor the http head
 this header is currently not part of the response developers might have created purpose-built functions
 in order to handle rate-limiting correctly.
 
-In order to maintain backward compatibility home servers should use both the `Retry-After` header and the
+In order to maintain backward compatibility with existing client libraries home servers must use both the `Retry-After` header and the
 `retry_after_ms` property in the response body.
 
-Client libraries are advised to use the values in this order:
+Client libraries shall use the values in this order:
 
 1) `Retry-After` http header.
 2) `retry_after_ms` property in the response body.

--- a/proposals/4041-retry-after-header-rate-limiting.md
+++ b/proposals/4041-retry-after-header-rate-limiting.md
@@ -18,14 +18,14 @@ potential that current http libraries offer in terms of automated retry handling
 
 In order to allow developers to make use of the automated retry handling capabilities of http libraries
 home servers should add an http header `Retry-After` in case they respond with an http error 429.
-Since the body of the response already contains a property `retry_after_ms` (in miliseconds) the value 
+Since the body of the response already contains a property `retry_after_ms` (in milliseconds) the value 
 of `Retry-After` should be the calculated by rounding up `retry_after_ms / 1000` to the next integer. 
 Doing so would correspond to a (relative) delay (in seconds) as defined in 
 [RFC 9119 - HTTP Semantics](https://www.rfc-editor.org/rfc/rfc9110#field.retry-after).
 
 ## Potential issues
 
-Existing SDKs may use client libraries that migth be able to honor the http header `Retry-After`. Since 
+Existing SDKs may use client libraries that might be able to honor the http header `Retry-After`. Since 
 this header is currently not part of the response developers might have created purpose-built functions
 in order to handle rate-limiting correctly.
 

--- a/proposals/4041-retry-after-header-rate-limiting.md
+++ b/proposals/4041-retry-after-header-rate-limiting.md
@@ -33,12 +33,12 @@ If the http header `Retry-After` is introduced existing SDKs might behave differ
 unexpected behaviour.
 
 In order to maintain backward compatibility home servers should use both the `Retry-After` header and the
-`retry-after-ms` property in the response body. 
+`retry_after_ms` property in the response body. 
 
 In this case, client libraries are advised to use the values in this order:
 
 1) `Retry-After` http header.
-2) `retry-after-ms` property in the response body.
+2) `retry_after_ms` property in the response body.
 
 
 ## Alternatives

--- a/proposals/4041-retry-after-header-rate-limiting.md
+++ b/proposals/4041-retry-after-header-rate-limiting.md
@@ -19,7 +19,7 @@ potential that current http libraries offer in terms of automated retry handling
 In order to allow developers to make use of the automated retry handling capabilities of http libraries
 home servers should add an http header `Retry-After` in case they respond with an http error 429.
 Since the body of the response already contains a property `retry_after_ms` (in miliseconds) the value 
-of `Retry-After` should be the calculated by rounding up `retry_after_ms * 1000` to the next integer. 
+of `Retry-After` should be the calculated by rounding up `retry_after_ms / 1000` to the next integer. 
 Doing so would correspond to a (relative) delay (in seconds) as defined in 
 [RFC 9119 - HTTP Semantics](https://www.rfc-editor.org/rfc/rfc9110#field.retry-after).
 


### PR DESCRIPTION
[Rendered](https://github.com/syncpoint/matrix-spec-proposals/blob/main/proposals/4041-retry-after-header-rate-limiting.md)

This proposes the usage of the http header `Retry-After` in case a home server sends a http response 429 (rate limiting).

The `Retry-After` header handling was implemented in 
* [Synapse](https://github.com/matrix-org/synapse/pull/16136)
* [mautrix](https://github.com/mautrix/go/pull/44/commits/4f046814b89cc94ac0884291142bf52ef6f65b22)

----

[FCP tickyboxes](https://github.com/matrix-org/matrix-spec-proposals/pull/4041#issuecomment-1908591427)
