### PR TITLE
.editorconfig to formalize MSC proposal line length

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+# EditorConfig is awesome: https://EditorConfig.org
+root = true
+
+[*]
+insert_final_newline = true
+charset = utf-8
+max_line_length = 120


### PR DESCRIPTION
# .editorconfig to formalize MSC proposal line length

MSC writers are diverse people with different languages and preferences. It's a common occurrence that MSC reviewers request MSC authors to wrap their lines.

## Proposal

This proposal formalizes [the request to wrap lines to 120 characters maximum](https://github.com/matrix-org/matrix-spec-proposals?tab=readme-ov-file#1-writing-the-proposal) for editorconfig capable text editors which are becoming more prevalent.

## Potential issues

This proposal doesn't take into account text editors that don't support .editorconfig. However the author believes this to be a smaller issue than MSC authors having to reconfigure their text editors or have to be poked about line wrapping.

As additional concerns, this MSC doesn't touch already existing MSCs and doesn't comment on their line wrapping, in the future this could be addressed by [editorconfig-checker](https://github.com/editorconfig-checker/editorconfig-checker), perhaps as a [pre-commit](https://pre-commit.com) [hook](https://github.com/editorconfig-checker/editorconfig-checker.python).

A related concern is the matrix-spec-proposals repository not specifying line-endings in `.gitattributes` leaving that entirely to MSC author's individual git configurations. If either `lf` or `crlf` line-endings were to be required in the future, that should be specified in the `.editorconfig` file.

## Alternatives

The only alternative the author can think of is the current system where either MSC authors reconfigure their text editor just for the MSC writing process or the MSC reviewers request them to wrap their lines again.


## Security considerations

The author doesn't see security considerations with this MSC.

---

Signed-off-by: Aminda Suomalainen <831184+Mikaela@users.noreply.github.com>