### PR TITLE
Fix MSC3930's unstable prefix references

### DIFF
--- a/proposals/3930-polls-notifications.md
+++ b/proposals/3930-polls-notifications.md
@@ -138,6 +138,5 @@ None applicable - no new considerations need to be made with this proposal.
 ## Unstable prefix
 
 While this MSC is not considered stable, implementations should use `org.matrix.msc3930.*` as a prefix
-in place of `m.*` for the push rule IDs. As of writing, polls are only implemented using the legacy
-`org.matrix.msc3381.poll.*` prefix rather than the newer `v2` prefix - implementations of this MSC
-should be aware of which version of MSC3381 they plan to support.
+in place of `m.*` for the push rule IDs. The event types for those associated push rules are described
+by the [Unstable Prefix section of MSC3381](https://github.com/matrix-org/matrix-spec-proposals/blob/main/proposals/3381-polls.md#unstable-prefix).


### PR DESCRIPTION
This was [raised](https://matrix.to/#/!NasysSDfxKxZBzJJoE:matrix.org/$ec426qBJSziUIy_tWlmhifw8TNvlAME2Yg7XWPxPybc?via=matrix.org&via=envs.net&via=element.io) approximately 1 eternity ago, and I [said](https://matrix.to/#/!NasysSDfxKxZBzJJoE:matrix.org/$Xje6106Al6g_Oql_il9l-oKX9PUUo0b30irS1ijCDDs?via=matrix.org&via=envs.net&via=element.io) I'd fix it, so here's that PR (finally).

Review requirements: 1 SCT member to acknowledge the words make sense and are non-conflicting with the normative sections of the MSC.