### PR TITLE
Retrospectively re-update MSC2403 to clarify that invite->knock is *not* legal.

### DIFF
--- a/proposals/2403-knock.md
+++ b/proposals/2403-knock.md
@@ -438,8 +438,8 @@ first we summarise the semantics of the proposed changes.
 
 ### Current membership
 Only users without a current membership or with their current membership
-set to "knock", "leave", or "invite" can knock on a room. This means that a user that
-is banned or is currently in the room cannot knock on it.
+set to "knock" or "leave" can knock on a room. This means that a user that
+is banned, is invited or is currently in the room cannot knock on it.
 
 ### Join Rules
 This proposal makes use of the existing "knock" join rule. The value of


### PR DESCRIPTION
Reverts https://github.com/matrix-org/matrix-spec-proposals/pull/3850

See https://github.com/matrix-org/matrix-spec/pull/1717

Rationale: https://github.com/matrix-org/matrix-spec/issues/1710