### PR TITLE
Stop typos from correcting the "OT" in "OTK"

### DIFF
--- a/.github/_typos.toml
+++ b/.github/_typos.toml
@@ -1,2 +1,10 @@
 [default]
 check-filename = true
+
+[default.extend-identifiers]
+OTK = "OTK"
+OTKs = "OTKs"
+
+[default.extend-words]
+OTK = "OTK"
+OTKs = "OTKs"


### PR DESCRIPTION
An example of the annoyance without this change can be seen in https://github.com/matrix-org/matrix-spec-proposals/pull/4081/files. Tested to have the desired effect locally.