### PR TITLE
Upgrade actions/checkout to v4

### DIFF
--- a/.github/workflows/spell-check.yaml
+++ b/.github/workflows/spell-check.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Check spelling of proposals
       uses: crate-ci/typos@9be36f97fdbe645ee9a12449fb13aca856c2516a


### PR DESCRIPTION
This eliminates the following error reported by Action runs:

> **Spell Check with Typos**
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.