### PR TITLE
Mandate that the new device commits to a particular identity key

### DIFF
--- a/proposals/4108-oidc-qr-login.md
+++ b/proposals/4108-oidc-qr-login.md
@@ -375,9 +375,8 @@ Participants:
 Regardless of which device generates the QR code, either device can be the existing (already signed in) device. The
 other device is then the new device (one seeking to be signed in).
 
-Symmetric encryption uses a separate encryption key for each sender, both derived from a shared secret using HKDF. A
-separate deterministic, monotonically-incrementing nonce is used for each sender. Devices initially set both nonces to
-`0` and increment the corresponding nonce by `1` for each message sent and received.
+Symmetric encryption uses deterministic nonces, incrementing by `2` with each payload. Device S starts with `0`, using only
+even nonces. Device A starts with `1`, using only odd nonces.
 
 1. **Ephemeral key pair generation**
 
@@ -402,8 +401,7 @@ that wishes to "reciprocate" a login
 - If the intent is to reciprocate a login, then the **homeserver base URL**
 
 To get a good trade-off between visual compactness and high level of error correction we use a binary mode QR with a
-similar structure to that of the existing Device Verification QR code encoding described in [Client-Server
-API](https://spec.matrix.org/v1.9/client-server-api/#qr-code-format).
+similar structure to that of the existing Device Verification QR code encoding described in [Client-Server API](https://spec.matrix.org/v1.9/client-server-api/#qr-code-format).
 
 This is defined in detail in a separate section of this proposal.
 
@@ -414,41 +412,22 @@ At this point Device S should check that the received intent matches what the us
 
 4. **Device S sends the initial payload**
 
-Device S computes a shared secret **SH** by performing ECDH between **Ss** and **Gp**. It then discards **Ss** and
-derives two 32-byte symmetric encryption keys from **SH** using HKDF-SHA256. One of those keys, **EncKey_S** is
-used for messages encrypted by device S, while the other, **EncKey_G** is used for encryption by device G.
+Device S computes a shared secret **SH** using ECDH between **Ss** and **Gp**, thereby establishing a secure channel
+with Device G which can be layered on top of the insecure rendezvous session transport. It then discards **Ss** and
+derives a symmetric encryption **EncKey** from **SH** using HKDF_SHA256, each 32 bytes in length.
 
-The keys are generated with the following HKDF parameters:
+Device S derives a confirmation payload that Device G can use to confirm that the channel is secure. It contains:
 
-**EncKey_S**
-
-- `MATRIX_QR_CODE_LOGIN_ENCKEY_S|Gp|Sp` as the info, where **Gp** and **Sp** stand for the generating
-  device's and the scanning device's ephemeral public keys, encoded as unpadded base64.
-- An all-zero salt.
-
-**EncKey_G**
-
-- `MATRIX_QR_CODE_LOGIN_ENCKEY_G|Gp|Sp` as the info, where **Gp** and **Sp** stand for the generating
-  device's and the scanning device's ephemeral public keys, encoded as unpadded base64.
-- An all-zero salt.
-
-With this, Device S has established its side of the secure channel. Device S then derives a confirmation payload that
-Device G can use to confirm that the channel is secure. It contains:
-
-- The string `MATRIX_QR_CODE_LOGIN_ENCKEY_S`, encrypted and authenticated with ChaCha20-Poly1305.
+- The string `MATRIX_QR_CODE_LOGIN_INITIATE`, encrypted and authenticated with ChaCha20-Poly1305.
 - Its public ephemeral key **Sp**.
 
 ```
-Nonce_S := 0
+Nonce := 0
 SH := ECDH(Ss, Gp)
-EncKey_S := HKDF_SHA256(SH, "MATRIX_QR_CODE_LOGIN_ENCKEY_S|" || Gp || "|" || Sp, salt=0, size=32)
-
-// Stored, but not yet used
-EncKey_G := HKDF_SHA256(SH, "MATRIX_QR_CODE_LOGIN_ENCKEY_G|" || Gp || "|" || Sp, salt=0, size=32)
-
-NonceBytes_S := ToLowEndianBytes(Nonce_S)[..12]
-TaggedCiphertext := ChaCha20Poly1305_Encrypt(EncKey_S, NonceBytes_S, "MATRIX_QR_CODE_LOGIN_INITIATE")
-Nonce_S := Nonce_S + 1
+EncKey := HKDF_SHA256(SH, "MATRIX_QR_CODE_LOGIN|" || Gp || "|" || Sp, salt=0, size=32)
+NonceBytes := ToLowEndianBytes(Nonce)[..12]
+TaggedCiphertext := ChaCha20Poly1305_Encrypt(EncKey, NonceBytes, "MATRIX_QR_CODE_LOGIN_INITIATE")
+Nonce := Nonce + 2
 LoginInitiateMessage := UnpaddedBase64(TaggedCiphertext) || "|" || UnpaddedBase64(Sp)
 ```
 
@@ -461,8 +440,7 @@ Device G receives **LoginInitiateMessage** (potentially coming from Device S) fr
 polling with `GET` requests.
 
 It then does the reverse of the previous step, obtaining **Sp**, deriving the shared secret using **Gs** and **Sp**,
-discarding **Gs**, deriving the two symmetric encryption keys **EncKey_S** and **EncKey_G**, then finally
-decrypting (and authenticating) the **TaggedCiphertext** using **EncKey_S**, obtaining a plaintext.
+discarding **Gs** and decrypting (and authenticating) the **TaggedCiphertext**, obtaining a plaintext.
 
 It checks that the plaintext matches the string `MATRIX_QR_CODE_LOGIN_INITIATE`, failing and aborting if not.
 
@@ -470,10 +448,10 @@ It then responds with a dummy payload containing the string `MATRIX_QR_CODE_LOGI
 as follows:
 
 ```
-Nonce_G := 1
-NonceBytes_G := ToLowEndianBytes(Nonce_G)[..12]
-TaggedCiphertext := ChaCha20Poly1305_Encrypt(EncKey_G, NonceBytes_G, "MATRIX_QR_CODE_LOGIN_OK")
-Nonce_G := Nonce_G + 1
+Nonce := 1
+NonceBytes := ToLowEndianBytes(Nonce)[..12]
+TaggedCiphertext := ChaCha20Poly1305_Encrypt(EncKey, NonceBytes, "MATRIX_QR_CODE_LOGIN_OK")
+Nonce := Nonce + 2
 LoginOkMessage := UnpaddedBase64Encode(TaggedCiphertext)
 ```
 
@@ -492,29 +470,27 @@ was indeed sent by Device G. It then verifies the plaintext matches `MATRIX_QR_C
 Nonce_G := 1
 (TaggedCiphertext, Sp) := Unpack(Message)
 NonceBytes := ToLowEndianBytes(Nonce)[..12]
-Plaintext := ChaCha20Poly1305_Decrypt(EncKey_G, NonceBytes, TaggedCiphertext)
-Nonce_G := Nonce_G + 1
+Plaintext := ChaCha20Poly1305_Decrypt(EncKey, NonceBytes, TaggedCiphertext)
+Nonce_G := Nonce_G + 2
 
 unless Plaintext == "MATRIX_QR_CODE_LOGIN_OK":
      FAIL
 ```
 
-If the above was successful, Device S then calculates a two digit **CheckCode** code derived from **SH**, **Gp** and
-**Sp**:
+If the above was successful, Device S then calculates a two digit **CheckCode** code derived from **SH**, **Gp** and **Sp**:
 
 ```
 CheckBytes := HKDF_SHA256(SH, "MATRIX_QR_CODE_LOGIN_CHECKCODE|" || Gp "|" || Sp , salt=0, size=2)
 CheckCode := NumToString(CheckBytes[0] % 10) || NumToString(CheckBytes[1] % 10)
 ```
 
-Device S then displays an indicator to the user that the secure channel has been established and that the **CheckCode**
-should be entered on the other device when prompted. Example wording could say "Secure connection established. Enter the
-code XY on your other device."
+Device S then displays an indication to the user that the secure channel has been established and that the **CheckCode**
+should be entered on the other device when prompted. e.g. wording to say "secure connection established"; enter the code
+XY on your other device;
 
 7. **Out-of-band confirmation**
 
-**Warning**: *This step is crucial for the security of the scheme since it overcomes the aforementioned limitation of
-ECIES.*
+**Warning**: *This step is crucial for the security of the scheme since it overcomes the aforementioned limitation of ECIES.*
 
 Device G asks the user to enter the **CheckCode** that is being displayed on Device S.
 
@@ -531,8 +507,7 @@ CheckCode := NumToString(CheckBytes[0] % 10) || NumToString(CheckBytes[1] % 10)
 
 If the code that the user enters matches then the secure channel is established.
 
-Subsequent payloads sent from G should be encrypted using **EncKey_G**, while payloads sent from S should be
-encrypted with **EncKey_S**, incrementing the corresponding nonce for each message sent/received.
+Subsequent payloads can be sent encrypted with **EncKey** with the nonces incremented as described above.
 
 #### Sequence diagram
 
@@ -562,7 +537,7 @@ sequenceDiagram
     S->>+Z: GET /_matrix/client/rendezvous/abc-def
     Z->>-S: 200 OK<br>ETag: 1
 
-    note over S: 4) Device S computes SH, EncKey_S, EncKey_G and LoginInitiateMessage.<br>It sends LoginInitiateMessage via the rendezvous session
+    note over S: 4) Device S computes SH, EncKey and LoginInitiateMessage.<br>It sends LoginInitiateMessage via the rendezvous session
     S->>+Z: PUT /_matrix/client/rendezvous/abc-def<br>If-Match: 1<br>Body: LoginInitiateMessage
     Z->>-S: 202 Accepted<br>ETag: 2
     deactivate S
@@ -571,7 +546,7 @@ sequenceDiagram
     activate G
     Z->>-G: 200 OK<br>ETag: 2<br>Body: Data
 
-    note over G: 5) Device G attempts to parse Data as LoginInitiateMessage after calculating SH, EncKey_S and EncKey_G
+    note over G: 5) Device G attempts to parse Data as LoginInitiateMessage after calculating SH and EncKey
     note over G: Device G checks that the plaintext matches MATRIX_QR_CODE_LOGIN_INITIATE
 
     note over G: Device G computes LoginOkMessage and sends to the rendezvous session
@@ -601,20 +576,21 @@ sequenceDiagram
 Conceptually, once established, the secure channel offers two operations, `SecureSend` and `SecureReceive`, which wrap
 the `Send` and `Receive` operations offered by the rendezvous session API to securely send and receive data between two devices.
 
-At the end of the establishment phase, the next nonce for each device should be `1`.
+At the end of the establishment phase, the next nonce for Device G should be `3` and the next nonce for Device S should
+be `2`.
 
 Device G sets:
 
 ```
-Nonce_G := 1
-Nonce_S := 1
+Nonce := 3
+NonceOther = 2
 ```
 
 Device S sets:
 
 ```
-Nonce_G := 1
-Nonce_S := 1
+Nonce := 2
+NonceOther := 3
 ```
 
 #### Threat analysis

--- a/proposals/4108-oidc-qr-login.md
+++ b/proposals/4108-oidc-qr-login.md
@@ -827,7 +827,7 @@ Proof := UnpaddedBase64Encode(ProofBytes)
         "verification_uri": "https://auth-oidc.lab.element.dev/link",
         "verification_uri_complete": "https://auth-oidc.lab.element.dev/link?code=123456"
     },
-    "device_id": "3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI",
+    "device_id": "curve25519:3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI",
     "device_id_proof": "$base64_encoded_proof_of_identity_key_ownership"
 }
 ```
@@ -875,7 +875,7 @@ sequenceDiagram
         N->>+OP: POST /auth/device client_id=xyz&scope=openid+urn:matrix:api:*+urn:matrix:device:ABCDEFGH...
         OP->>-N: 200 OK {"user_code": "123456",<br>"verification_uri_complete": "https://id.matrix.org/device/abcde",<br>"expires_in_ms": 120000, "device_code": "XYZ", "interval": 1}
         note over N: 3) New device informs existing device of choice of protocol:
-        N->>Z: SecureSend({"type": "m.login.protocol", "protocol": "device_authorization_grant",<br> "device_authorization_grant":{<br>"verification_uri_complete": "https://id.matrix.org/device/abcde",<br>"verification_uri": ...,<br>"device_id": "3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI", "device_id_proof": "$base64_encoded_proof_of_identity_key_ownership"})
+        N->>Z: SecureSend({"type": "m.login.protocol", "protocol": "device_authorization_grant",<br> "device_authorization_grant":{<br>"verification_uri_complete": "https://id.matrix.org/device/abcde",<br>"verification_uri": ...,<br>"device_id": "curve25519:3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI", "device_id_proof": "$base64_encoded_proof_of_identity_key_ownership"})
 
     deactivate N
     end
@@ -887,7 +887,7 @@ sequenceDiagram
     end
 
     rect rgba(0,255,0, 0.1)
-        Z->>E: SecureReceive() => {"type": "m.login.protocol", "protocol": "device_authorization_grant",<br> "device_authorization_grant":{<br>"verification_uri_complete": "https://id.matrix.org/device/abcde",<br>"verification_uri": ...},<br>"device_id": "3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI", "device_id_proof": "$base64_encoded_proof_of_identity_key_ownership"}
+        Z->>E: SecureReceive() => {"type": "m.login.protocol", "protocol": "device_authorization_grant",<br> "device_authorization_grant":{<br>"verification_uri_complete": "https://id.matrix.org/device/abcde",<br>"verification_uri": ...},<br>"device_id": "curve25519:3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI", "device_id_proof": "$base64_encoded_proof_of_identity_key_ownership"}
     end
 
     rect rgba(255,0,0, 0.1)
@@ -945,7 +945,7 @@ sequenceDiagram
         N->>+OP: POST /auth/device client_id=xyz&scope=openid+urn:matrix:api:*+urn:matrix:device:ABCDEFGH...
         OP->>-N: 200 OK {"user_code": "123456",<br>"verification_uri_complete": "https://id.matrix.org/device/abcde",<br>"expires_in_ms": 120000, "device_code": "XYZ", "interval": 1}
         note over N: 3) New device informs existing device of choice of protocol:
-        N->>Z: SecureSend({"type": "m.login.protocol", "protocol": "device_authorization_grant",<br> "device_authorization_grant":{<br>"verification_uri_complete": "https://id.matrix.org/device/abcde",<br>"verification_uri": ...},<br>"device_id": "3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI", "device_id_proof": "$base64_encoded_proof_of_identity_key_ownership"})
+        N->>Z: SecureSend({"type": "m.login.protocol", "protocol": "device_authorization_grant",<br> "device_authorization_grant":{<br>"verification_uri_complete": "https://id.matrix.org/device/abcde",<br>"verification_uri": ...},<br>"device_id": "curve25519:3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI", "device_id_proof": "$base64_encoded_proof_of_identity_key_ownership"})
 
     deactivate N
     end
@@ -956,7 +956,7 @@ sequenceDiagram
     #end
 
     rect rgba(0,255,0, 0.1)
-        Z->>E: SecureReceive() => {"type": "m.login.protocol", "protocol": "device_authorization_grant",<br> "device_authorization_grant":{<br>"verification_uri_complete": "https://id.matrix.org/device/abcde",<br>"verification_uri": ...},<br>"device_id": "3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI", "device_id_proof": "$base64_encoded_proof_of_identity_key_ownership"}
+        Z->>E: SecureReceive() => {"type": "m.login.protocol", "protocol": "device_authorization_grant",<br> "device_authorization_grant":{<br>"verification_uri_complete": "https://id.matrix.org/device/abcde",<br>"verification_uri": ...},<br>"device_id": "curve25519:3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI", "device_id_proof": "$base64_encoded_proof_of_identity_key_ownership"}
     end
 
     # alt if New device scanned QR code
@@ -1175,14 +1175,14 @@ Content-Type: application/json
             "m.olm.v1.curve25519-aes-sha2",
             "m.megolm.v1.aes-sha2"
         ],
-        "device_id": "3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI",
+        "device_id": "curve25519:3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI",
         "keys": {
-            "curve25519:3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI": "3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI",
-            "ed25519:3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI": "b8gROFh+UIHLD/obY0+IlxoWiGtYVhKdqixvw4QHcN8"
+            "curve25519:curve25519:3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI": "3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI",
+            "ed25519:curve25519:3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI": "b8gROFh+UIHLD/obY0+IlxoWiGtYVhKdqixvw4QHcN8"
         },
         "signatures": {
             "@testing_35:morpheus.localhost": {
-                "ed25519:3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI": "ziHEUIsHnrYBH4CqYpN1JC/ex3t4VG3zvo16D8ORqN6yAErpsKsnd/5LDdZERIOB1MGffKGfCL6ny5V7rT9FCQ",
+                "ed25519:curve25519:3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI": "ziHEUIsHnrYBH4CqYpN1JC/ex3t4VG3zvo16D8ORqN6yAErpsKsnd/5LDdZERIOB1MGffKGfCL6ny5V7rT9FCQ",
                 "ed25519:bkYgAVUNqvuyy8b1w09utJNJxBvK3hZB65xxoLPVzFol": "p257k0tfPF98OIDuXnFSJS2DmVlxO4sgTHdF41DTdZBCpTZfPwok6iASo3xMRKdyy3WMEgkQ6lzhEyRKKZBGBQ"
             }
         },
@@ -1298,7 +1298,7 @@ Example:
         "verification_uri_complete": "https://id.matrix.org/device/abcde",
         "verification_uri": "..."
     },
-    "device_id": "3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI",
+    "device_id": "curve25519:3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI",
     "device_id_proof": "$base64_encoded_proof_of_identity_key_ownership"
 }
 ```

--- a/proposals/4108-oidc-qr-login.md
+++ b/proposals/4108-oidc-qr-login.md
@@ -422,13 +422,13 @@ The keys are generated with the following HKDF parameters:
 
 **EncKey_S**
 
-- `MATRIX_QR_CODE_LOGIN_ENCKEY_S|Gp|Sp` as the info the info, where Gp and Sp stand for the generating
+- `MATRIX_QR_CODE_LOGIN_ENCKEY_S|Gp|Sp` as the info, where **Gp** and **Sp** stand for the generating
   device's and the scanning device's ephemeral public keys, encoded as unpadded base64.
 - An all-zero salt.
 
 **EncKey_G**
 
-- `MATRIX_QR_CODE_LOGIN_ENCKEY_G|Gp|Sp` as the info the info, where Gp and Sp stand for the generating
+- `MATRIX_QR_CODE_LOGIN_ENCKEY_G|Gp|Sp` as the info, where **Gp** and **Sp** stand for the generating
   device's and the scanning device's ephemeral public keys, encoded as unpadded base64.
 - An all-zero salt.
 

--- a/proposals/4108-oidc-qr-login.md
+++ b/proposals/4108-oidc-qr-login.md
@@ -444,7 +444,7 @@ SH := ECDH(Ss, Gp)
 EncKey_S := HKDF_SHA256(SH, "MATRIX_QR_CODE_LOGIN_ENCKEY_S|" || Gp || "|" || Sp, salt=0, size=32)
 
 // Stored, but not yet used
-EncKey_G := HKDF_SHA256(SH, "MATRIX_QR_CODE_LOGIN_ENCKEY_S|" || Gp || "|" || Sp, salt=0, size=32)
+EncKey_G := HKDF_SHA256(SH, "MATRIX_QR_CODE_LOGIN_ENCKEY_G|" || Gp || "|" || Sp, salt=0, size=32)
 
 NonceBytes_S := ToLowEndianBytes(Nonce_S)[..12]
 TaggedCiphertext := ChaCha20Poly1305_Encrypt(EncKey_S, NonceBytes_S, "MATRIX_QR_CODE_LOGIN_INITIATE")
@@ -1092,7 +1092,7 @@ If no device is found then the process should be stopped.
 
 2. **Existing device confirms that the new device owns the private part of the committed-to device identity key**
 
-The new device then proves it controls the public key to which it previously committed. It does this by doing an ECDH
+The new device then proves it controls the private key to which it previously committed. It does this by doing an ECDH
 between the committed-to identity key and the other device's secure channel ephemeral key to derive a shared secret,
 which is used to construct a proof of ownership. Due to the properties of ECDH, the other device knows that the new
 device can only do this if it possesses the private part of the committed-to identity key.

--- a/proposals/4108-oidc-qr-login.md
+++ b/proposals/4108-oidc-qr-login.md
@@ -1126,14 +1126,14 @@ channel:
 {
   "type": "m.login.secrets",
   "cross_signing": {
-          "master_key": "$base64_of_the_key",
-          "self_signing_key": "$base64_of_the_key",
-          "user_signing_key": "$base64_of_the_key"
+      "master_key": "$base64_of_the_key",
+      "self_signing_key": "$base64_of_the_key",
+      "user_signing_key": "$base64_of_the_key"
   },
   "backup": {
-       "algorithm": "foobar",
-       "key": "$base64_of_the_backup_recovery_key",
-       "backup_version": "version_string"
+      "algorithm": "foobar",
+      "key": "$base64_of_the_backup_recovery_key",
+      "backup_version": "version_string"
   }
 }
 ```
@@ -1320,9 +1320,9 @@ Example:
 
 ```json
 {
- "type":"m.login.failure",
-"reason": "unsupported",
- "homeserver": "https://matrix-client.matrix.org"
+    "type":"m.login.failure",
+    "reason": "unsupported",
+    "homeserver": "https://matrix-client.matrix.org"
 }
 ```
 
@@ -1342,7 +1342,7 @@ Example:
 
 ```json
 {
- "type":"m.login.declined"
+    "type":"m.login.declined"
 }
 ```
 
@@ -1362,7 +1362,7 @@ Example:
 
 ```json
 {
- "type": "m.login.success"
+    "type": "m.login.success",
 }
 ```
 
@@ -1386,14 +1386,14 @@ Example:
 {
   "type": "m.login.secrets",
   "cross_signing": {
-          "master_key": "$base64_of_the_key",
-          "self_signing_key": "$base64_of_the_key",
-     "user_signing_key": "$base64_of_the_key"
+      "master_key": "$base64_of_the_key",
+      "self_signing_key": "$base64_of_the_key",
+      "user_signing_key": "$base64_of_the_key"
   },
   "backup": {
-       "algorithm": "foobar",
-       "key": "base64_of_the_backup_recovery_key",
-       "backup_version": "version_string"
+      "algorithm": "foobar",
+      "key": "base64_of_the_backup_recovery_key",
+      "backup_version": "version_string"
   }
 }
 ```
@@ -1577,4 +1577,5 @@ key org.matrix.msc4108 set to true. So, the response could look then as followin
 
 This MSC builds on [MSC3861](https://github.com/matrix-org/matrix-spec-proposals/pull/3861) (and its dependencies) which
 proposes the adoption of OIDC for authentication in Matrix.
+
 

--- a/proposals/4108-oidc-qr-login.md
+++ b/proposals/4108-oidc-qr-login.md
@@ -24,7 +24,7 @@ In order for the new device to be fully set up, it needs to exchange information
 
 It is proposed that an HTTP-based protocol be used to establish an ephemeral bi-directional communication session over
 which the two devices can exchange the necessary data. This session is described as "insecure" as it provides no
-end-to-end confidentiality nor authenticity by itself—these are layered on top of it.
+end-to-end confidentiality nor authenticity by itself---these are layered on top of it.
 
 #### High-level description
 
@@ -242,7 +242,7 @@ Access-Control-Expose-Headers: ETag
 ```
 
 To support usage from web browsers the rendezvous URLs should allow CORS requests from any origin and expose the headers
-which aren’t on the CORS [request header](https://developer.mozilla.org/en-US/docs/Glossary/CORS-safelisted_request_header) and 
+which aren't on the CORS [request header](https://developer.mozilla.org/en-US/docs/Glossary/CORS-safelisted_request_header) and 
 [response header](https://developer.mozilla.org/en-US/docs/Glossary/CORS-safelisted_response_header) safelists:
 
 ```http
@@ -394,14 +394,15 @@ with an empty payload. It parses the **id** and **server** received.
 
 Device G displays a QR code containing:
 
-- its public key **Gp**
-- the insecure rendezvous session **URL**
+- Its public key **Gp**
+- The insecure rendezvous session **URL**
 - An indicator (the **intent**) to say if this is a new device which wishes to "initiate" a login, or an existing device
 that wishes to "reciprocate" a login
 - If the intent is to reciprocate a login, then the **homeserver base URL**
 
 To get a good trade-off between visual compactness and high level of error correction we use a binary mode QR with a
-similar structure to that of the existing Device Verification QR code encoding described in [Client-Server API](https://spec.matrix.org/v1.9/client-server-api/#qr-code-format).
+similar structure to that of the existing Device Verification QR code encoding described in [Client-Server
+API](https://spec.matrix.org/v1.9/client-server-api/#qr-code-format).
 
 This is defined in detail in a separate section of this proposal.
 
@@ -414,7 +415,7 @@ At this point Device S should check that the received intent matches what the us
 
 Device S computes a shared secret **SH** using ECDH between **Ss** and **Gp**, thereby establishing a secure channel
 with Device G which can be layered on top of the insecure rendezvous session transport. It then discards **Ss** and
-derives a symmetric encryption **EncKey** from **SH** using HKDF_SHA256, each 32 bytes in length.
+derives a symmetric encryption **EncKey** from **SH** using HKDF-SHA256, each 32 bytes in length.
 
 Device S derives a confirmation payload that Device G can use to confirm that the channel is secure. It contains:
 
@@ -618,9 +619,9 @@ Since Device G has no way of authenticating Device S, an attacker present for th
 attempt to mimic Device S in order to get their Device S signed in instead.
 
 - In step 3, Specter can shoulder surf the QR code scanning to obtain **Gp**.
-- In step 4, Specter can intercept S’s payload and replace it with a payload of their own, replacing  **Sp** with its
+- In step 4, Specter can intercept S's payload and replace it with a payload of their own, replacing  **Sp** with its
 own key.
-- The attack is only thwarted in step 7, because Device S won’t ever display the indicator of success to the user. The
+- The attack is only thwarted in step 7, because Device S won't ever display the indicator of success to the user. The
 user then must cancel the process on Device G, preventing it from sharing any sensitive material.
 
 ### The OIDC login part and set up of E2EE
@@ -962,7 +963,7 @@ and expecting to receive an HTTP 404 response.
 If the device already exists then the login request should be rejected with an `m.login.failure` and reason `device_already_exists`.
 
 If no existing device was found then the existing device opens the `verification_uri_complete` - falling back to the
-`verification_uri`, if `verification_uri_complete` isn’t present - in a system browser.
+`verification_uri`, if `verification_uri_complete` isn't present - in a system browser.
 
 Ideally this is in a trusted/secure environment where the cookie jar and password manager features are available. e.g.
 on iOS this could be a `ASWebAuthenticationSession`
@@ -1050,7 +1051,7 @@ with the corresponding device_id (from the `m.login.protocol` message).
 It does so by calling [GET /_matrix/client/v3/devices/<device_id>](https://spec.matrix.org/v1.9/client-server-api/#get_matrixclientv3devicesdeviceid)
 and expecting to receive an HTTP 200 response.
 
-If the device isn’t immediately visible it can repeat the `GET` request for up to, say, 10 seconds to allow for any latency.
+If the device isn't immediately visible it can repeat the `GET` request for up to, say, 10 seconds to allow for any latency.
 
 If no device is found then the process should be stopped.
 
@@ -1068,7 +1069,7 @@ The existing device sends a `m.login.secrets` message via the secure channel:
   },
   "backup": {
        "algorithm": "foobar",
-       "key": "base64_of_the_backup_recovery_key",
+       "key": "$base64_of_the_backup_recovery_key",
        "backup_version": "version_string"
   }
 }
@@ -1144,7 +1145,7 @@ deactivate HS
 
               activate N
               note over N: 3) New device stores the secrets locally
-              
+
 alt is cross_signing present in m.login.secrets?
 note over N: New device signs itself
               note over N: New device uploads device keys and cross-signing signature:
@@ -1513,3 +1514,4 @@ key org.matrix.msc4108 set to true. So, the response could look then as followin
 
 This MSC builds on [MSC3861](https://github.com/matrix-org/matrix-spec-proposals/pull/3861) (and its dependencies) which
 proposes the adoption of OIDC for authentication in Matrix.
+

--- a/proposals/4108-oidc-qr-login.md
+++ b/proposals/4108-oidc-qr-login.md
@@ -806,7 +806,16 @@ device did the QR code scanning. This derived secret is then used to to construc
 HMAC-SHA256. Due to the properties of ECDH, the existing device knows that the new device can only do this if it
 possesses the private part of the Curve25519 identity key.
 
-TODO: a paragraph to say why we do this
+By requiring the device ID to equal the device identity key, we reduce the number of (unnecessarily) free parameters,
+allowing a user's E2EE devices to be uniquely identified only by their identity key, rather than by a (device ID,
+identity key) 2-tuple. This paves the way for potentially making this a strict requirement for all E2EE-supporting
+devices in a future iteration of the Matrix E2EE protocol. This would provide a marked increase in protocol robustness
+and reduces potential for implementation errors.
+
+Separately, the proof of ownership of the identity key ensures that the new device cannot submit a key it does not
+control, either by accident or maliciously. While this scenario doesn't represent an outright security
+compromise---because a device cannot decrypt traffic for an identity key it does not control---it further reduces the
+margin for implementation error.
 
 To calculate the proof the new device does:
 

--- a/proposals/4108-oidc-qr-login.md
+++ b/proposals/4108-oidc-qr-login.md
@@ -571,8 +571,7 @@ sequenceDiagram
     activate G
     Z->>-G: 200 OK<br>ETag: 2<br>Body: Data
 
-    note over G: 5) Device G attempts to parse Data as LoginInitiateMessage after calculating SH, EncKey_S and
-    EncKey_G
+    note over G: 5) Device G attempts to parse Data as LoginInitiateMessage after calculating SH, EncKey_S and EncKey_G
     note over G: Device G checks that the plaintext matches MATRIX_QR_CODE_LOGIN_INITIATE
 
     note over G: Device G computes LoginOkMessage and sends to the rendezvous session

--- a/proposals/4108-oidc-qr-login.md
+++ b/proposals/4108-oidc-qr-login.md
@@ -827,7 +827,7 @@ Proof := UnpaddedBase64Encode(ProofBytes)
         "verification_uri": "https://auth-oidc.lab.element.dev/link",
         "verification_uri_complete": "https://auth-oidc.lab.element.dev/link?code=123456"
     },
-    "device_id": "curve25519:3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI",
+    "device_id": "3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI",
     "device_id_proof": "$base64_encoded_proof_of_identity_key_ownership"
 }
 ```
@@ -875,7 +875,7 @@ sequenceDiagram
         N->>+OP: POST /auth/device client_id=xyz&scope=openid+urn:matrix:api:*+urn:matrix:device:ABCDEFGH...
         OP->>-N: 200 OK {"user_code": "123456",<br>"verification_uri_complete": "https://id.matrix.org/device/abcde",<br>"expires_in_ms": 120000, "device_code": "XYZ", "interval": 1}
         note over N: 3) New device informs existing device of choice of protocol:
-        N->>Z: SecureSend({"type": "m.login.protocol", "protocol": "device_authorization_grant",<br> "device_authorization_grant":{<br>"verification_uri_complete": "https://id.matrix.org/device/abcde",<br>"verification_uri": ...,<br>"device_id": "curve25519:3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI", "device_id_proof": "$base64_encoded_proof_of_identity_key_ownership"})
+        N->>Z: SecureSend({"type": "m.login.protocol", "protocol": "device_authorization_grant",<br> "device_authorization_grant":{<br>"verification_uri_complete": "https://id.matrix.org/device/abcde",<br>"verification_uri": ...,<br>"device_id": "3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI", "device_id_proof": "$base64_encoded_proof_of_identity_key_ownership"})
 
     deactivate N
     end
@@ -887,7 +887,7 @@ sequenceDiagram
     end
 
     rect rgba(0,255,0, 0.1)
-        Z->>E: SecureReceive() => {"type": "m.login.protocol", "protocol": "device_authorization_grant",<br> "device_authorization_grant":{<br>"verification_uri_complete": "https://id.matrix.org/device/abcde",<br>"verification_uri": ...},<br>"device_id": "curve25519:3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI", "device_id_proof": "$base64_encoded_proof_of_identity_key_ownership"}
+        Z->>E: SecureReceive() => {"type": "m.login.protocol", "protocol": "device_authorization_grant",<br> "device_authorization_grant":{<br>"verification_uri_complete": "https://id.matrix.org/device/abcde",<br>"verification_uri": ...},<br>"device_id": "3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI", "device_id_proof": "$base64_encoded_proof_of_identity_key_ownership"}
     end
 
     rect rgba(255,0,0, 0.1)
@@ -945,7 +945,7 @@ sequenceDiagram
         N->>+OP: POST /auth/device client_id=xyz&scope=openid+urn:matrix:api:*+urn:matrix:device:ABCDEFGH...
         OP->>-N: 200 OK {"user_code": "123456",<br>"verification_uri_complete": "https://id.matrix.org/device/abcde",<br>"expires_in_ms": 120000, "device_code": "XYZ", "interval": 1}
         note over N: 3) New device informs existing device of choice of protocol:
-        N->>Z: SecureSend({"type": "m.login.protocol", "protocol": "device_authorization_grant",<br> "device_authorization_grant":{<br>"verification_uri_complete": "https://id.matrix.org/device/abcde",<br>"verification_uri": ...},<br>"device_id": "curve25519:3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI", "device_id_proof": "$base64_encoded_proof_of_identity_key_ownership"})
+        N->>Z: SecureSend({"type": "m.login.protocol", "protocol": "device_authorization_grant",<br> "device_authorization_grant":{<br>"verification_uri_complete": "https://id.matrix.org/device/abcde",<br>"verification_uri": ...},<br>"device_id": "3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI", "device_id_proof": "$base64_encoded_proof_of_identity_key_ownership"})
 
     deactivate N
     end
@@ -956,7 +956,7 @@ sequenceDiagram
     #end
 
     rect rgba(0,255,0, 0.1)
-        Z->>E: SecureReceive() => {"type": "m.login.protocol", "protocol": "device_authorization_grant",<br> "device_authorization_grant":{<br>"verification_uri_complete": "https://id.matrix.org/device/abcde",<br>"verification_uri": ...},<br>"device_id": "curve25519:3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI", "device_id_proof": "$base64_encoded_proof_of_identity_key_ownership"}
+        Z->>E: SecureReceive() => {"type": "m.login.protocol", "protocol": "device_authorization_grant",<br> "device_authorization_grant":{<br>"verification_uri_complete": "https://id.matrix.org/device/abcde",<br>"verification_uri": ...},<br>"device_id": "3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI", "device_id_proof": "$base64_encoded_proof_of_identity_key_ownership"}
     end
 
     # alt if New device scanned QR code
@@ -1175,14 +1175,14 @@ Content-Type: application/json
             "m.olm.v1.curve25519-aes-sha2",
             "m.megolm.v1.aes-sha2"
         ],
-        "device_id": "curve25519:3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI",
+        "device_id": "3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI",
         "keys": {
-            "curve25519:curve25519:3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI": "3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI",
-            "ed25519:curve25519:3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI": "b8gROFh+UIHLD/obY0+IlxoWiGtYVhKdqixvw4QHcN8"
+            "curve25519:3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI": "3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI",
+            "ed25519:3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI": "b8gROFh+UIHLD/obY0+IlxoWiGtYVhKdqixvw4QHcN8"
         },
         "signatures": {
             "@testing_35:morpheus.localhost": {
-                "ed25519:curve25519:3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI": "ziHEUIsHnrYBH4CqYpN1JC/ex3t4VG3zvo16D8ORqN6yAErpsKsnd/5LDdZERIOB1MGffKGfCL6ny5V7rT9FCQ",
+                "ed25519:3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI": "ziHEUIsHnrYBH4CqYpN1JC/ex3t4VG3zvo16D8ORqN6yAErpsKsnd/5LDdZERIOB1MGffKGfCL6ny5V7rT9FCQ",
                 "ed25519:bkYgAVUNqvuyy8b1w09utJNJxBvK3hZB65xxoLPVzFol": "p257k0tfPF98OIDuXnFSJS2DmVlxO4sgTHdF41DTdZBCpTZfPwok6iASo3xMRKdyy3WMEgkQ6lzhEyRKKZBGBQ"
             }
         },
@@ -1298,7 +1298,7 @@ Example:
         "verification_uri_complete": "https://id.matrix.org/device/abcde",
         "verification_uri": "..."
     },
-    "device_id": "curve25519:3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI",
+    "device_id": "3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI",
     "device_id_proof": "$base64_encoded_proof_of_identity_key_ownership"
 }
 ```

--- a/proposals/4108-oidc-qr-login.md
+++ b/proposals/4108-oidc-qr-login.md
@@ -1298,7 +1298,7 @@ Example:
         "verification_uri_complete": "https://id.matrix.org/device/abcde",
         "verification_uri": "..."
     },
-    "device_id": "ABCDEFGH",
+    "device_id": "3C5BFWi2Y8MaVvjM8M22DBmh24PmgR0nPvJOIArzgyI",
     "device_id_proof": "$base64_encoded_proof_of_identity_key_ownership"
 }
 ```


### PR DESCRIPTION
Originally from https://github.com/matrix-org/matrix-spec-proposals/pull/4129, these are suggested changes to https://github.com/matrix-org/matrix-spec-proposals/pull/4108:

- Mandate that the new device commits to a particular identity key (by setting the device ID to the public part) and proves ownership of it (via a combination of ECDH and HMAC-SHA256)

Co-authored-by: Damir Jelić <poljar@termina.org.uk>