### PR TITLE
MSC4138: Update allowed HTTP methods in CORS responses

### DIFF
--- a/proposals/4138-update-cors-methods.md
+++ b/proposals/4138-update-cors-methods.md
@@ -9,7 +9,8 @@ the `Access-Control-Allow-Methods` header.
 
 ## Proposal
 
-The `Access-Control-Allow-Methods` header's recommended value is updated to include the following:
+The [`Access-Control-Allow-Methods` header's recommended value](https://spec.matrix.org/v1.10/client-server-api/#web-browser-clients)
+is updated to include the following:
 
 * `PATCH` - A plausibly useful HTTP method for future use.
 * `HEAD` - Similar to `PATCH`, `HEAD` is plausibly useful for feature detection and cases like

--- a/proposals/4138-update-cors-methods.md
+++ b/proposals/4138-update-cors-methods.md
@@ -1,0 +1,46 @@
+# MSC4138: Update allowed HTTP methods in CORS responses
+
+The [specification](https://spec.matrix.org/v1.10/client-server-api/#web-browser-clients) suggests
+that servers allow a limited subset of the available [HTTP methods](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods)
+available in [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) responses. However, it's
+reasonable to expect the specification to use other methods in the future or as part of feature
+detection. To permit these use cases early, this MSC proposes adding a few more allowable values to
+the `Access-Control-Allow-Methods` header.
+
+## Proposal
+
+The `Access-Control-Allow-Methods` header's recommended value is updated to include the following:
+
+* `PATCH` - A plausibly useful HTTP method for future use.
+* `HEAD` - Similar to `PATCH`, `HEAD` is plausibly useful for feature detection and cases like
+  [MSC4120](https://github.com/matrix-org/matrix-spec-proposals/pull/4120).
+
+The following methods are *not* included because they don't have foreseeable use in Matrix:
+
+* `CONNECT`
+* `TRACE`
+
+## Potential issues
+
+None anticipated.
+
+## Alternatives
+
+No significant alternatives.
+
+## Security considerations
+
+CORS is meant to help ensure requests made by the client are properly scoped in the client. If the
+client wishes to use an HTTP method not allowed by the server, the web browser will mask the
+response with an error before the application can inspect it. Therefore, to increase future
+compatibility, we append a few useful HTTP methods while still excluding ones which are (currently)
+nonsensical.
+
+## Unstable prefix
+
+This proposal cannot have an unstable prefix due to the nature of CORS. Servers are already able to
+go off-spec and serve different headers because the spec is merely a recommendation.
+
+## Dependencies
+
+This proposal has no dependencies.


### PR DESCRIPTION
[Rendered](https://github.com/matrix-org/matrix-spec-proposals/blob/travis/msc/update-cors/proposals/4138-update-cors-methods.md)

In line with https://github.com/matrix-org/matrix-spec/issues/1700, the following disclosure applies:

I am Director of Standards Development at The Matrix.org Foundation C.I.C., Matrix Spec Core Team (SCT) member, employed by Element, and operate the t2bot.io service. This proposal is written and published with my role as a member of the SCT.

Related: https://github.com/matrix-org/matrix-js-sdk/pull/4188

[FCP tickyboxes](https://github.com/matrix-org/matrix-spec-proposals/pull/4138#issuecomment-2093818285)