### PR TITLE
Clarify "real name" in contributor requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,10 +69,14 @@ include the line in your commit or pull request comment:
 
     Signed-off-by: Your Name <your@email.example.org>
 
-...using your real name; unfortunately pseudonyms and anonymous contributions
-can't be accepted. Git makes this trivial - just use the -s flag when you do
-``git commit``, having first set ``user.name`` and ``user.email`` git configs
-(which you should have done anyway :)
+We accept contributions under a legally identifiable name, such as
+your name on government documentation or common-law names (names
+claimed by legitimate usage or repute). Unfortunately, we cannot
+accept anonymous contributions at this time.
+
+Git allows you to add this signoff automatically when using the `-s`
+flag to `git commit`, which uses the name and email set in your
+`user.name` and `user.email` git configs.
 
 ### Private sign off
 


### PR DESCRIPTION
This updates the sign-off requirements to match what most other matrix-org and element-hq repos already have. The change was first made in synapse: https://github.com/matrix-org/synapse/pull/3467

Same change in matrix-spec: https://github.com/matrix-org/matrix-spec/pull/1886