### PR TITLE
Add a stable flag to MSC3916

### DIFF
--- a/proposals/3916-authentication-for-media.md
+++ b/proposals/3916-authentication-for-media.md
@@ -396,6 +396,17 @@ While this proposal is in development, the new endpoints should be named as foll
     The `serverName` was later dropped in favour of explicit scoping. See `allow_remote` details
     in the MSC body for details.
 
+## Stable flag
+
+After the proposal is accepted servers may advertise support for the stable
+endpoints by setting `org.matrix.msc3916.stable` to `true` in the
+`unstable_features` section of the
+[versions endpoint](https://spec.matrix.org/v1.11/client-server-api/#get_matrixclientversions)
+in addition to the usual version-based feature support. This option is provided
+to encourage a faster rollout in the wider Matrix ecosystem until servers
+support the full feature set of the respective version of the Matrix
+specification.
+
 ## Dependencies
 
 None.


### PR DESCRIPTION
In conversation with several client and homeserver developers it has come up that the current schedule for rolling out authenticated media is hard for them to follow if they have to support all of 1.11 at once.

I think the value of authenticated media is high enough to warrant a stable flag to encourage a faster rollout of authenticated media. This allows servers to support authenticated media without supporting all of 1.11 already and the additional burden on client developers is minimal.

This flag is already in use by serveral implementations:

- https://github.com/neilalexander/harmony/commit/51b5c9803344fa1f33832cd6ccacd37db383ec84
- https://github.com/famedly/matrix-dart-sdk/commit/2dce08bab1006abe27d1931f4ba74a7fb693873c