### PR TITLE
Make it more explicit that m.topic replaces m.room.topic without deprecation

### DIFF
--- a/proposals/3765-rich-room-topics.md
+++ b/proposals/3765-rich-room-topics.md
@@ -13,11 +13,11 @@ options.
 
 ## Proposal
 
-Drawing from extensible events as described in [MSC1767],
-`m.room.topic` is formally deprecated and replaced with a new `m.topic`
-event type. The latter contains a new content block `m.topic` which wraps
-an `m.text` content block that allows representing the room topic in
-different mime types.
+Drawing from extensible events as described in [MSC1767], `m.room.topic`
+is prohibited in room versions that support extensible events and replaced
+with a new `m.topic` event type. The latter contains a new content block
+`m.topic` which wraps an `m.text` content block that allows representing
+the room topic in different mime types.
 
 ``` json5
 {


### PR DESCRIPTION
This is to address https://github.com/matrix-org/matrix-spec-proposals/pull/3765/files#r1731217524 and sent as a PR because I cannot push to the original branch anymore.

CC @clokep 