### PR TITLE
MSC4198: Usage of OIDC login_hint

### DIFF
--- a/proposals/0000-oidc-login-hint.md
+++ b/proposals/0000-oidc-login-hint.md
@@ -1,0 +1,131 @@
+# MSC0000: Usage of OIDC login_hint
+
+[MSC3861] proposes using OAuth 2.0/OpenID Connect for authentication APIs.
+
+[OpenID Connect Core 1.0] specifies an optional `login_hint`
+authorization request parameter but leaves the contents of the parameter vague and "to the OP's discretion".
+
+This MSC aims to define a format for use in the context of Matrix which allows for a login flow that starts with the
+user typing their [MXID].
+
+
+## Proposal
+
+A client can start the login flow by asking the user for their [MXID].
+The client can then parse the domain, discover the homeserver and its auth issuer ([MSC2965]),
+register itself with the homeserver ([MSC2966])
+and send the user to the authorization endpoint ([MSC2964]), all in one step.
+
+To improve the UX of this flow, the MXID can be sent to the homeserver with the authorization request in the `login_hint`.
+In order to comply with the OpenID Connect specification, the requested scope must also include the `openid` scope.
+
+The value of `login_hint` should be set to the user's MXID, prefixed with `mxid:` (e.g. `mxid:@example-user:example.com`).
+Prefixing the value allows for more hint value types to be added in the future and for easy detection between them.
+
+The homeserver can then assist the user to complete the login flow with the correct account.
+
+The client should be prepared to handle a case where the account that the user signs into will not be the one that was
+initially suggested, especially if the homeserver does not support the `login_hint` parameter and/or
+the user mistakenly uses the wrong credentials.
+The client may inform the user about ending up on a different account than intended and present an option to try again.
+
+### Example authorization request
+
+Expanding on the example request in [MSC2964] (broken down into multiple lines for readability),
+with the following additional parameters:
+
+- `login_hint` set to `mxid:@example-user:example.com`
+- Additional `scope` of `openid`
+
+```
+https://account.example.com/oauth2/auth?
+    client_id             = s6BhdRkqt3 &
+    response_type         = code &
+    response_mode         = fragment &
+    redirect_uri          = https://app.example.com/oauth2-callback &
+    scope                 = openid urn:matrix:client:api:* urn:matrix:client:device:AAABBBCCCDDD &
+    state                 = ewubooN9weezeewah9fol4oothohroh3 &
+    code_challenge        = 72xySjpngTcCxgbPfFmkPHjMvVDl2jW1aWP7-J6rmwU &
+    code_challenge_method = S256 &
+    login_hint            = mxid:@example-user:example.com
+```
+
+With the line breaks removed and values properly encoded:
+```
+https://account.example.com/oauth2/auth?client_id=s6BhdRkqt3&response_type=code&response_mode=fragment&redirect_uri=https%3A%2F%2Fapp.example.com%2Foauth2-callback&scope=openid+urn%3Amatrix%3Aclient%3Aapi%3A*+urn%3Amatrix%3Aclient%3Adevice%3AAAABBBCCCDDD&state=ewubooN9weezeewah9fol4oothohroh3&code_challenge=72xySjpngTcCxgbPfFmkPHjMvVDl2jW1aWP7-J6rmwU&code_challenge_method=S256&login_hint=mxid%3A%40example-user%3Aexample.com
+```
+
+### Examples of homeserver assistance
+
+These are just some examples of what the homeserver could do. None of these are required.
+
+#### Prefilling the username
+
+The simplest method is to prefill the username in the username & password form.
+Implementing this is recommended, as it makes sure the user doesn't have to type their username multiple times.
+
+A more visually appealing method would be to replace the username field entirely with a preview of the user's profile
+including avatar and display name.
+
+#### Filtering login methods
+
+The homeserver could filter the login methods presented to only the ones the user has available to them.
+This can help if the user has forgotten if they set a password or used a social login.
+
+**Note:** See security consideration #1.
+
+#### Passing a login_hint to upstream providers
+
+To take full advantage of the benefits of `login_hint`, a suitable value could be forwarded to an upstream provider.
+The vague nature of the values for `login_hint` could make this difficult to implement, however.
+
+**Note:** See security consideration #2.
+
+#### Session management
+
+If there is already an active session with a different user, the homeserver could decide to log out and take the user to
+the login screen instead of showing the consent screen for the wrong account.
+
+If multiple concurrent sessions are supported,
+the homeserver could automatically switch to the correct session before showing the consent screen.
+
+## Potential issues
+
+TBD
+
+
+## Alternatives
+
+One alternative would be to only include the localpart (e.g. `login_hint=example-user`),
+as the domain is redundant information for the homeserver itself.
+However, the lack of a prefix makes adding and distinguishing additional future formats difficult
+and using an MXID builds on top of existing concepts within the spec.
+
+
+## Security considerations
+
+1. Filtering the available login methods has a risk of revealing too much information about the user and their security,
+allowing malicious actors to focus their efforts.
+However, other platforms have recently started being honest about the methods available to the user in their multi-step
+flows, deciding that the UX benefit outweighs the security risks.
+2. In the case an upstream provider wants some personally identifiable information as the value for the `login_hint`,
+such as an email, providing it would leak that information during the login flow.
+Therefore it is only recommended to provide such a value in an enterprise SSO situation where the value is predictable
+and public like a work email.
+
+
+## Unstable prefix
+
+No unstable prefix is necessary, as the format of the MXID is already stable within the spec.
+
+## Dependencies
+
+This MSC builds on [MSC3861] and its dependencies (which at the time of writing have not yet been accepted
+into the spec).
+
+[MSC3861]: https://github.com/matrix-org/matrix-spec-proposals/pull/3861
+[OpenID Connect Core 1.0]: https://openid.net/specs/openid-connect-core-1_0.html
+[MXID]: https://spec.matrix.org/v1.11/appendices/#user-identifiers
+[MSC2965]: https://github.com/matrix-org/matrix-spec-proposals/pull/2965
+[MSC2966]: https://github.com/matrix-org/matrix-spec-proposals/pull/2966
+[MSC2964]: https://github.com/matrix-org/matrix-spec-proposals/pull/2964

--- a/proposals/4198-oidc-login-hint.md
+++ b/proposals/4198-oidc-login-hint.md
@@ -38,27 +38,29 @@ Example valid hint value: `mxid:@example-user:example.com`
 
 ### Usage
 
-A client can start the login flow by asking the user for their MXID.
-It can then parse the domain, discover the homeserver and its auth metadata ([OAuth 2.0 API Server metadata discovery]),
+A client MAY start the login flow by asking the user for their MXID.
+It SHOULD then parse the domain, discover the homeserver and its auth metadata ([OAuth 2.0 API Server metadata discovery]),
 register itself with the homeserver ([OAuth 2.0 API Client registration])
 and send the user to the authorization endpoint ([OAuth 2.0 API Login flow]), all in one step.
 
-To improve the UX of this flow, the MXID may be sent to the homeserver with the authorization request in the `login_hint`
-query parameter, following the format specified above using the `mxid` hint type.
+To improve the UX of this flow, the MXID MAY be sent to the homeserver with the authorization request in the OPTIONAL
+`login_hint` query parameter from [OpenID Connect Core 1.0], following the format specified above using the `mxid` hint
+type.
 
 Despite the `login_hint` parameter being defined in the OpenID Connect specification, homeservers supporting this proposal
-must handle the parameter even without the `openid` scope.
+MUST handle the parameter even without the `openid` scope.
 
-The homeserver should then assist the user to complete the login flow with the correct account.
+The homeserver SHOULD then assist the user to complete the login flow with the correct account.
 
-The client must be prepared to handle a case where the account that the user signs into will not be the one that was
-initially suggested, especially if the homeserver does not support the `login_hint` parameter and/or
-the user mistakenly uses the wrong credentials.
-The client may inform the user about ending up on a different account than intended and present an option to try again.
+The client MUST be prepared to handle a case where the account that the user signs into will not be the one that was
+initially suggested, especially if the homeserver does not support the `login_hint` parameter and/or the user mistakenly
+uses the wrong credentials.
+The client MAY inform the user about ending up on a different account than intended and present an option to try again.
 
 ### Example authorization request
 
-Expanding on the example authorization request shown in [OAuth 2.0 API Login flow] (broken down into multiple lines for readability),
+Expanding on the example authorization request shown in [OAuth 2.0 API Login flow] (broken down into multiple lines for
+readability),
 with the following additional parameters:
 
 - `login_hint` set to `mxid:@example-user:example.com`

--- a/proposals/4198-oidc-login-hint.md
+++ b/proposals/4198-oidc-login-hint.md
@@ -3,11 +3,14 @@
 This proposal builds on the [OAuth 2.0 API](https://spec.matrix.org/v1.15/client-server-api/#oauth-20-api) that was
 added in v1.15 of the spec.
 
-[OpenID Connect Core 1.0] specifies an optional `login_hint`
-authorization request parameter but leaves the contents of the parameter vague and "to the OP's discretion".
+There are times when a client already knows or has asked for the user's identity before redirecting them to the homeserver's
+account management interface to log in or to manage their devices. It would be useful to pass this information along to
+the homeserver with these requests.
 
-This MSC aims to define a format for use in the context of Matrix which allows for a login flow that starts with the
-user typing their [MXID].
+[OpenID Connect Core 1.0] specifies an optional `login_hint` authorization request parameter which is perfect for this
+purpose but it leaves the contents of the parameter vague and "to the OP's discretion".
+
+This MSC aims to define a format for this parameter for use in the context of Matrix for interoperability.
 
 
 ## Proposal
@@ -36,12 +39,15 @@ The prefix for this hint is `mxid` (all lowercase) and the value is the Matrix u
 
 Example valid hint value: `mxid:@example-user:example.com`
 
-### Usage
+### Usage in authorization requests
 
 A client MAY start the login flow by asking the user for their MXID.
 It SHOULD then parse the domain, discover the homeserver and its auth metadata ([OAuth 2.0 API Server metadata discovery]),
 register itself with the homeserver ([OAuth 2.0 API Client registration])
 and send the user to the authorization endpoint ([OAuth 2.0 API Login flow]), all in one step.
+
+Alternatively, this MAY also be used when the user is already logged in and the client is requesting additional scopes
+(when more granular scopes are defined in a future proposal).
 
 To improve the UX of this flow, the MXID MAY be sent to the homeserver with the authorization request in the OPTIONAL
 `login_hint` query parameter from [OpenID Connect Core 1.0], following the format specified above using the `mxid` hint
@@ -57,7 +63,7 @@ initially suggested, especially if the homeserver does not support the `login_hi
 uses the wrong credentials.
 The client MAY inform the user about ending up on a different account than intended and present an option to try again.
 
-### Example authorization request
+#### Example authorization request
 
 Expanding on the example authorization request shown in [OAuth 2.0 API Login flow] (broken down into multiple lines for
 readability),
@@ -82,6 +88,16 @@ With the line breaks removed and values properly encoded:
 ```
 https://account.example.com/oauth2/auth?client_id=s6BhdRkqt3&response_type=code&response_mode=fragment&redirect_uri=https%3A%2F%2Fapp.example.com%2Foauth2-callback&scope=urn%3Amatrix%3Aclient%3Aapi%3A*+urn%3Amatrix%3Aclient%3Adevice%3AAAABBBCCCDDD&state=ewubooN9weezeewah9fol4oothohroh3&code_challenge=72xySjpngTcCxgbPfFmkPHjMvVDl2jW1aWP7-J6rmwU&code_challenge_method=S256&login_hint=mxid%3A%40example-user%3Aexample.com
 ```
+
+### Usage in [MSC4191] account management
+
+We also add the `login_hint` query parameter for the [MSC4191] `account_management_uri` using the same format.
+
+For example, if `@example-user:example.com` wishes to delete the device `ABCDEFGH` where the advertised
+`account_management_uri` was `https://account.example.com/myaccount` the client could open a link to
+`https://account.example.com/myaccount?action=org.matrix.device_delete&device_id=ABCDEFGH&login_hint=mxid%3A%40example-user%3Aexample.com`.
+
+Similarly to the authorization request, the homeserver SHOULD assist the user to the account the action was intended for.
 
 ### Examples of homeserver assistance
 
@@ -115,10 +131,10 @@ homeserver.
 #### Session management
 
 If there is already an active session with a different user, the homeserver could decide to log out and take the user to
-the login screen instead of showing the consent screen for the wrong account.
+the login screen instead of showing the consent screen or account management interface for the wrong account.
 
-If multiple concurrent sessions are supported,
-the homeserver could automatically switch to the correct session before showing the consent screen.
+If multiple concurrent sessions are supported, the homeserver could automatically switch to the correct session before
+showing the consent screen or account management interface.
 
 ## Potential issues
 
@@ -147,14 +163,18 @@ and public like a work email.
 
 ## Unstable prefix
 
-No unstable prefix is necessary, as the format of the MXID is already stable within the spec.
+For the authorization request we are borrowing the existing OIDC parameter so an unstable prefix isn't necessary.
+
+For the account management request, `org.matrix.msc4198.login_hint` should be used instead of `login_hint` while in
+development.
 
 ## Dependencies
 
-This MSC does not have any dependencies.
+This MSC builds on [MSC4191] (which at the time of writing has not yet been accepted into the spec).
 
 [OpenID Connect Core 1.0]: https://openid.net/specs/openid-connect-core-1_0.html
 [MXID]: https://spec.matrix.org/v1.11/appendices/#user-identifiers
 [OAuth 2.0 API Server metadata discovery]: https://spec.matrix.org/v1.15/client-server-api/#server-metadata-discovery
 [OAuth 2.0 API Client registration]: https://spec.matrix.org/v1.15/client-server-api/#client-registration
 [OAuth 2.0 API Login flow]: https://spec.matrix.org/v1.15/client-server-api/#login-flow
+[MSC4191]: https://github.com/matrix-org/matrix-spec-proposals/pull/4191

--- a/proposals/4198-oidc-login-hint.md
+++ b/proposals/4198-oidc-login-hint.md
@@ -1,6 +1,7 @@
 # MSC4198: Usage of OIDC login_hint
 
-[MSC3861] proposes using OAuth 2.0/OpenID Connect for authentication APIs.
+This proposal builds on the [OAuth 2.0 API](https://spec.matrix.org/v1.15/client-server-api/#oauth-20-api) that was
+added in v1.15 of the spec.
 
 [OpenID Connect Core 1.0] specifies an optional `login_hint`
 authorization request parameter but leaves the contents of the parameter vague and "to the OP's discretion".
@@ -38,9 +39,9 @@ Example valid hint value: `mxid:@example-user:example.com`
 ### Usage
 
 A client can start the login flow by asking the user for their MXID.
-It can then parse the domain, discover the homeserver and its auth issuer ([MSC2965]),
-register itself with the homeserver ([MSC2966])
-and send the user to the authorization endpoint ([MSC2964]), all in one step.
+It can then parse the domain, discover the homeserver and its auth metadata ([OAuth 2.0 API Server metadata discovery]),
+register itself with the homeserver ([OAuth 2.0 API Client registration])
+and send the user to the authorization endpoint ([OAuth 2.0 API Login flow]), all in one step.
 
 To improve the UX of this flow, the MXID may be sent to the homeserver with the authorization request in the `login_hint`
 query parameter, following the format specified above using the `mxid` hint type.
@@ -57,7 +58,7 @@ The client may inform the user about ending up on a different account than inten
 
 ### Example authorization request
 
-Expanding on the example request in [MSC2964] (broken down into multiple lines for readability),
+Expanding on the example authorization request shown in [OAuth 2.0 API Login flow] (broken down into multiple lines for readability),
 with the following additional parameters:
 
 - `login_hint` set to `mxid:@example-user:example.com`
@@ -148,12 +149,10 @@ No unstable prefix is necessary, as the format of the MXID is already stable wit
 
 ## Dependencies
 
-This MSC builds on [MSC3861] and its dependencies (which at the time of writing have not yet been accepted
-into the spec).
+This MSC does not have any dependencies.
 
-[MSC3861]: https://github.com/matrix-org/matrix-spec-proposals/pull/3861
 [OpenID Connect Core 1.0]: https://openid.net/specs/openid-connect-core-1_0.html
 [MXID]: https://spec.matrix.org/v1.11/appendices/#user-identifiers
-[MSC2965]: https://github.com/matrix-org/matrix-spec-proposals/pull/2965
-[MSC2966]: https://github.com/matrix-org/matrix-spec-proposals/pull/2966
-[MSC2964]: https://github.com/matrix-org/matrix-spec-proposals/pull/2964
+[OAuth 2.0 API Server metadata discovery]: https://spec.matrix.org/v1.15/client-server-api/#server-metadata-discovery
+[OAuth 2.0 API Client registration]: https://spec.matrix.org/v1.15/client-server-api/#client-registration
+[OAuth 2.0 API Login flow]: https://spec.matrix.org/v1.15/client-server-api/#login-flow

--- a/proposals/4198-oidc-login-hint.md
+++ b/proposals/4198-oidc-login-hint.md
@@ -1,4 +1,4 @@
-# MSC0000: Usage of OIDC login_hint
+# MSC4198: Usage of OIDC login_hint
 
 [MSC3861] proposes using OAuth 2.0/OpenID Connect for authentication APIs.
 

--- a/proposals/4198-oidc-login-hint.md
+++ b/proposals/4198-oidc-login-hint.md
@@ -19,7 +19,7 @@ and send the user to the authorization endpoint ([MSC2964]), all in one step.
 To improve the UX of this flow, the MXID can be sent to the homeserver with the authorization request in the `login_hint`.
 In order to comply with the OpenID Connect specification, the requested scope must also include the `openid` scope.
 
-The value of `login_hint` should be set to the user's MXID, prefixed with `mxid:` (e.g. `mxid:@example-user:example.com`).
+The value of `login_hint` may be set to the user's MXID, and must be prefixed with `mxid:` (e.g. `mxid:@example-user:example.com`).
 Prefixing the value allows for more hint value types to be added in the future and for easy detection between them.
 
 The homeserver can then assist the user to complete the login flow with the correct account.

--- a/proposals/4198-oidc-login-hint.md
+++ b/proposals/4198-oidc-login-hint.md
@@ -11,20 +11,44 @@ user typing their [MXID].
 
 ## Proposal
 
-A client can start the login flow by asking the user for their [MXID].
-The client can then parse the domain, discover the homeserver and its auth issuer ([MSC2965]),
+### Format
+
+In order to futureproof for new new types of hints in the future and to be able to identify and parse them easily,
+we introduce a format that contains a prefix before the value, separated by a colon.
+
+The ABNF syntax for it is as follows:
+```
+login-hint = prefix ":" value
+
+prefix = 1*prefix-char
+
+prefix-char = %x21-39 / %x3B-7E ; VCHAR excluding ":"
+
+value = 1*VCHAR
+```
+
+### The `mxid` hint
+
+This MSC specifies a hint that contains the user's [MXID].
+The prefix for this hint is `mxid` (all lowercase) and the value is the Matrix user ID as specified in the
+[User Identifiers][MXID] section.
+
+Example valid hint value: `mxid:@example-user:example.com`
+
+### Usage
+
+A client can start the login flow by asking the user for their MXID.
+It can then parse the domain, discover the homeserver and its auth issuer ([MSC2965]),
 register itself with the homeserver ([MSC2966])
 and send the user to the authorization endpoint ([MSC2964]), all in one step.
 
-To improve the UX of this flow, the MXID can be sent to the homeserver with the authorization request in the `login_hint`.
+To improve the UX of this flow, the MXID may be sent to the homeserver with the authorization request in the `login_hint`
+query parameter, following the format specified above using the `mxid` hint type.
 In order to comply with the OpenID Connect specification, the requested scope must also include the `openid` scope.
 
-The value of `login_hint` may be set to the user's MXID, and must be prefixed with `mxid:` (e.g. `mxid:@example-user:example.com`).
-Prefixing the value allows for more hint value types to be added in the future and for easy detection between them.
+The homeserver should then assist the user to complete the login flow with the correct account.
 
-The homeserver can then assist the user to complete the login flow with the correct account.
-
-The client should be prepared to handle a case where the account that the user signs into will not be the one that was
+The client must be prepared to handle a case where the account that the user signs into will not be the one that was
 initially suggested, especially if the homeserver does not support the `login_hint` parameter and/or
 the user mistakenly uses the wrong credentials.
 The client may inform the user about ending up on a different account than intended and present an option to try again.
@@ -98,8 +122,8 @@ TBD
 
 One alternative would be to only include the localpart (e.g. `login_hint=example-user`),
 as the domain is redundant information for the homeserver itself.
-However, the lack of a prefix makes adding and distinguishing additional future formats difficult
-and using an MXID builds on top of existing concepts within the spec.
+However, the lack of a prefix has the potential to make adding and distinguishing additional future formats difficult
+and using the full MXID builds on top of existing concepts within the spec.
 
 
 ## Security considerations

--- a/proposals/4198-oidc-login-hint.md
+++ b/proposals/4198-oidc-login-hint.md
@@ -44,7 +44,9 @@ and send the user to the authorization endpoint ([MSC2964]), all in one step.
 
 To improve the UX of this flow, the MXID may be sent to the homeserver with the authorization request in the `login_hint`
 query parameter, following the format specified above using the `mxid` hint type.
-In order to comply with the OpenID Connect specification, the requested scope must also include the `openid` scope.
+
+Despite the `login_hint` parameter being defined in the OpenID Connect specification, homeservers supporting this proposal
+must handle the parameter even without the `openid` scope.
 
 The homeserver should then assist the user to complete the login flow with the correct account.
 
@@ -59,7 +61,6 @@ Expanding on the example request in [MSC2964] (broken down into multiple lines f
 with the following additional parameters:
 
 - `login_hint` set to `mxid:@example-user:example.com`
-- Additional `scope` of `openid`
 
 ```
 https://account.example.com/oauth2/auth?
@@ -67,7 +68,7 @@ https://account.example.com/oauth2/auth?
     response_type         = code &
     response_mode         = fragment &
     redirect_uri          = https://app.example.com/oauth2-callback &
-    scope                 = openid urn:matrix:client:api:* urn:matrix:client:device:AAABBBCCCDDD &
+    scope                 = urn:matrix:client:api:* urn:matrix:client:device:AAABBBCCCDDD &
     state                 = ewubooN9weezeewah9fol4oothohroh3 &
     code_challenge        = 72xySjpngTcCxgbPfFmkPHjMvVDl2jW1aWP7-J6rmwU &
     code_challenge_method = S256 &
@@ -76,7 +77,7 @@ https://account.example.com/oauth2/auth?
 
 With the line breaks removed and values properly encoded:
 ```
-https://account.example.com/oauth2/auth?client_id=s6BhdRkqt3&response_type=code&response_mode=fragment&redirect_uri=https%3A%2F%2Fapp.example.com%2Foauth2-callback&scope=openid+urn%3Amatrix%3Aclient%3Aapi%3A*+urn%3Amatrix%3Aclient%3Adevice%3AAAABBBCCCDDD&state=ewubooN9weezeewah9fol4oothohroh3&code_challenge=72xySjpngTcCxgbPfFmkPHjMvVDl2jW1aWP7-J6rmwU&code_challenge_method=S256&login_hint=mxid%3A%40example-user%3Aexample.com
+https://account.example.com/oauth2/auth?client_id=s6BhdRkqt3&response_type=code&response_mode=fragment&redirect_uri=https%3A%2F%2Fapp.example.com%2Foauth2-callback&scope=urn%3Amatrix%3Aclient%3Aapi%3A*+urn%3Amatrix%3Aclient%3Adevice%3AAAABBBCCCDDD&state=ewubooN9weezeewah9fol4oothohroh3&code_challenge=72xySjpngTcCxgbPfFmkPHjMvVDl2jW1aWP7-J6rmwU&code_challenge_method=S256&login_hint=mxid%3A%40example-user%3Aexample.com
 ```
 
 ### Examples of homeserver assistance

--- a/proposals/4198-oidc-login-hint.md
+++ b/proposals/4198-oidc-login-hint.md
@@ -99,10 +99,13 @@ This can help if the user has forgotten if they set a password or used a social 
 
 **Note:** See security consideration #1.
 
-#### Passing a login_hint to upstream providers
+#### Passing a `login_hint` to upstream providers
 
-To take full advantage of the benefits of `login_hint`, a suitable value could be forwarded to an upstream provider.
-The vague nature of the values for `login_hint` could make this difficult to implement, however.
+To take full advantage of the benefits of `login_hint`, a suitable value that the upstream provider expects could be
+supplied when logging in with one.
+Since this proposal only covers the Matrix protocol, upstream providers likely won't follow the format laid out in this
+proposal and any upstream hint value would have to be configured on a per provider basis by the administrator of the
+homeserver.
 
 **Note:** See security consideration #2.
 

--- a/proposals/4198-oidc-login-hint.md
+++ b/proposals/4198-oidc-login-hint.md
@@ -99,6 +99,15 @@ For example, if `@example-user:example.com` wishes to delete the device `ABCDEFG
 
 Similarly to the authorization request, the homeserver SHOULD assist the user to the account the action was intended for.
 
+### Additional authentication server metadata
+
+This proposal introduces a new optional field in the authentication
+[server metadata discovery][OAuth 2.0 API Server metadata discovery]:
+
+* `org.matrix.login_hint_types_supported`: a JSON array of login hint types that the server supports
+
+Example: `"org.matrix.login_hint_types_supported": ["mxid"]`
+
 ### Examples of homeserver assistance
 
 These are just some examples of what the homeserver could do. None of these are required.
@@ -170,6 +179,9 @@ For the authorization request we are borrowing the existing OIDC parameter so an
 
 For the account management request, `org.matrix.msc4198.login_hint` should be used instead of `login_hint` while in
 development.
+
+The server metadata field `org.matrix.msc4198.login_hint_types_supported` should be used instead of
+`org.matrix.login_hint_types_supported`
 
 ## Dependencies
 

--- a/proposals/4198-oidc-login-hint.md
+++ b/proposals/4198-oidc-login-hint.md
@@ -38,19 +38,22 @@ The prefix for this hint is `mxid` (all lowercase) and the value is the Matrix u
 
 Example valid hint value: `mxid:@example-user:example.com`
 
-### Usage in authorization requests
-
-A client MAY start the login flow by asking the user for their MXID.
+A client MAY start a login flow by asking the user for their MXID.
 It SHOULD then parse the domain, discover the homeserver and its auth metadata ([OAuth 2.0 API Server metadata discovery]),
-register itself with the homeserver ([OAuth 2.0 API Client registration])
-and send the user to the authorization endpoint ([OAuth 2.0 API Authorization code flow]), all in one step.
+register itself with the homeserver ([OAuth 2.0 API Client registration]) and start the appropriate authorization flow,
+all in one step.
 
-Alternatively, this MAY also be used when the user is already logged in and the client is requesting additional scopes
-(when more granular scopes are defined in a future proposal).
+Alternatively, this MAY also be used when the user is already logged in and the client already knows the user's MXID
+when requesting additional scopes (when more granular scopes are defined in a future proposal)
+or when redirecting to the homeserver's account management UI.
 
-To improve the UX of this flow, the MXID MAY be sent to the homeserver with the authorization request in the OPTIONAL
-`login_hint` query parameter from [OpenID Connect Core 1.0], following the format specified above using the `mxid` hint
-type.
+To improve the UX in these cases, the MXID MAY be sent to the homeserver in the ways defined below, following the format
+specified above using the `mxid` hint type.
+
+### Usage in authorization code flow
+
+To use a login hint with the [OAuth 2.0 API Authorization code flow],
+the `login_hint` query parameter is added to the authorization request using the format defined above.
 
 Despite the `login_hint` parameter being defined in the OpenID Connect specification, homeservers supporting this proposal
 MUST handle the parameter even without the `openid` scope.
@@ -97,7 +100,8 @@ For example, if `@example-user:example.com` wishes to delete the device `ABCDEFG
 `account_management_uri` was `https://account.example.com/myaccount` the client could open a link to
 `https://account.example.com/myaccount?action=org.matrix.device_delete&device_id=ABCDEFGH&login_hint=mxid%3A%40example-user%3Aexample.com`.
 
-Similarly to the authorization request, the homeserver SHOULD assist the user to the account the action was intended for.
+Similarly to the authorization request, the homeserver SHOULD assist the user to perform the action with the account
+it was intended for.
 
 ### Additional authentication server metadata
 

--- a/proposals/4198-oidc-login-hint.md
+++ b/proposals/4198-oidc-login-hint.md
@@ -30,7 +30,7 @@ prefix-char = %x21-39 / %x3B-7E ; VCHAR excluding ":"
 value = 1*VCHAR
 ```
 
-### The `mxid` hint
+### The `mxid` hint type
 
 This MSC specifies a hint that contains the user's [MXID].
 The prefix for this hint is `mxid` (all lowercase) and the value is the Matrix user ID as specified in the
@@ -43,9 +43,10 @@ It SHOULD then parse the domain, discover the homeserver and its auth metadata (
 register itself with the homeserver ([OAuth 2.0 API Client registration]) and start the appropriate authorization flow,
 all in one step.
 
-Alternatively, this MAY also be used when the user is already logged in and the client already knows the user's MXID
-when requesting additional scopes (when more granular scopes are defined in a future proposal)
-or when redirecting to the homeserver's account management UI.
+Alternatively, this MAY also be used when the user is already logged in and the client already knows the user's MXID.
+For example when requesting additional scopes (when more granular scopes are defined in a future proposal),
+when redirecting to the homeserver's account management UI,
+or provided to a new device through [MSC4108] QR code login.
 
 To improve the UX in these cases, the MXID MAY be sent to the homeserver in the ways defined below, following the format
 specified above using the `mxid` hint type.
@@ -89,6 +90,28 @@ https://account.example.com/oauth2/auth?
 With the line breaks removed and values properly encoded:
 ```
 https://account.example.com/oauth2/auth?client_id=s6BhdRkqt3&response_type=code&response_mode=fragment&redirect_uri=https%3A%2F%2Fapp.example.com%2Foauth2-callback&scope=urn%3Amatrix%3Aclient%3Aapi%3A*+urn%3Amatrix%3Aclient%3Adevice%3AAAABBBCCCDDD&state=ewubooN9weezeewah9fol4oothohroh3&code_challenge=72xySjpngTcCxgbPfFmkPHjMvVDl2jW1aWP7-J6rmwU&code_challenge_method=S256&login_hint=mxid%3A%40example-user%3Aexample.com
+```
+
+### Usage in device authorization flow
+
+To use a login hint with the [OAuth 2.0 API Device authorization flow], a `login_hint` parameter is added to the device authorization request body using the format defined above.
+
+Similarly to the authorization code flow, homeservers SHOULD assist users to complete the login flow with the correct
+account and clients MUST be prepared to handle users signing in with a different user account than expected.
+
+#### Example device authorization request
+
+Expanding on the example device authorization request shown in [OAuth 2.0 API Device authorization flow],
+with the following additional parameters:
+
+- `login_hint` set to `mxid:@example-user:example.com`
+
+```
+POST /oauth2/device HTTP/1.1
+Host: account.example.com
+Content-Type: application/x-www-form-urlencoded
+
+client_id=s6BhdRkqt3&scope=urn%3Amatrix%3Aclient%3Aapi%3A%2A%20urn%3Amatrix%3Aclient%3Adevice%3AAABBBCCCDDD&login_hint=mxid%3A%40example-user%3Aexample.com
 ```
 
 ### Usage in account management
@@ -179,13 +202,13 @@ and public like a work email.
 
 ## Unstable prefix
 
-For the authorization request we are borrowing the existing OIDC parameter so an unstable prefix isn't necessary.
+For the authorization code request we are borrowing the existing OIDC parameter so an unstable prefix isn't necessary.
 
-For the account management request, `org.matrix.msc4198.login_hint` should be used instead of `login_hint` while in
-development.
+For the device authorization request and account management request, `org.matrix.msc4198.login_hint` should be used
+instead of `login_hint` while in development.
 
 The server metadata field `org.matrix.msc4198.login_hint_types_supported` should be used instead of
-`org.matrix.login_hint_types_supported`
+`org.matrix.login_hint_types_supported` while in development.
 
 ## Dependencies
 
@@ -197,4 +220,6 @@ None.
 [OAuth 2.0 API Server metadata discovery]: https://spec.matrix.org/v1.19/client-server-api/#server-metadata-discovery
 [OAuth 2.0 API Client registration]: https://spec.matrix.org/v1.19/client-server-api/#client-registration
 [OAuth 2.0 API Authorization code flow]: https://spec.matrix.org/v1.19/client-server-api/#authorisation-code-flow
+[OAuth 2.0 API Device authorization flow]: https://spec.matrix.org/v1.19/client-server-api/#device-authorisation-flow
 [OAuth 2.0 API Account management]: https://spec.matrix.org/v1.19/client-server-api/#oauth-20-account-management
+[MSC4108]: https://github.com/matrix-org/matrix-spec-proposals/pull/4108

--- a/proposals/4198-oidc-login-hint.md
+++ b/proposals/4198-oidc-login-hint.md
@@ -64,8 +64,8 @@ The client MAY inform the user about ending up on a different account than inten
 
 #### Example authorization request
 
-Expanding on the example authorization request shown in [OAuth 2.0 API Authorization code flow] (broken down into multiple lines for
-readability),
+Expanding on the example authorization request shown in [OAuth 2.0 API Authorization code flow] (broken down into multiple
+lines for readability),
 with the following additional parameters:
 
 - `login_hint` set to `mxid:@example-user:example.com`
@@ -143,10 +143,13 @@ TBD
 
 ## Alternatives
 
-One alternative would be to only include the localpart (e.g. `login_hint=example-user`),
-as the domain is redundant information for the homeserver itself.
-However, the lack of a prefix has the potential to make adding and distinguishing additional future formats difficult
-and using the full MXID builds on top of existing concepts within the spec.
+One obvious alternative would be to only include the MXID (e.g. `login_hint=@example-user:example.com`)
+or just the localpart (e.g. `login_hint=example-user`) since the domain is redundant information for the homeserver itself.
+However, the lack of a prefix has the potential to make adding and distinguishing additional future formats difficult.
+
+Another option would be to use something that most upstream OIDC providers use, like a plain username (localpart) or email.
+This would allow transparently passing the hint value upstream and might work with most of them but not for all of them.
+There is also no guarantee that the user's matrix localpart or email is the same as their upstream username or email.
 
 
 ## Security considerations

--- a/proposals/4198-oidc-login-hint.md
+++ b/proposals/4198-oidc-login-hint.md
@@ -1,7 +1,6 @@
 # MSC4198: Usage of OIDC login_hint
 
-This proposal builds on the [OAuth 2.0 API](https://spec.matrix.org/v1.15/client-server-api/#oauth-20-api) that was
-added in v1.15 of the spec.
+This proposal builds on the [OAuth 2.0 API] that was added in v1.15 of the spec.
 
 There are times when a client already knows or has asked for the user's identity before redirecting them to the homeserver's
 account management interface to log in or to manage their devices. It would be useful to pass this information along to
@@ -44,7 +43,7 @@ Example valid hint value: `mxid:@example-user:example.com`
 A client MAY start the login flow by asking the user for their MXID.
 It SHOULD then parse the domain, discover the homeserver and its auth metadata ([OAuth 2.0 API Server metadata discovery]),
 register itself with the homeserver ([OAuth 2.0 API Client registration])
-and send the user to the authorization endpoint ([OAuth 2.0 API Login flow]), all in one step.
+and send the user to the authorization endpoint ([OAuth 2.0 API Authorization code flow]), all in one step.
 
 Alternatively, this MAY also be used when the user is already logged in and the client is requesting additional scopes
 (when more granular scopes are defined in a future proposal).
@@ -65,7 +64,7 @@ The client MAY inform the user about ending up on a different account than inten
 
 #### Example authorization request
 
-Expanding on the example authorization request shown in [OAuth 2.0 API Login flow] (broken down into multiple lines for
+Expanding on the example authorization request shown in [OAuth 2.0 API Authorization code flow] (broken down into multiple lines for
 readability),
 with the following additional parameters:
 
@@ -89,9 +88,10 @@ With the line breaks removed and values properly encoded:
 https://account.example.com/oauth2/auth?client_id=s6BhdRkqt3&response_type=code&response_mode=fragment&redirect_uri=https%3A%2F%2Fapp.example.com%2Foauth2-callback&scope=urn%3Amatrix%3Aclient%3Aapi%3A*+urn%3Amatrix%3Aclient%3Adevice%3AAAABBBCCCDDD&state=ewubooN9weezeewah9fol4oothohroh3&code_challenge=72xySjpngTcCxgbPfFmkPHjMvVDl2jW1aWP7-J6rmwU&code_challenge_method=S256&login_hint=mxid%3A%40example-user%3Aexample.com
 ```
 
-### Usage in [MSC4191] account management
+### Usage in account management
 
-We also add the `login_hint` query parameter for the [MSC4191] `account_management_uri` using the same format.
+We also add the `login_hint` query parameter for the `account_management_uri` in [OAuth 2.0 API Account management]
+using the same format.
 
 For example, if `@example-user:example.com` wishes to delete the device `ABCDEFGH` where the advertised
 `account_management_uri` was `https://account.example.com/myaccount` the client could open a link to
@@ -170,11 +170,12 @@ development.
 
 ## Dependencies
 
-This MSC builds on [MSC4191] (which at the time of writing has not yet been accepted into the spec).
+None.
 
 [OpenID Connect Core 1.0]: https://openid.net/specs/openid-connect-core-1_0.html
-[MXID]: https://spec.matrix.org/v1.11/appendices/#user-identifiers
-[OAuth 2.0 API Server metadata discovery]: https://spec.matrix.org/v1.15/client-server-api/#server-metadata-discovery
-[OAuth 2.0 API Client registration]: https://spec.matrix.org/v1.15/client-server-api/#client-registration
-[OAuth 2.0 API Login flow]: https://spec.matrix.org/v1.15/client-server-api/#login-flow
-[MSC4191]: https://github.com/matrix-org/matrix-spec-proposals/pull/4191
+[MXID]: https://spec.matrix.org/v1.19/appendices/#user-identifiers
+[OAuth 2.0 API]: https://spec.matrix.org/v1.19/client-server-api/#oauth-20-api
+[OAuth 2.0 API Server metadata discovery]: https://spec.matrix.org/v1.19/client-server-api/#server-metadata-discovery
+[OAuth 2.0 API Client registration]: https://spec.matrix.org/v1.19/client-server-api/#client-registration
+[OAuth 2.0 API Authorization code flow]: https://spec.matrix.org/v1.19/client-server-api/#authorisation-code-flow
+[OAuth 2.0 API Account management]: https://spec.matrix.org/v1.19/client-server-api/#oauth-20-account-management


### PR DESCRIPTION
[Rendered](https://github.com/tonkku107/matrix-spec-proposals/blob/oidc-login-hint/proposals/4198-oidc-login-hint.md)

**Implementations:**
- Authorization code flow
  - Homeserver / Authentication service:
    - https://github.com/element-hq/matrix-authentication-service/pull/3343
  - Client:
    - Element X
      - https://github.com/element-hq/element-x-ios/pull/4108
      - https://github.com/element-hq/element-x-android/pull/4752
      - https://github.com/element-hq/element-x-android/pull/7500
 - Device authorization flow
    - Homeserver / Authentication service:
      - https://github.com/element-hq/matrix-authentication-service/pull/5982
    - Client:
      - TBD
 - Account management requests
   - Homeserver / Authentication service:
     - https://github.com/element-hq/matrix-authentication-service/pull/5516
   - Client:
     - TBD
 - Metadata
   - Homeserver / Authentication service:
     - https://github.com/element-hq/matrix-authentication-service/pull/5981