### PR TITLE
Clean up MSC_CHECKLIST.md

### DIFF
--- a/MSC_CHECKLIST.md
+++ b/MSC_CHECKLIST.md
@@ -12,7 +12,7 @@ MSC authors, feel free to ask in a thread on your PR or in the
 clarification of any of these points.
 
 - [ ] Are [appropriate implementation(s)](https://spec.matrix.org/proposals/#implementing-a-proposal)
-specified in the MSC’s PR description?
+  specified in the MSC’s PR description?
 - [ ] Are all MSCs that this MSC depends on already accepted?
 - [ ] For each new endpoint that is introduced:
   - [ ] Have authentication requirements been specified?
@@ -30,13 +30,13 @@ specified in the MSC’s PR description?
   - [ ] Do HTTP endpoints `use_underscores_like_this`?
   - [ ] Will the endpoint return unbounded data? If so, has pagination been considered?
   - [ ] If the endpoint utilises pagination, is it consistent with
-  [the appendices](https://spec.matrix.org/v1.8/appendices/#pagination)?
+    [the appendices](https://spec.matrix.org/v1.8/appendices/#pagination)?
 - [ ] An introduction exists and clearly outlines the problem being solved.
       Ideally, the first paragraph should be understandable by a non-technical audience.
 - [ ] All outstanding threads are resolved
   - [ ] All feedback is incorporated into the proposal text itself, either as a fix or noted as an alternative
 - [ ] While the exact sections do not need to be present,
-the details implied by the proposal template are covered. Namely:
+  the details implied by the proposal template are covered. Namely:
   - [ ] Introduction
   - [ ] Proposal text
   - [ ] Potential issues
@@ -47,6 +47,6 @@ the details implied by the proposal template are covered. Namely:
   - [ ] Chosen unstable prefixes do not pollute any global namespace (use “org.matrix.mscXXXX”, not “org.matrix”).
 - [ ] Changes have applicable [Sign Off](CONTRIBUTING.md#sign-off) from all authors/editors/contributors
 - [ ] There is a dedicated "Security Considerations" section which detail
-any possible attacks/vulnerabilities this proposal may introduce, even if this is "None.".
-See [RFC3552](https://datatracker.ietf.org/doc/html/rfc3552) for things to think about,
-but in particular pay attention to the [OWASP Top Ten](https://owasp.org/www-project-top-ten/).
+  any possible attacks/vulnerabilities this proposal may introduce, even if this is "None.".
+  See [RFC3552](https://datatracker.ietf.org/doc/html/rfc3552) for things to think about,
+  but in particular pay attention to the [OWASP Top Ten](https://owasp.org/www-project-top-ten/).

--- a/MSC_CHECKLIST.md
+++ b/MSC_CHECKLIST.md
@@ -11,7 +11,8 @@ MSC authors, feel free to ask in a thread on your PR or in the
 [#matrix-spec:matrix.org](https://matrix.to/#/#matrix-spec:matrix.org) room for
 clarification of any of these points.
 
-- [ ] Are [appropriate implementation(s)](https://spec.matrix.org/proposals/#implementing-a-proposal) specified in the MSC’s PR description?
+- [ ] Are [appropriate implementation(s)](https://spec.matrix.org/proposals/#implementing-a-proposal)
+specified in the MSC’s PR description?
 - [ ] Are all MSCs that this MSC depends on already accepted?
 - [ ] For each new endpoint that is introduced:
   - [ ] Have authentication requirements been specified?
@@ -28,12 +29,14 @@ clarification of any of these points.
 - [ ] Are the [endpoint conventions](https://spec.matrix.org/latest/appendices/#conventions-for-matrix-apis) honoured?
   - [ ] Do HTTP endpoints `use_underscores_like_this`?
   - [ ] Will the endpoint return unbounded data? If so, has pagination been considered?
-  - [ ] If the endpoint utilises pagination, is it consistent with [the appendices](https://spec.matrix.org/v1.8/appendices/#pagination)?
+  - [ ] If the endpoint utilises pagination, is it consistent with
+  [the appendices](https://spec.matrix.org/v1.8/appendices/#pagination)?
 - [ ] An introduction exists and clearly outlines the problem being solved.
       Ideally, the first paragraph should be understandable by a non-technical audience.
 - [ ] All outstanding threads are resolved
   - [ ] All feedback is incorporated into the proposal text itself, either as a fix or noted as an alternative
-- [ ] While the exact sections do not need to be present, the details implied by the proposal template are covered. Namely:
+- [ ] While the exact sections do not need to be present,
+the details implied by the proposal template are covered. Namely:
   - [ ] Introduction
   - [ ] Proposal text
   - [ ] Potential issues
@@ -43,4 +46,7 @@ clarification of any of these points.
   - [ ] Unstable prefixes [consider](README.md#unstable-prefixes) the awkward accepted-but-not-merged state
   - [ ] Chosen unstable prefixes do not pollute any global namespace (use “org.matrix.mscXXXX”, not “org.matrix”).
 - [ ] Changes have applicable [Sign Off](CONTRIBUTING.md#sign-off) from all authors/editors/contributors
-- [ ] There is a dedicated "Security Considerations" section which detail any possible attacks/vulnerabilities this proposal may introduce, even if this is "None.". See [RFC3552](https://datatracker.ietf.org/doc/html/rfc3552) for things to think about, but in particular pay attention to the [OWASP Top Ten](https://owasp.org/www-project-top-ten/).
+- [ ] There is a dedicated "Security Considerations" section which detail
+any possible attacks/vulnerabilities this proposal may introduce, even if this is "None.".
+See [RFC3552](https://datatracker.ietf.org/doc/html/rfc3552) for things to think about,
+but in particular pay attention to the [OWASP Top Ten](https://owasp.org/www-project-top-ten/).

--- a/MSC_CHECKLIST.md
+++ b/MSC_CHECKLIST.md
@@ -11,40 +11,36 @@ MSC authors, feel free to ask in a thread on your PR or in the
 [#matrix-spec:matrix.org](https://matrix.to/#/#matrix-spec:matrix.org) room for
 clarification of any of these points.
 
-- [ ] Are [appropriate
-      implementation(s)](https://spec.matrix.org/proposals/#implementing-a-proposal)
-      specified in the MSC’s PR description?
+- [ ] Are [appropriate implementation(s)](https://spec.matrix.org/proposals/#implementing-a-proposal) specified in the MSC’s PR description?
 - [ ] Are all MSCs that this MSC depends on already accepted?
 - [ ] For each new endpoint that is introduced:
-    - [ ] Have authentication requirements been specified?
-    - [ ] Have rate-limiting requirements been specified?
-    - [ ] Have guest access requirements been specified?
-    - [ ] Are error responses specified?
-        - [ ] Does each error case have a specified `errcode` (e.g. `M_FORBIDDEN`) and HTTP status code?
-            - [ ] If a new `errcode` is introduced, is it clear that it is new?
+  - [ ] Have authentication requirements been specified?
+  - [ ] Have rate-limiting requirements been specified?
+  - [ ] Have guest access requirements been specified?
+  - [ ] Are error responses specified?
+    - [ ] Does each error case have a specified `errcode` (e.g. `M_FORBIDDEN`) and HTTP status code?
+      - [ ] If a new `errcode` is introduced, is it clear that it is new?
 - [ ] Will the MSC require a new room version, and if so, has that been made clear?
-    - [ ] Is the reason for a new room version clearly stated? For example,
+  - [ ] Is the reason for a new room version clearly stated? For example,
           modifying the set of redacted fields changes how event IDs are calculated,
           thus requiring a new room version.
 - [ ] Are backwards-compatibility concerns appropriately addressed?
 - [ ] Are the [endpoint conventions](https://spec.matrix.org/latest/appendices/#conventions-for-matrix-apis) honoured?
-    - [ ] Do HTTP endpoints `use_underscores_like_this`?
-    - [ ] Will the endpoint return unbounded data? If so, has pagination been considered?
-    - [ ] If the endpoint utilises pagination, is it consistent with [the
-          appendices](https://spec.matrix.org/v1.8/appendices/#pagination)?
+  - [ ] Do HTTP endpoints `use_underscores_like_this`?
+  - [ ] Will the endpoint return unbounded data? If so, has pagination been considered?
+  - [ ] If the endpoint utilises pagination, is it consistent with [the appendices](https://spec.matrix.org/v1.8/appendices/#pagination)?
 - [ ] An introduction exists and clearly outlines the problem being solved.
-      Ideally, the first paragraph should be understandable by a non-technical
-      audience
+      Ideally, the first paragraph should be understandable by a non-technical audience.
 - [ ] All outstanding threads are resolved
-    - [ ] All feedback is incorporated into the proposal text itself, either as a fix or noted as an alternative
+  - [ ] All feedback is incorporated into the proposal text itself, either as a fix or noted as an alternative
 - [ ] While the exact sections do not need to be present, the details implied by the proposal template are covered. Namely:
-    - [ ] Introduction
-    - [ ] Proposal text
-    - [ ] Potential issues
-    - [ ] Alternatives
-    - [ ] Dependencies
+  - [ ] Introduction
+  - [ ] Proposal text
+  - [ ] Potential issues
+  - [ ] Alternatives
+  - [ ] Dependencies
 - [ ] Stable identifiers are used throughout the proposal, except for the unstable prefix section
-    - [ ] Unstable prefixes [consider](README.md#unstable-prefixes) the awkward accepted-but-not-merged state
-    - [ ] Chosen unstable prefixes do not pollute any global namespace (use “org.matrix.mscXXXX”, not “org.matrix”).
+  - [ ] Unstable prefixes [consider](README.md#unstable-prefixes) the awkward accepted-but-not-merged state
+  - [ ] Chosen unstable prefixes do not pollute any global namespace (use “org.matrix.mscXXXX”, not “org.matrix”).
 - [ ] Changes have applicable [Sign Off](CONTRIBUTING.md#sign-off) from all authors/editors/contributors
 - [ ] There is a dedicated "Security Considerations" section which detail any possible attacks/vulnerabilities this proposal may introduce, even if this is "None.". See [RFC3552](https://datatracker.ietf.org/doc/html/rfc3552) for things to think about, but in particular pay attention to the [OWASP Top Ten](https://owasp.org/www-project-top-ten/).


### PR DESCRIPTION
So i decided to go and read the MSC Checklist in vscode as i was about to start writing a new MSC and my markdown linter started screaming. Well turns out the checklist is making it quite unhappy.

i also fixed some overly eager line breaks that only hurt the ability to read the file on my screen. And since they mostly dont change the max line lenght its not a readability concern in my book. Especially with Line 46 being as long as it is. 

Signed-off-by: Catalan Lover <catalanlover@protonmail.com>