### PR TITLE
MSC4216: Set Maximum Allowed Tags

### DIFF
--- a/proposals/4216-limit-creating-same-tag.md
+++ b/proposals/4216-limit-creating-same-tag.md
@@ -1,33 +1,3 @@
-# MSC4216: Set Maximum Allowed Tags
+## MSC4216 Proposal
 
-[MSC4216](https://github.com/matrix-org/matrix-spec-proposals/blob/main/proposals/4216-limit-creating-same-tag.md)
-
-Enable matrix servers the choice to set a threshold on tags applied by a user, so the user can apply certain tags only to predefined maximum amount.
-
-## Proposal
-
-I'm proposing to add config to matrix servers that specify if the matrix server admin want to limit the tags or not. See the example below on limiting the user to apply the tag `u.pin` to only 3 rooms. This is useful because other chat systems use the same logic on restricting some tag. And with this change we can allow matrix servers admins to dynamically set the max to a tag. Also, if the admin wants to create tag `u.archive` and didn't add it to the config file, that tag will not be restricted to a threshold unlike `u.pin` and `u.favorite`.
-
-```yaml
-tags:
-    - name: u.pin
-      max: 3
-    - name: u.favorite
-      max: 10
-```
-
-## Potential issues
-
-NA
-
-## Alternatives
-
-NA
-
-## Security considerations
-
-NA
-
-## Dependencies
-
-This MSC has no dependencies.
+Let matrix server admins limit user-applied tags, e.g., u.pin to 3 rooms. Useful for consistency with other chat systems.

--- a/proposals/4216-limit-creating-same-tag.md
+++ b/proposals/4216-limit-creating-same-tag.md
@@ -1,3 +1,19 @@
 ## MSC4216 Proposal
 
-Give admins the ability to limit user-applied tags, e.g., u.pin to 3 rooms. Useful for consistency with other chat systems.
+Admins should have the ability to limit tag usage, like restricting `u.pin` to **3** rooms, while tags like `u.archive` will remain unrestricted if **not defined**.
+
+## Potential issues
+
+NA
+
+## Alternatives
+
+NA
+
+## Security considerations
+
+NA
+
+## Dependencies
+
+This MSC has no dependencies.

--- a/proposals/4216-limit-creating-same-tag.md
+++ b/proposals/4216-limit-creating-same-tag.md
@@ -1,3 +1,3 @@
 ## MSC4216 Proposal
 
-Let matrix server admins the ability to limit user-applied tags, e.g., u.pin to 3 rooms. Useful for consistency with other chat systems.
+Give admins the ability to limit user-applied tags, e.g., u.pin to 3 rooms. Useful for consistency with other chat systems.

--- a/proposals/4216-limit-creating-same-tag.md
+++ b/proposals/4216-limit-creating-same-tag.md
@@ -1,0 +1,33 @@
+# MSC4216: Set Maximum Allowed Tags
+
+[MSC4216](https://github.com/matrix-org/matrix-spec-proposals/blob/main/proposals/4216-limit-creating-same-tag.md)
+
+Enable matrix servers the choice to set a threshold on tags applied by a user, so the user can apply certain tags only to predefined maximum amount.
+
+## Proposal
+
+I'm proposing to add config to matrix servers that specify if the matrix server admin want to limit the tags or not. See the example below on limiting the user to apply the tag `u.pin` to only 3 rooms. This is useful because other chat systems use the same logic on restricting some tag. And with this change we can allow matrix servers admins to dynamically set the max to a tag. Also, if the admin wants to create tag `u.archive` and didn't add it to the config file, that tag will not be restricted to a threshold unlike `u.pin` and `u.favorite`.
+
+```yaml
+tags:
+    - name: u.pin
+      max: 3
+    - name: u.favorite
+      max: 10
+```
+
+## Potential issues
+
+NA
+
+## Alternatives
+
+NA
+
+## Security considerations
+
+NA
+
+## Dependencies
+
+This MSC has no dependencies.

--- a/proposals/4216-limit-creating-same-tag.md
+++ b/proposals/4216-limit-creating-same-tag.md
@@ -1,3 +1,3 @@
 ## MSC4216 Proposal
 
-Let matrix server admins limit user-applied tags, e.g., u.pin to 3 rooms. Useful for consistency with other chat systems.
+Let matrix server admins the ability to limit user-applied tags, e.g., u.pin to 3 rooms. Useful for consistency with other chat systems.


### PR DESCRIPTION
Enable matrix servers the choice to set a threshold on tags applied by a user, so the user can apply certain tags only to predefined maximum amount.