### PR TITLE
MSC4262: Sliding Sync Extension: Profile Updates

### DIFF
--- a/proposals/4262-sliding-sync-profiles.md
+++ b/proposals/4262-sliding-sync-profiles.md
@@ -1,0 +1,121 @@
+# MSC4262: Sliding Sync Extension: Profile Updates
+
+This MSC is an extension to [MSC3575](https://github.com/matrix-org/matrix-spec-proposals/pull/3575) which adds support for receiving profile updates via Sliding Sync. It complements [MSC4259](https://github.com/matrix-org/matrix-spec-proposals/pull/4259) which handles federation-level profile updates.
+
+## Proposal
+
+MSC3575 currently does not include support for receiving profile field updates through the `/sync` endpoint. This extension adds support for receiving profile updates for users who are members of rooms the client is subscribed to.
+
+The proposal introduces a new extension called `profiles`. It processes the core extension arguments `enabled`, `rooms`, and `lists`, and adds the following optional arguments:
+
+```json5
+{
+    "enabled": true,           // sticky
+    "lists": ["rooms", "dms"], // sticky
+    "rooms": ["!abcd:example.com"], // sticky
+    "fields": ["displayname", "avatar_url"], // optional filter for specific profile fields
+    "include_history": false   // optional, defaults to false
+}
+```
+
+If `enabled` is `true`, then the sliding sync response MAY include profile updates in the following format:
+
+```json5
+{
+    "users": {
+        "@alice:example.com": {
+            "displayname": "Alice",
+            "avatar_url": "mxc://example.com/abc123",
+            "org.example.language": "en-GB"
+        },
+        "@bob:example.com": {
+            "displayname": null  // Field removal
+        }
+    }
+}
+```
+
+### Behaviour
+
+1. The extension only returns profile updates for users who are members of rooms that the client is subscribed to via either:
+   - Room IDs explicitly listed in the `rooms` argument
+   - Rooms that fall within the sliding windows specified in `lists`
+
+2. The optional `fields` argument allows clients to filter which profile fields they want to receive updates for. If omitted, all profile field updates are included.
+
+3. The optional `include_history` argument controls whether the initial sync includes recent historical profile changes:
+   - If false (default), only current profile states are sent on initial sync
+   - If true, the server MAY include recent profile changes that occurred before the sync
+
+4. On an initial sync:
+   - Profile data MUST only be sent for rooms returned in the sliding sync response
+   - If `include_history` is false, only current profile states are sent
+   - If `include_history` is true, recent profile changes MAY be included
+
+5. When live streaming:
+   - Profile updates MUST be sent as the server receives them
+   - For rooms which initially appear (`initial: true`) due to direct subscriptions or rooms moving into the sliding window, current profile states MUST be included
+   - A null value for a field indicates the field has been removed
+   - Omitted fields should be considered unchanged
+
+### Implementation Notes
+
+- Servers SHOULD implement appropriate batching and rate limiting of profile updates to prevent overwhelming clients
+
+- While this extension provides real-time profile updates, implementations should note:
+  - Network issues could cause missed updates
+  - Clients MAY implement periodic full profile refreshes if they require stronger consistency guarantees
+  - The frequency of such refreshes should be balanced against resources and desired freshness
+
+- Profile updates are typically infrequent compared to other real-time events like typing notifications, so including them in sliding sync is considered efficient
+
+## Potential Issues
+
+1. Large Initial Sync Payload
+   - With `include_history` enabled, the initial sync could be large for rooms with many members
+   - Servers should consider implementing reasonable limits on historical profile data
+
+2. Update Frequency
+   - Some users might update profiles frequently
+   - Implementations should consider rate limiting and batching updates
+
+## Alternatives
+
+1. Separate Profile Sync API
+   - Could provide more granular control over profile syncing
+   - Would increase complexity by requiring another connection
+   - Would duplicate much of sliding sync's room subscription logic
+
+2. Push-based Profile Updates
+   - Could use a separate WebSocket connection for profile updates
+   - Would increase complexity and connection overhead
+   - Would duplicate room subscription logic
+
+## Security Considerations
+
+1. Profile information is considered public data in Matrix
+
+2. The extension respects existing privacy boundaries:
+   - Only returns updates for users in rooms the client can access
+   - Follows the same authentication and authorization as the main sliding sync endpoint
+
+3. Rate limiting helps prevent abuse
+
+## Unstable Prefix
+
+No unstable prefix as Sliding Sync is still in review. To enable this extension, add this to your request JSON:
+
+```json
+{
+    "extensions": {
+        "profiles": {
+            "enabled": true
+        }
+    }
+}
+```
+
+## Dependencies
+
+This MSC builds on:
+- MSC3575 (Sliding Sync), which is not yet accepted into the spec

--- a/proposals/4262-sliding-sync-profiles.md
+++ b/proposals/4262-sliding-sync-profiles.md
@@ -1,6 +1,7 @@
 # MSC4262: Sliding Sync Extension: Profile Updates
 
 This MSC is an extension to [MSC3575](https://github.com/matrix-org/matrix-spec-proposals/pull/3575)
+(and its proposed successor [MSC4186](https://github.com/matrix-org/matrix-spec-proposals/pull/4186))
 which adds support for receiving profile updates via Sliding Sync. It complements
 [MSC4259](https://github.com/matrix-org/matrix-spec-proposals/pull/4259) which handles
 federation-level profile updates.
@@ -132,4 +133,6 @@ request JSON:
 
 This MSC builds on:
 
-- MSC3575 (Sliding Sync), which is not yet accepted into the spec
+- [MSC3575](https://github.com/matrix-org/matrix-spec-proposals/pull/3575) (Sliding Sync) or its
+  proposed successor [MSC4186](https://github.com/matrix-org/matrix-spec-proposals/pull/4186)  
+  (Simplified Sliding Sync), neither of which are yet accepted into the spec

--- a/proposals/4262-sliding-sync-profiles.md
+++ b/proposals/4262-sliding-sync-profiles.md
@@ -134,5 +134,5 @@ request JSON:
 This MSC builds on:
 
 - [MSC3575](https://github.com/matrix-org/matrix-spec-proposals/pull/3575) (Sliding Sync) or its
-  proposed successor [MSC4186](https://github.com/matrix-org/matrix-spec-proposals/pull/4186)  
+  proposed successor [MSC4186](https://github.com/matrix-org/matrix-spec-proposals/pull/4186)
   (Simplified Sliding Sync), neither of which are yet accepted into the spec

--- a/proposals/4262-sliding-sync-profiles.md
+++ b/proposals/4262-sliding-sync-profiles.md
@@ -1,12 +1,18 @@
 # MSC4262: Sliding Sync Extension: Profile Updates
 
-This MSC is an extension to [MSC3575](https://github.com/matrix-org/matrix-spec-proposals/pull/3575) which adds support for receiving profile updates via Sliding Sync. It complements [MSC4259](https://github.com/matrix-org/matrix-spec-proposals/pull/4259) which handles federation-level profile updates.
+This MSC is an extension to [MSC3575](https://github.com/matrix-org/matrix-spec-proposals/pull/3575)
+which adds support for receiving profile updates via Sliding Sync. It complements
+[MSC4259](https://github.com/matrix-org/matrix-spec-proposals/pull/4259) which handles
+federation-level profile updates.
 
 ## Proposal
 
-MSC3575 currently does not include support for receiving profile field updates through the `/sync` endpoint. This extension adds support for receiving profile updates for users who are members of rooms the client is subscribed to.
+MSC3575 currently does not include support for receiving global profile field updates through the
+`/sync` endpoint. This extension adds support for receiving profile updates for users who are
+members of rooms the client is subscribed to.
 
-The proposal introduces a new extension called `profiles`. It processes the core extension arguments `enabled`, `rooms`, and `lists`, and adds the following optional arguments:
+The proposal introduces a new extension called `profiles`. It processes the core extension
+arguments `enabled`, `rooms`, and `lists`, and adds the following optional arguments:
 
 ```json5
 {
@@ -37,13 +43,16 @@ If `enabled` is `true`, then the sliding sync response MAY include profile updat
 
 ### Behaviour
 
-1. The extension only returns profile updates for users who are members of rooms that the client is subscribed to via either:
+1. The extension only returns profile updates for users who are members of rooms that the client is
+   subscribed to via either:
    - Room IDs explicitly listed in the `rooms` argument
    - Rooms that fall within the sliding windows specified in `lists`
 
-2. The optional `fields` argument allows clients to filter which profile fields they want to receive updates for. If omitted, all profile field updates are included.
+2. The optional `fields` argument allows clients to filter which profile fields they want to receive
+   updates for. If omitted, all profile field updates are included.
 
-3. The optional `include_history` argument controls whether the initial sync includes recent historical profile changes:
+3. The optional `include_history` argument controls whether the initial sync includes recent
+   historical profile changes:
    - If false (default), only current profile states are sent on initial sync
    - If true, the server MAY include recent profile changes that occurred before the sync
 
@@ -54,20 +63,23 @@ If `enabled` is `true`, then the sliding sync response MAY include profile updat
 
 5. When live streaming:
    - Profile updates MUST be sent as the server receives them
-   - For rooms which initially appear (`initial: true`) due to direct subscriptions or rooms moving into the sliding window, current profile states MUST be included
+   - For rooms which initially appear (`initial: true`) due to direct subscriptions or rooms moving
+     into the sliding window, current profile states MUST be included
    - A null value for a field indicates the field has been removed
    - Omitted fields should be considered unchanged
 
 ### Implementation Notes
 
-- Servers SHOULD implement appropriate batching and rate limiting of profile updates to prevent overwhelming clients
+- Servers SHOULD implement appropriate batching and rate limiting of profile updates to prevent
+  overwhelming clients
 
 - While this extension provides real-time profile updates, implementations should note:
   - Network issues could cause missed updates
   - Clients MAY implement periodic full profile refreshes if they require stronger consistency guarantees
   - The frequency of such refreshes should be balanced against resources and desired freshness
 
-- Profile updates are typically infrequent compared to other real-time events like typing notifications, so including them in sliding sync is considered efficient
+- Profile updates are typically infrequent compared to other real-time events like typing
+  notifications, so including them in sliding sync is considered efficient
 
 ## Potential Issues
 
@@ -103,7 +115,8 @@ If `enabled` is `true`, then the sliding sync response MAY include profile updat
 
 ## Unstable Prefix
 
-No unstable prefix as Sliding Sync is still in review. To enable this extension, add this to your request JSON:
+No unstable prefix as Sliding Sync is still in review. To enable this extension, add this to your
+request JSON:
 
 ```json
 {
@@ -118,4 +131,5 @@ No unstable prefix as Sliding Sync is still in review. To enable this extension,
 ## Dependencies
 
 This MSC builds on:
+
 - MSC3575 (Sliding Sync), which is not yet accepted into the spec

--- a/proposals/4262-sliding-sync-profiles.md
+++ b/proposals/4262-sliding-sync-profiles.md
@@ -191,14 +191,26 @@ configuration. This might make implementation easier? Needs to be explored.
 ## Unstable Prefix
 
 Before this MSC is accepted, implementations should use
-`org.matrix.msc4262.profiles` as the extension field name, rather than
-`profiles`:
+`org.matrix.msc4262.profiles`, rather than `profiles`, as the extension field
+name in both sliding sync requests:
 
 ```json
 {
     "extensions": {
         "org.matrix.msc4262.profiles": {
             "enabled": true
+        }
+    }
+}
+```
+
+and responses:
+
+```json
+{
+    "extensions": {
+        "org.matrix.msc4262.profiles": {
+            "users": { ... }
         }
     }
 }

--- a/proposals/4262-sliding-sync-profiles.md
+++ b/proposals/4262-sliding-sync-profiles.md
@@ -1,108 +1,179 @@
 # MSC4262: Sliding Sync Extension: Profile Updates
 
-This MSC is an extension to [MSC3575](https://github.com/matrix-org/matrix-spec-proposals/pull/3575)
-(and its proposed successor [MSC4186](https://github.com/matrix-org/matrix-spec-proposals/pull/4186))
-which adds support for receiving profile updates via Sliding Sync. It complements
-[MSC4259](https://github.com/matrix-org/matrix-spec-proposals/pull/4259) which handles
-federation-level profile updates.
+This MSC is an extension to Simplified Sliding Sync (specified by
+[MSC4186](https://github.com/matrix-org/matrix-spec-proposals/pull/4186)). As
+that MSC did not specify the shape of extensions, this MSC assumes the base
+shape from [MSC3575: Sliding
+Sync](https://github.com/matrix-org/matrix-spec-proposals/pull/3575) (the
+predecessor to the ultimately accepted simplified variant).
+
+This MSC adds support for receiving profile updates via Sliding Sync. It
+complements
+[MSC4429](https://github.com/matrix-org/matrix-spec-proposals/pull/4259), which
+adds the same information to legacy sync. And it is related to
+[MSC4259](https://github.com/matrix-org/matrix-spec-proposals/pull/4259) which
+handles federation-level profile updates.
 
 ## Proposal
 
-MSC3575 currently does not include support for receiving global profile field updates through the
-`/sync` endpoint. This extension adds support for receiving profile updates for users who are
-members of rooms the client is subscribed to.
+This extension adds support for receiving profile updates for other users they
+share rooms with.
 
-The proposal introduces a new extension called `profiles`. It processes the core extension
-arguments `enabled`, `rooms`, and `lists`, and adds the following optional arguments:
+The proposal introduces a new extension called `profiles`. It processes the core
+extension arguments `enabled`, `rooms`, and `lists`, and adds the following
+optional arguments:
 
 ```json5
 {
-    "enabled": true,           // sticky
-    "lists": ["rooms", "dms"], // sticky
-    "rooms": ["!abcd:example.com"], // sticky
-    "fields": ["displayname", "avatar_url"], // optional filter for specific profile fields
-    "include_history": false   // optional, defaults to false
+    "enabled": true,
+    "fields": ["displayname", "avatar_url", "m.some_field"], // optional filter for specific profile fields
 }
 ```
 
-If `enabled` is `true`, then the sliding sync response MAY include profile updates in the following format:
+If `enabled` is `true`, then the sliding sync response MAY include profile
+updates in the following format:
 
 ```json5
 {
-    "users": {
-        "@alice:example.com": {
-            "displayname": "Alice",
-            "avatar_url": "mxc://example.com/abc123",
-            "org.example.language": "en-GB"
-        },
-        "@bob:example.com": {
-            "displayname": null  // Field removal
+    // extensions is a top-level field in the response body.
+    "extensions": {
+        "profiles": {
+            "users": {
+                "@alice:example.com": {
+                    // Fields that were newly set, or updated.
+                    "updated": {
+                        "displayname": "Alice",
+                        "avatar_url": "mxc://example.com/abc123",
+                        "org.example.language": "en-GB"
+                    },
+                    // A field has been removed from a user's profile.
+                    "removed": ["com.example.other_field"]
+                },
+                // Client can stop tracking this user (they left all shared rooms).
+                "@bob:remote.example.com": null
+            },
         }
     }
 }
 ```
 
-### Behaviour
+Profile fields that are either newly added to a user's profile or recently
+updated are found under `users-><user_id>->updated`. Likewise, any field IDs that
+are cleared/removed from a user's profile will appear under
+`users-><user_id>->removed`. Omitted fields are considered unchanged.
 
-1. The extension only returns profile updates for users who are members of rooms that the client is
-   subscribed to via either:
-   - Room IDs explicitly listed in the `rooms` argument
-   - Rooms that fall within the sliding windows specified in `lists`
+Only fields specified by the `fields` request parameter will be included in
+these two sections.
 
-2. The optional `fields` argument allows clients to filter which profile fields they want to receive
-   updates for. If omitted, all profile field updates are included.
+These fields must be specified in every sync request.
 
-3. The optional `include_history` argument controls whether the initial sync includes recent
-   historical profile changes:
-   - If false (default), only current profile states are sent on initial sync
-   - If true, the server MAY include recent profile changes that occurred before the sync
+If the value directly underneath a user's ID is `null`
+(`@bob:remote.example.com` in the above example), this is a signal to the client
+that they may stop tracking this user, as that user has left all shared rooms.
 
-4. On an initial sync:
-   - Profile data MUST only be sent for rooms returned in the sliding sync response
-   - If `include_history` is false, only current profile states are sent
-   - If `include_history` is true, recent profile changes MAY be included
+### When are profile updates returned?
 
-5. When live streaming:
-   - Profile updates MUST be sent as the server receives them
-   - For rooms which initially appear (`initial: true`) due to direct subscriptions or rooms moving
-     into the sliding window, current profile states MUST be included
-   - A null value for a field indicates the field has been removed
-   - Omitted fields should be considered unchanged
+An individual sliding sync session (which persists over the lifetime of a
+client's login) contains top-level `rooms` and `lists` parameters. From these,
+the homeserver derives a list of rooms the client wants updates for.
 
-### Implementation Notes
+When a room enters this subset in this connection for the first time, all
+requested `fields` from profiles of users in that room MAY be sent down. This
+gives the client a base set of information for which future field updates can be
+applied on top of. The homeserver MAY omit some fields and profiles if it
+believes that the client has already received them, likewise repeat profiles MAY
+be sent down based on homeserver implementation.
 
-- Servers SHOULD implement appropriate batching and rate limiting of profile updates to prevent
-  overwhelming clients
+Separately, any time a user who shares a room with the syncing user updates a
+field on their profile, that update should be sent down. Even for users whose
+rooms are not part of the room subset. While these profiles may not even be
+rendered on the client yet, this covers the case where a room subset may shrink
+to exclude certain users who then update their profile in the meanwhile. If the
+room subset then grew to cover them again, the client would end up with stale
+data.
 
-- While this extension provides real-time profile updates, implementations should note:
-  - Network issues could cause missed updates
-  - Clients MAY implement periodic full profile refreshes if they require stronger consistency guarantees
-  - The frequency of such refreshes should be balanced against resources and desired freshness
+Finally, if the list of `fields` expands to cover a new field ID, those fields
+should be sent down for all users that are within the current room subset.
+Future incremental updates will then include changes to this field.
 
-- Profile updates are typically infrequent compared to other real-time events like typing
-  notifications, so including them in sliding sync is considered efficient
+Homeservers MUST include updates that the syncing user has made themselves to
+allow a user's other devices to be aware of the changes.
+
+### Lazy-loading user profiles
+
+The above strategy restricts the profiles that are sent down to only those users
+in rooms which are within the sliding window or direct subscriptions. However,
+if a room like Matrix HQ, which has over 6000 users, is part of the that list
+then the homeserver is forced to send down membership information for 6000 users
+in a single response.
+
+Sliding Sync offers the `lazy_members` boolean flag on a per-room basis, which
+when `true` will only send down membership information for a user if:
+
+- the user is one of the `sender`s of a timeline event included in the response
+- membership event state keys in the timeline
+- users in `required_state` member events that are returned
+- heroes(? - not mentioned in the MSC, but seems like Synapse implements it)
+- invite/knock stripped-state users/senders(? - likewise)
+
+Similarly, when `lazy_members` is `true` for a given room, a user's full profile
+will only be included if they meet the above criteria. If a user is in two rooms
+and only one has `lazy_members: true`, the user's full profile should be sent
+down anyways due to being in a room where `lazy_members: false` was set.
+
+Lazy loading does not affect the fact that homeservers MUST include updates that
+the syncing user has made themselves.
+
+### Implementation-specific notes
+
+#### Homeservers
+
+Homeservers should only consider a profile field update "accepted" by a
+client once the client returns with a new `/sync` request with the next `/sync`
+token, NOT just after sending down the profile update. The client may never
+receive response due to network conditions, or a bug in the client
+implementation.
+
+Homeservers are encouraged to maintain a record of which user profile fields
+have been sent down in a given sliding sync connection. That way, as new rooms
+enter the room subset, users who were already in rooms within the room subset
+will not have their full profiles sent down a second time.
+
+#### Clients
+
+Upon receiving a notification, a client may want to show profile information in
+the notification pop-up. Because the user in question may not be part of any of
+the rooms that were included in the current sliding sync connection, or the
+client may not have synced for a while, clients are recommended to request the
+other user's profile directly using [`GET
+/_matrix/client/v3/profile/{userId}/{keyName}`](https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3profileuseridkeyname)
+to build the notification UI, instead of relying on local profile cache.
 
 ## Potential Issues
 
-1. Large Initial Sync Payload
-   - With `include_history` enabled, the initial sync could be large for rooms with many members
-   - Servers should consider implementing reasonable limits on historical profile data
-
-2. Update Frequency
+1. Update Frequency
    - Some users might update profiles frequently
-   - Implementations should consider rate limiting and batching updates
+   - Implementations should consider rate limiting and batching updates (TODO: How?)
+   - A `limit` parameter could be added to prevent too many updates being down sent at once.
 
 ## Alternatives
 
-1. Separate Profile Sync API
-   - Could provide more granular control over profile syncing
-   - Would increase complexity by requiring another connection
-   - Would duplicate much of sliding sync's room subscription logic
+### Only send profile updates for users in rooms that are in the sliding sync room subset
 
-2. Push-based Profile Updates
-   - Could use a separate WebSocket connection for profile updates
-   - Would increase complexity and connection overhead
-   - Would duplicate room subscription logic
+The proposal asks for full profiles of users to only be sent down when the room
+they're in *initially* enters the sliding sync room subset. Profile updates for
+all users that share a room with the syncing user must then be sent down to
+cover any gaps if the room subset shrinks again.
+
+Instead, full profiles of users could be sent down *whenever* a room enters the
+sliding sync window, even if it was there before. There's no real downside to
+this approach; the chosen solution just fits Synapse's implementation better.
+
+### Add a `lazy_loading` boolean to the extension settings
+
+Instead of relying on the per-room lazy-loading configuration in sliding sync
+today, one could add a global `lazy_loading` flag to the profile extensions
+configuration. This might make implementation easier? Needs to be explored.
 
 ## Security Considerations
 
@@ -112,17 +183,16 @@ If `enabled` is `true`, then the sliding sync response MAY include profile updat
    - Only returns updates for users in rooms the client can access
    - Follows the same authentication and authorization as the main sliding sync endpoint
 
-3. Rate limiting helps prevent abuse
-
 ## Unstable Prefix
 
-No unstable prefix as Sliding Sync is still in review. To enable this extension, add this to your
-request JSON:
+Before this MSC is accepted, implementations should use
+`org.matrix.msc4262.profiles` as the extension field name, rather than
+`profiles`:
 
 ```json
 {
     "extensions": {
-        "profiles": {
+        "org.matrix.msc4262.profiles": {
             "enabled": true
         }
     }
@@ -131,8 +201,7 @@ request JSON:
 
 ## Dependencies
 
-This MSC builds on:
+This MSC depends on:
 
-- [MSC3575](https://github.com/matrix-org/matrix-spec-proposals/pull/3575) (Sliding Sync) or its
-  proposed successor [MSC4186](https://github.com/matrix-org/matrix-spec-proposals/pull/4186)
-  (Simplified Sliding Sync), neither of which are yet accepted into the spec
+- [MSC4186](https://github.com/matrix-org/matrix-spec-proposals/pull/4186) (Simplified Sliding Sync, for the endpoint)
+- [MSC3575](https://github.com/matrix-org/matrix-spec-proposals/pull/3575) (Sliding Sync, for the extensions shape)

--- a/proposals/4262-sliding-sync-profiles.md
+++ b/proposals/4262-sliding-sync-profiles.md
@@ -47,7 +47,8 @@ updates in the following format:
                     "updated": {
                         "displayname": "Alice",
                         "avatar_url": "mxc://example.com/abc123",
-                        "org.example.language": "en-GB"
+                        "org.example.language": "en-GB",
+                        "org.example.another_field": null
                     },
                     // Optional. A field has been removed from a user's profile.
                     "removed": ["com.example.other_field"]
@@ -68,14 +69,23 @@ are cleared/removed from a user's profile will appear under
 The `updated` field SHOULD only be present if there are changes to existing
 fields on a user's profile. Otherwise, the field should not be present (i.e. if
 fields were only removed). Likewise, the `removed` field should not be present
-if there were only updated to existing fields (and none were cleared).
+if there were only updates to existing fields (and none were cleared).
 
 Only fields specified by the `fields` request parameter will be included in
 these two sections.
 
-If the value directly underneath a user's ID is `null`
-(`@bob:remote.example.com` in the above example), this is a signal to the client
-that they may stop tracking this user, as that user has left all shared rooms.
+Note that the value of a profile field MAY be `null`, as per the definition of
+[`PUT /_matrix/client/v3/profile/{userId}/{keyName}`](https://spec.matrix.org/v1.19/client-server-api/#put_matrixclientv3profileuseridkeyname):
+
+> Servers MAY reject `null` values. Servers that accept `null` values SHOULD store
+> them rather than treating `null` as a deletion request. Clients that want to
+> delete a field, including its key and value, SHOULD use the DELETE endpoint
+> instead.
+
+Homeservers SHOULD set the value directly underneath a user's ID to `null`
+(`@bob:remote.example.com` in the above example), if the user has left all
+shared rooms. This is a signal to the client that they may stop tracking this
+user.
 
 ### When are profile updates returned?
 

--- a/proposals/4262-sliding-sync-profiles.md
+++ b/proposals/4262-sliding-sync-profiles.md
@@ -26,9 +26,12 @@ optional arguments:
 ```json5
 {
     "enabled": true,
-    "fields": ["displayname", "avatar_url", "m.some_field"], // optional filter for specific profile fields
+    "fields": ["displayname", "avatar_url", "m.some_field"],
 }
 ```
+
+The `fields` parameter is optional. If omitted, *all* profile fields will be in
+scope.
 
 If `enabled` is `true`, then the sliding sync response MAY include profile
 updates in the following format:
@@ -68,9 +71,7 @@ fields were only removed). Likewise, the `removed` field should not be present
 if there were only updated to existing fields (and none were cleared).
 
 Only fields specified by the `fields` request parameter will be included in
-these two sections. `fields` must be specified in every sync request; the
-homeserver does not "remember" the client's requested `fields` from the last
-sync request.
+these two sections.
 
 If the value directly underneath a user's ID is `null`
 (`@bob:remote.example.com` in the above example), this is a signal to the client

--- a/proposals/4262-sliding-sync-profiles.md
+++ b/proposals/4262-sliding-sync-profiles.md
@@ -40,13 +40,13 @@ updates in the following format:
         "profiles": {
             "users": {
                 "@alice:example.com": {
-                    // Fields that were newly set, or updated.
+                    // Optional. Fields that were newly set, or updated.
                     "updated": {
                         "displayname": "Alice",
                         "avatar_url": "mxc://example.com/abc123",
                         "org.example.language": "en-GB"
                     },
-                    // A field has been removed from a user's profile.
+                    // Optional. A field has been removed from a user's profile.
                     "removed": ["com.example.other_field"]
                 },
                 // Client can stop tracking this user (they left all shared rooms).
@@ -62,10 +62,15 @@ updated are found under `users-><user_id>->updated`. Likewise, any field IDs tha
 are cleared/removed from a user's profile will appear under
 `users-><user_id>->removed`. Omitted fields are considered unchanged.
 
-Only fields specified by the `fields` request parameter will be included in
-these two sections.
+The `updated` field SHOULD only be present if there are changes to existing
+fields on a user's profile. Otherwise, the field should not be present (i.e. if
+fields were only removed). Likewise, the `removed` field should not be present
+if there were only updated to existing fields (and none were cleared).
 
-These fields must be specified in every sync request.
+Only fields specified by the `fields` request parameter will be included in
+these two sections. `fields` must be specified in every sync request; the
+homeserver does not "remember" the client's requested `fields` from the last
+sync request.
 
 If the value directly underneath a user's ID is `null`
 (`@bob:remote.example.com` in the above example), this is a signal to the client

--- a/proposals/4262-sliding-sync-profiles.md
+++ b/proposals/4262-sliding-sync-profiles.md
@@ -227,6 +227,24 @@ and responses:
 }
 ```
 
+Before this MSC is merged into a released version of the spec, homeserver
+implementations SHOULD advertise support for this feature to clients by adding
+an entry to the `unstable_features` section of the
+[`/_matrix/client/versions`](https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientversions)
+endpoint with the following content:
+
+```json5
+{
+  // ...
+  "unstable_features": {
+    "org.matrix.msc4262": true
+  }
+}
+```
+
+Clients should interpret the absence of this field, or a value as `false`, as
+the homeserver NOT supporting the feature.
+
 ## Dependencies
 
 This MSC depends on:


### PR DESCRIPTION
[Rendered](https://github.com/tcpipuk/matrix-spec-proposals/blob/patch-2/proposals/4262-sliding-sync-profiles.md)

Signed-off-by: Tom Foster <tom@tcpip.uk>

---

Known Implementations:
- Clients:
  -  Element X
- Servers:
  - Synapse