### PR TITLE
Clarify the meaning of a read_events action without a state_key

### DIFF
--- a/proposals/2762-widget-event-receiving.md
+++ b/proposals/2762-widget-event-receiving.md
@@ -285,6 +285,9 @@ API action:
 }
 ```
 
+When no `state_key` is present, the client will respond with message-like events (i.e. non-state
+events) matching the event type.
+
 When a `state_key` is present, the client will respond with state events matching that state key. If
 `state_key` is instead a boolean `true`, the client will respond with state events of the given type
 with any state key.


### PR DESCRIPTION
This is **not an MSC** but rather an update to MSC2762. I'm using this PR to give our team a chance to discuss the update.

Currently MSC2762 is ambiguous as to whether the absence of a `state_key` in a `read_events` action means that both state events and message-like events should be returned, or just message-like events. We should clarify this behavior, and I for one find it difficult to imagine a real use case that would benefit from the ability to read both state events and message-like events of a single event type as part of the same request, so I propose we limit the response to just message-like events in this case. This aligns the behavior with what Element Web did prior to the [introduction of the `update_state` action](https://github.com/matrix-org/matrix-spec-proposals/pull/4237).