### PR TITLE
MSC4303: Disallowing non-compliant user IDs in rooms

### DIFF
--- a/proposals/4303-slightly-strict-user-id-grammar-in-rooms.md
+++ b/proposals/4303-slightly-strict-user-id-grammar-in-rooms.md
@@ -1,0 +1,62 @@
+# MSC4303: Disallowing non-compliant user IDs in rooms
+
+The specification presently allows for a "historical" grammar for user IDs, described
+[here](https://spec.matrix.org/v1.15/appendices/#historical-user-ids). The use of this historical
+character set has allowed for "weird" and generally not-great user IDs to appear in the wild,
+causing a variety of issues for software projects.
+
+The historical grammar can be split into two classes:
+
+1. printable ASCII (U+0021 to U+007E), aka. historical-but-compliant
+2. arbitrary unicode, aka. non-compliant
+
+This proposal uses a future room version to prohibit the second class, while still allowing the first.
+Users with non-ASCII user IDs will not be able to join or participating in those room versions.
+
+## Proposal
+
+In a future room version, the historical-but-compliant grammar for user IDs is strictly enforced on
+all places a user ID can appear in an event.
+
+* The `sender` of all events.
+* The `state_key` of `m.room.member` events.
+* The `join_authorised_via_users_server` field in `m.room.member` events.
+* Keys of the `users` object in `m.room.power_levels`.
+
+User IDs in the new room version must only consist of ASCII characters between U+0021 and U+007E.
+
+By making this change in a room version, non-compliant user IDs are slowly removed from the public
+federation. Several rooms will naturally upgrade to a room version which includes this MSC's change
+after it becomes available in servers, and eventually the specification will update the
+[recommended default room version](https://spec.matrix.org/v1.15/rooms/#complete-list-of-room-versions)
+to include this MSC's change as well to affect new room creation.
+
+In short, this MSC starts a multi-year process to formally phase out non-compliant user IDs as new
+(and existing through upgrades) rooms use a room version which bans such user IDs.
+
+## Potential issues
+
+Unlike [MSC4044](https://github.com/matrix-org/matrix-spec-proposals/pull/4044), this MSC does
+not define all historical user IDs as non-compliant. Therefore, real users who registered historical
+user IDs should not be affected. Only accounts registered by modified servers will be prohibited
+from participating in new rooms.
+
+## Alternatives
+
+[MSC4044](https://github.com/matrix-org/matrix-spec-proposals/pull/4044)
+
+We don't do this, or hope that pseudo IDs fix the problem.
+
+## Security considerations
+
+This MSC improves the security posture of the protocol by reducing the likelihood of strange characters
+appearing in user IDs.
+
+## Unstable prefix
+
+This MSC can be implemented in a room version identified as `fi.mau.msc4303`. A future MSC will
+be required to incorporate this MSC into a stable room version.
+
+## Dependencies
+
+None.


### PR DESCRIPTION
[Rendered](https://github.com/matrix-org/matrix-spec-proposals/blob/tulir/slighty-strict-user-id-grammar/proposals/4303-slightly-strict-user-id-grammar-in-rooms.md)