### PR TITLE
Editorial: Fix dates & unstable prefix of MSC4291

### DIFF
--- a/proposals/4289-privilege-creators.md
+++ b/proposals/4289-privilege-creators.md
@@ -175,11 +175,11 @@ confusion and technical debt, given clients are already making breaking changes 
 
 ### Alternatives
 
-(Embargoed until Aug 11, 2025)
+(Embargoed until Aug 14, 2025)
 
 ### Security Considerations
 
-(Embargoed until Aug 11, 2025)
+(Embargoed until Aug 14, 2025)
 
 ### Credits
 
@@ -187,7 +187,7 @@ Thanks to Timo Kösters for initiating discussion around this MSC.
 
 ### Unstable prefix
 
-During development this room version is referred to as `org.matrix.hydra.11` alongside MSC4291 and MSC4297 (embargoed until Aug 11, 2025).
+During development this room version is referred to as `org.matrix.hydra.11` alongside MSC4291 and MSC4297 (embargoed until Aug 14, 2025).
 
 ### Dependencies
 

--- a/proposals/4291-room-ids-as-hashes.md
+++ b/proposals/4291-room-ids-as-hashes.md
@@ -170,6 +170,10 @@ room). This has always been implied due to the federation endpoint `/event/{even
 makes the data model rely on global uniqueness. See [MSC2848](https://github.com/matrix-org/matrix-spec-proposals/pull/2848)
 for more discussion.
 
+### Unstable prefix
+
+During development this room version is referred to as `org.matrix.hydra.11` alongside MSC4291 and MSC4297 (embargoed until Aug 14, 2025).
+
 ### Dependencies
 
 This MSC has no dependencies.


### PR DESCRIPTION
Process note: This isn't an MSC, but is used to bring visibility to the changes.