### PR TITLE
Fix links and remove linebreaks in checklist

### DIFF
--- a/MSC_CHECKLIST.md
+++ b/MSC_CHECKLIST.md
@@ -11,8 +11,7 @@ MSC authors, feel free to ask in a thread on your PR or in the
 [#matrix-spec:matrix.org](https://matrix.to/#/#matrix-spec:matrix.org) room for
 clarification of any of these points.
 
-- [ ] Are [appropriate implementation(s)](https://spec.matrix.org/proposals/#implementing-a-proposal)
-  specified in the MSC’s PR description?
+- [ ] Are [appropriate implementation(s)](https://spec.matrix.org/proposals/#implementing-a-proposal) specified in the MSC’s PR description?
 - [ ] Are all MSCs that this MSC depends on already accepted?
 - [ ] For each new endpoint that is introduced:
   - [ ] Have authentication requirements been specified?
@@ -22,31 +21,23 @@ clarification of any of these points.
     - [ ] Does each error case have a specified `errcode` (e.g. `M_FORBIDDEN`) and HTTP status code?
       - [ ] If a new `errcode` is introduced, is it clear that it is new?
 - [ ] Will the MSC require a new room version, and if so, has that been made clear?
-  - [ ] Is the reason for a new room version clearly stated? For example,
-          modifying the set of redacted fields changes how event IDs are calculated,
-          thus requiring a new room version.
+  - [ ] Is the reason for a new room version clearly stated? For example, modifying the set of redacted fields changes how event IDs are calculated, thus requiring a new room version.
 - [ ] Are backwards-compatibility concerns appropriately addressed?
 - [ ] Are the [endpoint conventions](https://spec.matrix.org/latest/appendices/#conventions-for-matrix-apis) honoured?
   - [ ] Do HTTP endpoints `use_underscores_like_this`?
   - [ ] Will the endpoint return unbounded data? If so, has pagination been considered?
-  - [ ] If the endpoint utilises pagination, is it consistent with
-    [the appendices](https://spec.matrix.org/v1.8/appendices/#pagination)?
-- [ ] An introduction exists and clearly outlines the problem being solved.
-      Ideally, the first paragraph should be understandable by a non-technical audience.
+  - [ ] If the endpoint utilises pagination, is it consistent with [the appendices](https://spec.matrix.org/v1.8/appendices/#pagination)?
+- [ ] An introduction exists and clearly outlines the problem being solved. Ideally, the first paragraph should be understandable by a non-technical audience.
 - [ ] All outstanding threads are resolved
   - [ ] All feedback is incorporated into the proposal text itself, either as a fix or noted as an alternative
-- [ ] While the exact sections do not need to be present,
-  the details implied by the proposal template are covered. Namely:
+- [ ] While the exact sections do not need to be present, the details implied by the proposal template are covered. Namely:
   - [ ] Introduction
   - [ ] Proposal text
   - [ ] Potential issues
   - [ ] Alternatives
   - [ ] Dependencies
 - [ ] Stable identifiers are used throughout the proposal, except for the unstable prefix section
-  - [ ] Unstable prefixes [consider](/README.md#unstable-prefixes) the awkward accepted-but-not-merged state
+  - [ ] Unstable prefixes [consider](https://github.com/matrix-org/matrix-spec-proposals/blob/main/README.md#unstable-prefixes) the awkward accepted-but-not-merged state
   - [ ] Chosen unstable prefixes do not pollute any global namespace (use “org.matrix.mscXXXX”, not “org.matrix”).
-- [ ] Changes have applicable [Sign Off](/CONTRIBUTING.md#sign-off) from all authors/editors/contributors
-- [ ] There is a dedicated "Security Considerations" section which detail
-  any possible attacks/vulnerabilities this proposal may introduce, even if this is "None.".
-  See [RFC3552](https://datatracker.ietf.org/doc/html/rfc3552) for things to think about,
-  but in particular pay attention to the [OWASP Top Ten](https://owasp.org/www-project-top-ten/).
+- [ ] Changes have applicable [Sign Off](https://github.com/matrix-org/matrix-spec-proposals/blob/main/CONTRIBUTING.md#sign-off) from all authors/editors/contributors
+- [ ] There is a dedicated "Security Considerations" section which detail any possible attacks/vulnerabilities this proposal may introduce, even if this is "None.". See [RFC3552](https://datatracker.ietf.org/doc/html/rfc3552) for things to think about, but in particular pay attention to the [OWASP Top Ten](https://owasp.org/www-project-top-ten/).


### PR DESCRIPTION
Both changes are needed to make it easy to copy the checklist into a comment on a MSC, because GitHub uses hard linebreaks in comments and will not translate absolute paths into URLs pointing at the repo files.