### PR TITLE
Clarify room version requirements on MSC3381

### DIFF
--- a/proposals/3381-polls.md
+++ b/proposals/3381-polls.md
@@ -373,9 +373,11 @@ If a client/user wishes to make a poll statically visible, they should check out
 
 Notifications support for polls have been moved to [MSC3930](https://github.com/matrix-org/matrix-spec-proposals/pull/3930).
 
-Normally extensible events would only be permitted in a specific room version, however as a known-lossy chat
-feature, this proposal's events are permitted in any room version. The stable event types should only be sent
-in a room version which supports extensible events, however.
+Normally extensible events would only be permitted in a specific room version. However, unlike other proposals
+related to extensible events, this proposal's events don't replace any existing events in the spec. Additionally,
+the only extensible events component this proposal depends on is `m.text` which has already entered the spec via
+[MSC3765](https://github.com/matrix-org/matrix-spec-proposals/pull/3765) in version 1.15. Therefore, this proposal's
+events are permitted in any room version.
 
 ## Unstable prefix
 
@@ -453,15 +455,3 @@ Examples of unstable events are:
   }
 }
 ```
-
-### Implementation considerations
-
-Client authors should note that as a feature using the Extensible Events system,
-usage of the *stable* event types in regular room versions is not permitted. As
-of writing (December 2023), Extensible Events does not have a *stable* room version
-which supports such events, therefore meaning that clients will have to use the
-*unstable* event types if they intend to support polls in existing room versions.
-
-When Extensible Events as a system is released in a dedicated room version, clients
-will be able to use the stable event types there. The unstable event types should
-not be used in that dedicated room version.


### PR DESCRIPTION
I believe #3381 is erroneously blocked on the extensible events system and its room version requirements. Polls don't exist in the current spec. Poll events, therefore, cannot conflict with any other events in existing room versions. Additionally, the only extensible events building block that polls depend on is `m.text`. This has already entered the spec in v1.15 via #3765, however.

Process note: MSCs can receive clarification changes post-FCP, but anything materially different requires a new MSC. I believe this qualifies as clarification because the room version restriction for polls does not appear to have any practical uses and arbitrarily prevents us from adding them into the spec.