### PR TITLE
MSC4439: Encryption key URIs in `/.well-known/matrix/support`

### DIFF
--- a/proposals/4439-support-contact-encryption.md
+++ b/proposals/4439-support-contact-encryption.md
@@ -48,7 +48,11 @@ or mandate out-of-band channels, which this MSC accommodates.
 
 Sensitive information may simply be encrypted to the key already listed in a site's security.txt file, however, at
 larger organizations this does not provide the same per-contact granularity (and may not even reference someone
-responsible for hosting the Matrix homeserver at all).
+responsible for hosting the Matrix homeserver at all). A homeserver is unlikely to be the only service running on a
+domain. Especially for larger organizations, where the single key that security.txt provides may not actually represent
+anyone responsible for the Matrix homeserver itself. This is a tool to aid in discovery alongside WKD or key servers.
+
+Additionally, this helps obtain per-contact granularity in contrast to just one "this is our security team's key."
 
 ## Unstable prefix
 

--- a/proposals/4439-support-contact-encryption.md
+++ b/proposals/4439-support-contact-encryption.md
@@ -46,6 +46,10 @@ None identified.
 Sensitive communications may instead be conducted over Matrix, where E2EE is native. However, some researchers prefer
 or mandate out-of-band channels, which this MSC accommodates.
 
+Sensitive information may simply be encrypted to the key already listed in a site's security.txt file, however, at
+larger organizations this does not provide the same per-contact granularity (and may not even reference someone
+responsible for hosting the Matrix homeserver at all).
+
 ## Unstable prefix
 
 While this proposal is unstable, `pgp_key` should be referred to as `dev.zirco.msc4439.pgp_key`.

--- a/proposals/4439-support-contact-encryption.md
+++ b/proposals/4439-support-contact-encryption.md
@@ -12,9 +12,12 @@ other insecure channels.
 ## Proposal
 
 A new optional property `pgp_key` (unstable prefix: `dev.zirco.msc4439.pgp_key`) is added to the [`Contact`]
-response from [`/.well-known/matrix/support`]. This field indicates a PGP key that should be used for encrypted communication to that particular contact.
+response from [`/.well-known/matrix/support`]. This field indicates a PGP key that should be used for encrypted
+communication to that particular contact.
 
-The value of this field MUST be a URI pointing to a location where the key can be retrieved. Raw key material MUST NOT appear as the value of this field. As with [RFC9116], it is always the responsibility of the sender to ensure they trust the key provided.
+The value of this field MUST be a URI pointing to a location where the key can be retrieved. Raw key material MUST
+NOT appear as the value of this field. As with [RFC9116], it is always the responsibility of the sender to ensure they
+trust the key provided.
 
 Example of an OpenPGP key available from a web URI:
 
@@ -51,5 +54,4 @@ While this proposal is unstable, `pgp_key` should be referred to as `dev.zirco.m
   [`email_address`]: https://spec.matrix.org/unstable/client-server-api/#getwell-knownmatrixsupport_response-200_contact
   [`Contact`]: https://spec.matrix.org/unstable/client-server-api/#getwell-knownmatrixsupport_response-200_contact
   [RFC9116]: https://www.rfc-editor.org/info/rfc9116
-  [RFC7230]: https://www.rfc-editor.org/info/rfc7230
   [RFC7929]: https://www.rfc-editor.org/info/rfc7929

--- a/proposals/4439-support-contact-encryption.md
+++ b/proposals/4439-support-contact-encryption.md
@@ -6,16 +6,16 @@ as `security.txt`\) serves a similar purpose and defines an `Encryption` field (
 advertise a key URI for encrypted communication with security researchers.
 
 This proposal adds a similar `pgp_key` field to the [`Contact`] entry on [`/.well-known/matrix/support`], enabling
-homeserver operators to indicate a key that senders should use when communicating sensitive information over email or
+homeserver operators to indicate a key that senders may use when communicating sensitive information over email or
 other insecure channels.
 
 ## Proposal
 
 A new optional property `pgp_key` (unstable prefix: `dev.zirco.msc4439.pgp_key`) is added to the [`Contact`]
-response from [`/.well-known/matrix/support`]. This field indicates a PGP key that should be used for encrypted
-communication to that particular contact.
+response from [`/.well-known/matrix/support`]. This field indicates a PGP key that may be used for encrypted
+communication to that particular contact. If the field is used, the `email_address` field SHOULD also be present.
 
-The value of this field MUST be a URI pointing to a location where the key can be retrieved. Raw key material MUST
+The value of this field MUST be a URI pointing to a location where the key may be retrieved. Raw key material MUST
 NOT appear as the value of this field. As with [RFC9116], it is always the responsibility of the sender to ensure they
 trust the key provided.
 

--- a/proposals/4439-support-contact-encryption.md
+++ b/proposals/4439-support-contact-encryption.md
@@ -1,0 +1,55 @@
+# MSC4439: Encryption key URIs in `/.well-known/matrix/support`
+
+The [`/.well-known/matrix/support`] endpoint provides an [`email_address`] property for reaching server contacts,
+including those intended for sensitive security disclosures (the `m.role.security` role). [RFC9116] \(commonly known
+as `security.txt`\) serves a similar purpose and defines an `Encryption` field (&sect;2.5.4) allowing operators to
+advertise a key URI for encrypted communication with security researchers.
+
+This proposal adds a similar `pgp_key` field to the [`Contact`] entry on [`/.well-known/matrix/support`], enabling
+homeserver operators to indicate a key that senders should use when communicating sensitive information over email or
+other insecure channels.
+
+## Proposal
+
+A new optional property `pgp_key` (unstable prefix: `dev.zirco.msc4439.pgp_key`) is added to the [`Contact`]
+response from [`/.well-known/matrix/support`]. This field indicates a PGP key that should be used for encrypted communication to that particular contact.
+
+The value of this field MUST be a URI pointing to a location where the key can be retrieved. Raw key material MUST NOT appear as the value of this field. As with [RFC9116], it is always the responsibility of the sender to ensure they trust the key provided.
+
+Example of an OpenPGP key available from a web URI:
+
+```
+{
+    "contacts": [
+        {
+            "email_address": "logan@zirco.dev",
+            "pgp_key": "https://zirco.dev/pgp/logn.pub",
+            "role": "m.role.admin"
+        }
+    ]
+}
+```
+
+Other URI schemes other than `https` may also be used, common examples include, but are not limited to:
+- `openpgp4fpr:67FAAA655DBD691E7957E0951594E544D8F8F21E` (key fingerprint)
+- `dns:HASH._openpgpkey.zirco.dev?type=OPENPGPKEY` (`OPENPGPKEY` DNS record) ([RFC7929])
+
+## Potential issues
+
+None identified.
+
+## Alternatives
+
+Sensitive communications may instead be conducted over Matrix, where E2EE is native. However, some researchers prefer
+or mandate out-of-band channels, which this MSC accommodates.
+
+## Unstable prefix
+
+While this proposal is unstable, `pgp_key` should be referred to as `dev.zirco.msc4439.pgp_key`.
+
+  [`/.well-known/matrix/support`]: https://spec.matrix.org/unstable/client-server-api/#getwell-knownmatrixsupport
+  [`email_address`]: https://spec.matrix.org/unstable/client-server-api/#getwell-knownmatrixsupport_response-200_contact
+  [`Contact`]: https://spec.matrix.org/unstable/client-server-api/#getwell-knownmatrixsupport_response-200_contact
+  [RFC9116]: https://www.rfc-editor.org/info/rfc9116
+  [RFC7230]: https://www.rfc-editor.org/info/rfc7230
+  [RFC7929]: https://www.rfc-editor.org/info/rfc7929

--- a/proposals/4439-support-contact-encryption.md
+++ b/proposals/4439-support-contact-encryption.md
@@ -16,7 +16,8 @@ response from [`/.well-known/matrix/support`]. This field indicates a PGP key th
 communication to that particular contact. If the field is used, the `email_address` field SHOULD also be present.
 
 The value of this field MUST be a URI pointing to a location where the key may be retrieved. Raw key material MUST
-NOT appear as the value of this field. As with [RFC9116], it is always the responsibility of the sender to ensure they
+NOT appear as the value of this field. If a key fingerprint is to be used as this field, it MUST be prefixed with
+the `openpgp4fpr:` URI scheme. As with [RFC9116], it is always the responsibility of the sender to ensure they
 trust the key provided.
 
 Example of an OpenPGP key available from a web URI:

--- a/proposals/4439-support-contact-encryption.md
+++ b/proposals/4439-support-contact-encryption.md
@@ -16,9 +16,9 @@ response from [`/.well-known/matrix/support`]. This field indicates a PGP key th
 communication to that particular contact. If the field is used, the `email_address` field SHOULD also be present.
 
 The value of this field MUST be a URI pointing to a location where the key may be retrieved. Raw key material MUST
-NOT appear as the value of this field. If a key fingerprint is to be used as this field, it MUST be prefixed with
-the `openpgp4fpr:` URI scheme. As with [RFC 9116], it is always the responsibility of the sender to ensure they
-trust the key provided.
+NOT appear as the value of this field. If this field indicates a web URI, then it MUST begin with `https://`. If a
+key fingerprint is to be used as this field, it MUST begin with the  `openpgp4fpr:` URI scheme. As with [RFC9116], it
+is always the responsibility of the sender to ensure they trust the key provided.
 
 Example of an OpenPGP key available from a web URI:
 
@@ -64,3 +64,4 @@ While this proposal is unstable, `pgp_key` should be referred to as `dev.zirco.m
   [`Contact`]: https://spec.matrix.org/unstable/client-server-api/#getwell-knownmatrixsupport_response-200_contact
   [RFC 9116]: https://www.rfc-editor.org/info/rfc9116
   [RFC 7929]: https://www.rfc-editor.org/info/rfc7929
+

--- a/proposals/4439-support-contact-encryption.md
+++ b/proposals/4439-support-contact-encryption.md
@@ -1,7 +1,7 @@
 # MSC4439: Encryption key URIs in `/.well-known/matrix/support`
 
 The [`/.well-known/matrix/support`] endpoint provides an [`email_address`] property for reaching server contacts,
-including those intended for sensitive security disclosures (the `m.role.security` role). [RFC9116] \(commonly known
+including those intended for sensitive security disclosures (the `m.role.security` role). [RFC 9116] \(commonly known
 as `security.txt`\) serves a similar purpose and defines an `Encryption` field (&sect;2.5.4) allowing operators to
 advertise a key URI for encrypted communication with security researchers.
 
@@ -17,7 +17,7 @@ communication to that particular contact. If the field is used, the `email_addre
 
 The value of this field MUST be a URI pointing to a location where the key may be retrieved. Raw key material MUST
 NOT appear as the value of this field. If a key fingerprint is to be used as this field, it MUST be prefixed with
-the `openpgp4fpr:` URI scheme. As with [RFC9116], it is always the responsibility of the sender to ensure they
+the `openpgp4fpr:` URI scheme. As with [RFC 9116], it is always the responsibility of the sender to ensure they
 trust the key provided.
 
 Example of an OpenPGP key available from a web URI:
@@ -36,7 +36,7 @@ Example of an OpenPGP key available from a web URI:
 
 Other URI schemes other than `https` may also be used, common examples include, but are not limited to:
 - `openpgp4fpr:67FAAA655DBD691E7957E0951594E544D8F8F21E` (key fingerprint)
-- `dns:HASH._openpgpkey.zirco.dev?type=OPENPGPKEY` (`OPENPGPKEY` DNS record) ([RFC7929])
+- `dns:HASH._openpgpkey.zirco.dev?type=OPENPGPKEY` (`OPENPGPKEY` DNS record) ([RFC 7929])
 
 ## Potential issues
 
@@ -62,5 +62,5 @@ While this proposal is unstable, `pgp_key` should be referred to as `dev.zirco.m
   [`/.well-known/matrix/support`]: https://spec.matrix.org/unstable/client-server-api/#getwell-knownmatrixsupport
   [`email_address`]: https://spec.matrix.org/unstable/client-server-api/#getwell-knownmatrixsupport_response-200_contact
   [`Contact`]: https://spec.matrix.org/unstable/client-server-api/#getwell-knownmatrixsupport_response-200_contact
-  [RFC9116]: https://www.rfc-editor.org/info/rfc9116
-  [RFC7929]: https://www.rfc-editor.org/info/rfc7929
+  [RFC 9116]: https://www.rfc-editor.org/info/rfc9116
+  [RFC 7929]: https://www.rfc-editor.org/info/rfc7929

--- a/proposals/4439-support-contact-encryption.md
+++ b/proposals/4439-support-contact-encryption.md
@@ -55,6 +55,20 @@ anyone responsible for the Matrix homeserver itself. This is a tool to aid in di
 
 Additionally, this helps obtain per-contact granularity in contrast to just one "this is our security team's key."
 
+## Security considerations
+
+Alongside [RFC 9116](https://datatracker.ietf.org/doc/html/rfc9116#name-security-considerations), this proposal comes
+alongside the following security considerations, most of which being true for the rest of the fields in `support`:
+
+* The `.well-known/matrix/support` file could be compromised by an attacker. The file is not currently signed by the
+  homeserver, and it must be trusted as it is. It could be possible to add a signature in the future, similar to
+  `security.txt`.
+* The information contained within the file could be stale and out of date. It is the responsibility of a homeserver's
+  operator to keep the information current.
+* Control by other users or departments. In larger enterprise or multi-user environments, an unauthorized user with
+  access could edit or otherwise control the support record to change the listed PGP key. The same is true for all other
+  well-known files, however.
+
 ## Unstable prefix
 
 While this proposal is unstable, `pgp_key` should be referred to as `dev.zirco.msc4439.pgp_key`.


### PR DESCRIPTION
[Rendered](https://github.com/thetayloredman/matrix-spec-proposals/blob/msc4439/proposals/4439-support-contact-encryption.md)

Implementations:
* Server (publishing):
  * MDAD: https://github.com/spantaleev/matrix-docker-ansible-deploy/pull/5090
  * [Continuwuity](https://forgejo.ellis.link/continuwuation/continuwuity/pulls/1609)
  * [Tuwunel](https://github.com/matrix-construct/tuwunel/commit/eaf1b93201f3f97513d16815f54043d93e021e38)
  * Example servers using this MSC:
    * `openpgp4fpr:` URI: https://electrologic.org/.well-known/matrix/support
    * `https` URI: https://zirco.dev/.well-known/matrix/support
* Client (using):
  * Ruma: https://github.com/ruma/ruma/pull/2446
  * `go-msc1929`: https://github.com/etkecc/go-msc1929/pull/1
  * [Connectivity Tester](https://github.com/MTRNord/matrix-connection-tester-ui/releases/tag/v0.5.1)
  * Any other tool which displays `.well-known/matrix/support` fields raw

Signed-Off-By: Logan Devine <logan@zirco.dev>