### PR TITLE
MSC4458: Handling incoming JSON in the server-server API

### DIFF
--- a/proposals/4458-handling-received-json.md
+++ b/proposals/4458-handling-received-json.md
@@ -71,6 +71,34 @@ clarifications.
    Implementations are free to implement this requirement by dropping one or
    other duplicate, or by rejecting the JSON as a whole.
 
+   > ### Justification
+   >
+   > The previous paragraph merits some explanation as to its safety.
+   >
+   > Duplicate keys can only arise when the sending server is buggy or
+   > malicious. There are two possibilities:
+   >
+   >  * Having dropped one or both of the duplicates, we find the signature
+   >    matches. We now have a regular event or request containing valid JSON; in
+   >    the case of an event, the deduplicated version becomes our
+   >    authoritative reference.
+   >
+   >  * Having dropped one or both of the duplicates, the signature does not
+   >    match. We reject the request or event. In the case of an event which
+   >    other servers accept via the previous possibility, we may end up later
+   >    requesting a copy of that event from an honest server — in which case,
+   >    we will receive a deduplicated copy that everyone in the room can agree
+   >    on.
+   >
+   > In either case, everyone in the room except the originating server ends up
+   > coming to the same eventual conclusion about the room DAG. The originating
+   > server may have a different idea of the room DAG, but that is the expected
+   > fate of a buggy server implementation.
+   >
+   > Note also that neither possibility allows the sending server to do
+   > anything that they wouldn't already be able to do by sending well-formed
+   > JSON without duplicates.
+
    Assuming that the internal data structures mentioned above only allow one
    value per key, no action will be needed by homeservers to comply with this
    requirement, as duplicate keys will be dropped automatically.

--- a/proposals/4458-handling-received-json.md
+++ b/proposals/4458-handling-received-json.md
@@ -401,3 +401,14 @@ N/A
 ## Dependencies
 
 None
+
+## Appendix: test vectors for Canonical JSON
+
+The existing spec contains a number of
+[examples](https://spec.matrix.org/v1.19/appendices/#examples) of the Canonical
+JSON representation of a number of JSON objects. This MSC is accompanied by an
+extended set of test vectors which come as corrolaries of the existing rules,
+or the clarifications set out above.
+
+These test cases are at
+https://github.com/matrix-org/matrix-spec-proposals/tree/rav/proposal/json_handling_clarifications/proposals/data/4458.

--- a/proposals/4458-handling-received-json.md
+++ b/proposals/4458-handling-received-json.md
@@ -307,7 +307,7 @@ Such an change remains under consideration, but is left for a future MSC.
    duplicate. A split-brain *can* occur between A and the rest of the room, but
    that is acceptable because A is buggy/malicious. (There are plenty of ways
    for a server to split-brain itself from the rest of the room via
-   non-conformant behaviour: poor JSON implentation is not special in this
+   non-conformant behaviour: poor JSON implementation is not special in this
    regard).
 
 ## Unstable prefix

--- a/proposals/4458-handling-received-json.md
+++ b/proposals/4458-handling-received-json.md
@@ -1,0 +1,293 @@
+# MSC4458: Handling incoming JSON in the server-server API
+
+The structure of Matrix rooms, and the security of the server-server API,
+relies on the calculation and checking of signatures and hashes of data
+structures. Examples include:
+
+ * Server-server API requests are
+   [authenticated](https://spec.matrix.org/v1.17/server-server-api/#request-authentication)
+   by a signature on a data structure containing the details of the request.
+
+ * Room events must be
+   [signed](https://spec.matrix.org/v1.17/server-server-api/#signing-events) by
+   the homeserver that created them (and, in the case of invite events, by the
+   target of the invite), to guard against impersonation.
+
+ * [Event IDs](https://spec.matrix.org/v1.17/rooms/v12/#event-ids) are hashes of
+   events, to guard against equivocation (i.e. an attacker sending different
+   event contents to different recipients, claiming that they fit in the same
+   place in room history).
+
+ * Room events also include a [content
+   hash](https://spec.matrix.org/v1.17/server-server-api/#calculating-the-content-hash-for-an-event),
+   to guard against tampering of the `contents` (which are not directly
+   protected by the signature or Event ID).
+
+All of these processes rely on encoding the data structure in question as
+[Canonical JSON](https://spec.matrix.org/v1.17/appendices/#canonical-json), and
+feeding the bytes thus obtained into the relevant hashing or signing algorithm.
+
+However, the specification today is not sufficiently clear on how exactly
+Canonical JSON should be used. This MSC seeks to provide the necessary
+clarifications.
+
+## Proposal
+
+1. When receiving JSON over the server-server API (either in a request or
+   response body), server implementations MUST first deserialize the incoming
+   JSON into internal data structures. These data structures must be able to
+   fully represent the data types permissible in Canonical JSON:
+     * strings
+     * numbers (or at least, integers in the range `[-(2**53)+1, (2**53)-1]`)
+     * objects
+     * arrays
+     * `true`, `false`, `null`.
+
+   The original JSON MUST then be discarded, and all future operations must be
+   based on the deserialized structures. This includes hashing and signature
+   checking, which must be done be encoding the deserialized structures as
+   Canonical JSON.
+
+   In particular: it is **not** sufficient to construct the Canonical JSON by
+   modifying the unparsed JSON data, since this brings the risk of inconsistent
+   parsing when the JSON is later parsed. Further discussion of the potential
+   problems can be found in the [Alternatives](#altenatives) below.
+
+2. Implementations MUST guard against duplicate keys in the incoming JSON, and
+   ensure that duplicates are dropped before encoding to Canonical JSON. (In
+   JSON, a "duplicate key" refers to a JSON object which contains two or more
+   entries using the same key; for example: `{"a": 1, "a": 2}`.)
+
+   Implementations are free to implement this requirement by dropping one or
+   other duplicate, or by rejecting the JSON as a whole.
+
+   Assuming that the internal data structures mentioned above only allow one
+   value per key, no action will be needed by homeservers to comply with this
+   requirement, as duplicate keys will be dropped automatically.
+
+   To be explicit: Canonical JSON encodings MUST NOT contain duplicate keys.
+
+3. A clarification to the handling of the [UTF-16
+   surrogates](https://www.unicode.org/faq/utf_bom#utf16-2) `U+D800`-`U+DFFF`.
+   It is possible that implementations will encounter these codepoints in
+   incoming JSON (possibly, though not necessarily, represented with a `\uXXXX`
+   escape). For example, the JSON `{"emoji": "\ud83d\ude00"}` contains one possible
+   representation of the smiley face, 😀.
+
+   There is no way to legally express the UTF-16 surrogates in Canonical JSON,
+   since Canonical JSON forbids the use of `\uXXXX` escapes other than for
+   some of the C0 control characters, and Canonical JSON is defined to use
+   the UTF-8 encoding (which
+   [forbids](https://www.unicode.org/faq/utf_bom#utf8-4) encoding of the
+   surrogates).
+
+   To be explicit, then: Canonical JSON MUST NOT encode the UTF-16
+   surrogates.
+
+   Valid surrogate pairs SHOULD be decoded to their Unicode code point on
+   parsing, and then encoded as a 4-byte UTF-8 sequence when encoding as
+   Canonical JSON. JSON containing unpaired surrogates MUST be rejected
+   (either on parsing, or when attempting to encode as Canonical JSON).
+
+## Potential issues
+
+TODO
+
+## Alternatives
+
+A number of alternative approaches have been proposed, and are discussed below.
+
+### Require servers to transmit Canonical JSON on the wire
+
+One approach would be to mandate that federation request bodies be serialized
+as Canonical JSON. Doing so could bring performance benefits: the signature on
+an incoming federation request could be checked much more efficiently than
+today.
+
+The benefit is less clear for *response* bodies, since they are not signed in
+their own right, though some responses, such as
+[`/backfill`](https://spec.matrix.org/v1.17/server-server-api/#get_matrixfederationv1backfillroomid),
+contain event bodies, which are signed, so requiring them to be transmitted as
+Canonical JSON could be beneficial.
+
+In any case, the main difficulty is that such a rule has no benefit unless it
+can be enforced. Receiving servers would have to verify that incoming JSON is
+actually compliant with Canonical JSON, to prevent attacks from malicious
+servers. This is not a trivial operation.
+
+Ideally a JSON parser might check that incoming JSON is Canonical during
+parsing, but we are not aware of any JSON parsers capable of doing this, and it
+is worth noting that any implementation must be absolutely watertight to avoid
+the danger of inconsistent parsing between different implementations.
+
+A completely separate pass over the incoming JSON is feasible but not obviously
+much more efficient than reserializing the received data as Canonical JSON.
+
+A secondary problem is that this is not the way the Matrix ecosystem works
+today. To maintain compatibility with today's servers, we would need to spec a
+way to indicate that sending servers are opting in to the requirements (New API
+endpoints? Alternative `Content-Encoding` headers?) and implementation would be
+a significant amount of work for server maintainers, leading to an opportunity
+cost in development in other areas of Matrix.
+
+### Sign/hash the transmitted JSON rather than a canonical representation
+
+Another suggestion is that when receiving JSON, either in request bodies or
+room events, servers must validate signatures and hashes against the received
+JSON (including any whitespace and unordered object keys) rather than
+converting it to a canonical form. Checking signatures and hashes *before*
+parsing JSON could bring security and performance benefits.
+
+There are three significant problems with this approach:
+
+- There is a danger of implementations parsing the same event object
+  inconsistently; in particular, different JSON deserializers can interpret
+  JSON in different ways. One example is with duplicate keys on JSON objects;
+  others include floating-point numbers (which may be rounded differently or
+  have different range), or acceptance of non-standard JSON such as `NaN` or
+  `Infinity`, or even comments or trailing commas.
+
+  Such inconsistency can be used by a malicious server to create a split-brain
+  in a room, where different servers accept different subsets of events.
+
+  These effects could in theory be guarded against by forbidding all ambiguous
+  JSON constructs, but that's essentially equivalent to requiring Canonical
+  JSON on the wire, which is discussed above.
+
+- Such an approach would require servers to keep a copy of the original JSON
+  for each event, so that it can be sent on to other servers which will
+  themselves need to check the signatures and hashes.
+
+- The [hashing and
+  signing](https://spec.matrix.org/v1.17/server-server-api/#signing-events)
+  process on room events involves manipulating the event in question (the
+  content must be
+  [redacted](https://spec.matrix.org/v1.17/rooms/v12/#redactions) to calculate
+  the reference hash/event ID, and the `signatures` and `unsigned` properties
+  must be removed to calculate the signature). If the incoming JSON is not
+  Canonical, there are questions about how to perform this process: in
+  particular, how should whitespace before and after removed properties be
+  handled?
+
+  Further, manipulating the raw JSON in this way is very unnatural in some
+  languages: it is much easer to parse the incoming JSON, manipulate the data,
+  and re-serialize.
+
+### Allow servers to canonicalise incoming JSON separately to parsing
+
+Some implementations (for example, Dendrite) operate on incoming JSON at the
+byte level to transform it to Canonical JSON, before checking
+signatures/hashes. They then retain the *original* JSON, deserializing it where
+necessary for later operation. Should we allow such an approach?
+
+The short answer is: if this approach can *provably* give the same result as
+that suggested in the proposal, then yes it should be tolerated.
+
+However, the practicalties make it dangerous. It is possible for the
+canonicalisation process to remove ambiguities (such as duplicate keys),
+allowing a malicious server to construct JSON which passes a signature or hash
+check but is then interpreted differently later on.
+
+This is therefore not a recommended approach.
+
+### Allow servers to canonicalise incoming JSON *before* parsing
+
+A variation on the previous approach is to canonicalise the JSON at the byte
+level, check the signatures/hashes, and only then deserialize the JSON for
+later operations.
+
+This is safer than retaining the original JSON, However, the canonicalisation
+process must be absolutely fail-safe to ensure that any possible ambiguities
+are removed, to avoid security vulnerablities.
+
+For example: consider a bug where the canonicaliser failed to realise that the
+following object contains duplicate keys:
+
+```json
+{
+   "apple": "foo",
+   "appl\u0065": "bar"
+}
+```
+
+This could obviously lead to a security vulnerability.
+
+It should be *possible* to write a byte-level canonicaliser that is not subject
+to such bugs (particularly if we provide a good set of Canonical JSON test
+vectors); however implementations which round-trip the JSON via deserialised
+objects appear to be more robust.
+
+In short: we're not recommending this approach, for robustness.
+
+### Use an alternative Canonical JSON format
+
+Rather than using a Canonical JSON format specific to Matrix, could we use a
+standardised format such as "JSON Canonicalization Scheme" (JCS, specified by
+[RFC8785](https://www.rfc-editor.org/rfc/rfc8785.html))?
+
+This is a somewhat orthogonal question, but worth discussing while we're in the
+area. Adopting a standardized canonical JSON format might mean that we could
+benefit from existing implementations.
+
+For reference, the differences between Matrix's Canonical JSON and JCS are as
+follows:
+
+ * JCS forbids the Unicode non-characters, whereas Canonical JSON allows
+   them. The non-characters are defined by [Unicode section
+   3.4](https://www.unicode.org/versions/Unicode17.0.0/core-spec/chapter-3/#G21465)
+   to be the codepoints U+nFFFE and U+nFFFF (where n is from 0 to 0x10) and the
+   codepoints U+FDD0..U+FDEF".
+
+ * JCS allows floating point numbers, in the full range supported by IEEE 754
+   doubles (i.e., up to 1.8e+308), with associated complicated formatting
+   rules drawn from the ECMAScript specification.
+
+   CanonicalJSON allows only integers in the range `[-(2**53)+1, (2**53)-1]`,
+   forbidding exponential notation and decimal points.
+
+ * The sort order for object keys is subtly different: JCS encodes the keys
+   using UTF-16 and sorts the resulting code units, whilst Canonical JSON sorts
+   the UTF-32 code points.
+
+   In other words, JCS sorts the smiley face 😀 (U+1F600) before the Hebrew
+   letter דּ (U+FB33), whilst Canonical JSON uses the opposite sorting.
+
+It's not obvious that the benefits of switching to an alternative Canonical
+JSON format are worthwhile at this time.
+
+### Use an alternative serialization format
+
+We could go further than switching JSON format, and use a completely different
+format. A different serialisation format might be more amenable to consistent
+parsing, and signature checking.
+
+One candidate for such a format is [DRISL](https://dasl.ing/drisl.html) (a
+proposed format based on CBOR which aims specifically for consistent
+representation of data).
+
+Such an change remains under consideration, but is left for a future MSC.
+
+## Security considerations
+
+Consistent JSON canonicalisation is central to the security of the Matrix
+protocol. It is therefore critical that the specification be clear about
+expected behaviour, and that implementations match those expectations.
+
+## Unstable prefix
+
+N/A
+
+## Dependencies
+
+None
+
+##
+
+- we assume that rejecting questionable JSON is much, much safer than accepting
+  it
+- there are no safe CanonicalJSON decoders
+- examples of attacks
+- examples of suitable implementations:
+  - Go: unmarshal into `interface{}`
+  - Python: json.load
+  - Rust: deserialize to serde_json::Value

--- a/proposals/4458-handling-received-json.md
+++ b/proposals/4458-handling-received-json.md
@@ -95,7 +95,7 @@ clarifications.
    surrogates.
 
    When parsing incoming JSON, valid surrogate pairs SHOULD be decoded to their
-   Unicode codedpoint. Such codepoints MUST then be encoded as a 4-byte UTF-8
+   Unicode codepoint. Such codepoints MUST then be encoded as a 4-byte UTF-8
    sequence when encoding as Canonical JSON.
 
    Incoming JSON containing unpaired surrogates MUST be rejected (either on

--- a/proposals/4458-handling-received-json.md
+++ b/proposals/4458-handling-received-json.md
@@ -205,8 +205,8 @@ This is therefore not a recommended approach.
 ### Allow servers to canonicalise incoming JSON *before* parsing
 
 A variation on the previous approach is to canonicalise the JSON at the byte
-level, check the signatures/hashes, and only then deserialize the JSON for
-later operations.
+level, check the signatures/hashes, and then deserialize the canonicalised
+JSON for later operations.
 
 This is safer than retaining the original JSON, However, the canonicalisation
 process must be absolutely fail-safe to ensure that any possible ambiguities

--- a/proposals/4458-handling-received-json.md
+++ b/proposals/4458-handling-received-json.md
@@ -131,7 +131,7 @@ clarifications.
 
 Requiring that implementations parse and then re-serialize incoming JSON in
 this way runs the risk that differences in JSON parsers could prevent
-homeserver implemementations from interoperating. To take one example: in older
+homeserver implementations from interoperating. To take one example: in older
 room versions, Synapse would accept events which contained the invalid JSON
 `NaN`. Therefore, to successfully interoperate with Synapse in these room
 versions, other implementations must also accept `NaN`; failure to do so risks

--- a/proposals/4458-handling-received-json.md
+++ b/proposals/4458-handling-received-json.md
@@ -51,7 +51,7 @@ clarifications.
    In particular: it is **not** sufficient to construct the Canonical JSON by
    modifying the unparsed JSON data, since this brings the risk of inconsistent
    parsing when the JSON is later parsed. Further discussion of the potential
-   problems can be found in the [Alternatives](#alternatives) below.
+   problems can be found in the [Alternatives](#allow-servers-to-canonicalise-incoming-json-separately-to-parsing) below.
 
 2. Implementations MUST guard against duplicate keys in the incoming JSON, and
    ensure that duplicates are dropped before encoding to Canonical JSON. (In
@@ -84,10 +84,12 @@ clarifications.
    To be explicit, then: Canonical JSON MUST NOT encode the UTF-16
    surrogates.
 
-   Valid surrogate pairs SHOULD be decoded to their Unicode code point on
-   parsing, and then encoded as a 4-byte UTF-8 sequence when encoding as
-   Canonical JSON. JSON containing unpaired surrogates MUST be rejected
-   (either on parsing, or when attempting to encode as Canonical JSON).
+   When parsing incoming JSON, valid surrogate pairs SHOULD be decoded to their
+   Unicode codedpoint. Such codepoints MUST then be encoded as a 4-byte UTF-8
+   sequence when encoding as Canonical JSON.
+
+   Incoming JSON containing unpaired surrogates MUST be rejected (either on
+   parsing, or when attempting to encode as Canonical JSON).
 
 ## Potential issues
 
@@ -236,7 +238,7 @@ follows:
    them. The non-characters are defined by [Unicode section
    3.4](https://www.unicode.org/versions/Unicode17.0.0/core-spec/chapter-3/#G21465)
    to be the codepoints U+nFFFE and U+nFFFF (where n is from 0 to 0x10) and the
-   codepoints U+FDD0..U+FDEF".
+   codepoints U+FDD0..U+FDEF.
 
  * JCS allows floating point numbers, in the full range supported by IEEE 754
    doubles (i.e., up to 1.8e+308), with associated complicated formatting

--- a/proposals/4458-handling-received-json.md
+++ b/proposals/4458-handling-received-json.md
@@ -316,8 +316,8 @@ Such an change remains under consideration, but is left for a future MSC.
    protocol. It is therefore critical that the specification be clear about
    expected behaviour, and that implementations match those expectations.
 
-2. A useful general insight is that it is generally much safer to reject than
-   to accept any "questionable" incoming JSON ­ for example, that containing
+2. A useful general insight: it is generally much safer to reject than to
+   accept any "questionable" incoming JSON — for example, that containing
    duplicate keys, out-of-range numbers, or unpaired surrogates. Such JSON
    should only be encountered when the sending implementation is either buggy
    or malicious, so it is clearly preferable to reject malformed incoming
@@ -340,6 +340,33 @@ Such an change remains under consideration, but is left for a future MSC.
    for a server to split-brain itself from the rest of the room via
    non-conformant behaviour: poor JSON implementation is not special in this
    regard).
+
+3. As a server verifying a JSON object, we want to verify our interpretation of
+   the data. This is safely done by serializing the parsed data and checking
+   the signature of that, rather than checking the signature of untrusted input
+   and then parsing.
+
+   An example issue is duplicate keys: if a server receives JSON with duplicate
+   keys, then there are multiple ways of interpreting that data. Therefore
+   different servers could successfully validate the signature but parse in
+   different ways.
+
+   One could write a deserializer to hande/detect this, but it's harder to
+   write a "canonical" deserializer on untrusted input than a canonical
+   serializer on a parsed/valid structure.
+
+4. We should note that (non-evil) servers are responsible for serving up valid
+   JSON that all other servers can parse and validate. In particular, for a
+   room event that a server has accepted (from a potentially evil server), it
+   should ensure when it serializes the event to send to a third server the
+   bytes sent are a) unambiguous, and b) when serialized to canonical json
+   passes signature/hash checks.
+
+   This means that extreme care would need to be taken if storing events as raw
+   bytes received from third parties, and it is much easier to parse into an
+   internal representation and serialize from that. Evil servers can
+   potentially craft JSON that parses differently on different implementations
+   (and thus will pass checks on some impls and not others).
 
 ## Unstable prefix
 

--- a/proposals/4458-handling-received-json.md
+++ b/proposals/4458-handling-received-json.md
@@ -43,9 +43,19 @@ clarifications.
      * arrays
      * `true`, `false`, `null`.
 
+   Example implementations of this step include:
+     * In Go, [`Decode`](https://pkg.go.dev/encoding/json#Decoder.Decode) into
+       an `interface{}`.
+     * In Python,
+       [`json.loads`](https://docs.python.org/3/library/json.html#json.loads).
+     * In Rust,
+       [`serde_json::from_str`](https://docs.rs/serde_json/latest/serde_json/fn.from_str.html)
+       with a target of
+       [`serde_json::Value`](https://docs.rs/serde_json/latest/serde_json/enum.Value.html).
+
    The original JSON MUST then be discarded, and all future operations must be
    based on the deserialized structures. This includes hashing and signature
-   checking, which must be done be encoding the deserialized structures as
+   checking, which must be done by encoding the deserialized structures as
    Canonical JSON.
 
    In particular: it is **not** sufficient to construct the Canonical JSON by
@@ -307,10 +317,3 @@ N/A
 ## Dependencies
 
 None
-
-##
-
-- examples of suitable implementations:
-  - Go: unmarshal into `interface{}`
-  - Python: json.load
-  - Rust: deserialize to serde_json::Value

--- a/proposals/4458-handling-received-json.md
+++ b/proposals/4458-handling-received-json.md
@@ -268,7 +268,7 @@ Rather than using a Canonical JSON format specific to Matrix, could we use a
 standardised format such as "JSON Canonicalization Scheme" (JCS, specified by
 [RFC8785](https://www.rfc-editor.org/rfc/rfc8785.html))?
 
-This is a somewhat orthogonal question, but worth discussing while we're in the
+This is a somewhat orthogonal question as it does not help solve the issues discussed above with verifying signatures and hashes, but it is worth discussing while we're in the
 area. Adopting a standardized canonical JSON format might mean that we could
 benefit from existing implementations.
 

--- a/proposals/4458-handling-received-json.md
+++ b/proposals/4458-handling-received-json.md
@@ -103,7 +103,38 @@ clarifications.
 
 ## Potential issues
 
-TODO
+Requiring that implementations parse and then re-serialize incoming JSON in
+this way runs the risk that differences in JSON parsers could prevent
+homeserver implemementations from interoperating. To take one example: in older
+room versions, Synapse would accept events which contained the invalid JSON
+`NaN`. Therefore, to successfully interoperate with Synapse in these room
+versions, other implementations must also accept `NaN`; failure to do so risks
+a split-brain in the room. In other words: Synapse's JSON-parsing quirks were
+forced onto the rest of the ecosystem.
+
+Whilst this should not be a problem in modern room versions, where the allowed
+JSON is much more rigidly specified and enforced, we still have the issue that
+different implementations could, potentially, have different parsing edge-cases.
+
+In theory, such problems could be avoided either by requiring that servers
+transmit Canonical JSON on the wire, or by having implementations sign and hash
+the uncanonicalised data on the wire rather than a canonicalised representation
+of it. Both approaches are discussed in more detail under
+[Alternatives](#alternatives).
+
+However, requiring servers to transmit Canonical JSON is currently believed to
+be technically infeasible, as discussed below.
+
+Having implementations sign and hash the data on the wire would mean that
+servers could at least get as far as agreeing on whether an event was correctly
+signed, even if their JSON parsers then treat the event differently. However,
+it is exactly this property — that events are accepted even if they are parsed
+differently — that we must avoid, since once again it allows attackers to
+create split-brains.
+
+In short: the proposal in this MSC isn't ideal, but has no known vulnerabilities
+in modern room versions. The only practical alternative has known attacks, and
+is therefore rejected.
 
 ## Alternatives
 

--- a/proposals/4458-handling-received-json.md
+++ b/proposals/4458-handling-received-json.md
@@ -51,7 +51,7 @@ clarifications.
    In particular: it is **not** sufficient to construct the Canonical JSON by
    modifying the unparsed JSON data, since this brings the risk of inconsistent
    parsing when the JSON is later parsed. Further discussion of the potential
-   problems can be found in the [Alternatives](#altenatives) below.
+   problems can be found in the [Alternatives](#alternatives) below.
 
 2. Implementations MUST guard against duplicate keys in the incoming JSON, and
    ensure that duplicates are dropped before encoding to Canonical JSON. (In
@@ -170,7 +170,7 @@ There are three significant problems with this approach:
   handled?
 
   Further, manipulating the raw JSON in this way is very unnatural in some
-  languages: it is much easer to parse the incoming JSON, manipulate the data,
+  languages: it is much easier to parse the incoming JSON, manipulate the data,
   and re-serialize.
 
 ### Allow servers to canonicalise incoming JSON separately to parsing
@@ -198,7 +198,7 @@ later operations.
 
 This is safer than retaining the original JSON, However, the canonicalisation
 process must be absolutely fail-safe to ensure that any possible ambiguities
-are removed, to avoid security vulnerablities.
+are removed, to avoid security vulnerabilities.
 
 For example: consider a bug where the canonicaliser failed to realise that the
 following object contains duplicate keys:

--- a/proposals/4458-handling-received-json.md
+++ b/proposals/4458-handling-received-json.md
@@ -271,9 +271,34 @@ Such an change remains under consideration, but is left for a future MSC.
 
 ## Security considerations
 
-Consistent JSON canonicalisation is central to the security of the Matrix
-protocol. It is therefore critical that the specification be clear about
-expected behaviour, and that implementations match those expectations.
+1. Consistent JSON canonicalisation is central to the security of the Matrix
+   protocol. It is therefore critical that the specification be clear about
+   expected behaviour, and that implementations match those expectations.
+
+2. A useful general insight is that it is generally much safer to reject than
+   to accept any "questionable" incoming JSON ­ for example, that containing
+   duplicate keys, out-of-range numbers, or unpaired surrogates. Such JSON
+   should only be encountered when the sending implementation is either buggy
+   or malicious, so it is clearly preferable to reject malformed incoming
+   federation requests.
+
+   The situation is less clear-cut in the case of Matrix room events, where
+   rejecting certain JSON forms could lead to a split-brain if other servers
+   have accepted it. However, even there, rejecting malformed JSON is generally
+   safe. Suppose we have a room containing three servers: server A is
+   buggy/malicions, whilst servers B and C are conformant but use different
+   implementations.
+
+   Now, server A generates a malformed event with duplicate keys in the JSON;
+   server B discards one of the duplicates and accept the event, whilst server
+   C rejects it. A split-brain still does not occur between the conformant
+   servers (B and C), because server C can request the event from server B,
+   which will return the now-sanitised version of the event without the
+   duplicate. A split-brain *can* occur between A and the rest of the room, but
+   that is acceptable because A is buggy/malicious. (There are plenty of ways
+   for a server to split-brain itself from the rest of the room via
+   non-conformant behaviour: poor JSON implentation is not special in this
+   regard).
 
 ## Unstable prefix
 
@@ -285,10 +310,6 @@ None
 
 ##
 
-- we assume that rejecting questionable JSON is much, much safer than accepting
-  it
-- there are no safe CanonicalJSON decoders
-- examples of attacks
 - examples of suitable implementations:
   - Go: unmarshal into `interface{}`
   - Python: json.load

--- a/proposals/4458-handling-received-json.md
+++ b/proposals/4458-handling-received-json.md
@@ -71,8 +71,6 @@ clarifications.
    Implementations are free to implement this requirement by dropping one or
    other duplicate, or by rejecting the JSON as a whole.
 
-   > ### Justification
-   >
    > The previous paragraph merits some explanation as to its safety.
    >
    > Duplicate keys can only arise when the sending server is buggy or

--- a/proposals/4458-handling-received-json.md
+++ b/proposals/4458-handling-received-json.md
@@ -152,8 +152,8 @@ However, requiring servers to transmit Canonical JSON is currently believed to
 be technically infeasible, as discussed below.
 
 Having implementations sign and hash the data on the wire would mean that
-servers could at least get as far as agreeing on whether an event was correctly
-signed, even if their JSON parsers then treat the event differently. However,
+servers could at least get as far as agreeing on whether the event bytes were correctly
+signed, even if their JSON parsers then treat the parsed event differently. However,
 it is exactly this property — that events are accepted even if they are parsed
 differently — that we must avoid, since once again it allows attackers to
 create split-brains.

--- a/proposals/data/4458/README.md
+++ b/proposals/data/4458/README.md
@@ -1,0 +1,23 @@
+Test vectors for Canonical JSON encoders
+----------------------------------------
+
+This is supporting data for [MSC4458](https://github.com/matrix-org/matrix-spec-proposals/pull/4458): it contains an
+extended set of test vectors for Canonical JSON encoders.
+
+The test data itself is contained in the `testcases` directory. Each file is a single testcase, and has the format
+described below.
+
+A script which goes through the test vectors and verifies the Python canonicaljson implementation is provided as 
+`test.py`.
+
+## Testcase file format
+
+Each testcase file has two parts, separated by a line containing (only) `---`.
+
+The first part is the input data: it is data that might be received in the body of a federation request or response:
+in other words, it is JSON-encoded data. Within this section, lines starting with `#` are comments and should be
+ignored.
+
+The second part lists acceptable encodings of the input data as Canonical JSON, one per line. In some cases
+(such as objects with duplicate keys), there are multiple acceptable encodings of the given data. The special value
+`REJECT` is used to indicate rejection of the input data (either during initial parsing, or during canonicalisation).

--- a/proposals/data/4458/test.py
+++ b/proposals/data/4458/test.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+#
+# Validates the Python canonicaljson encoder implementation, https://pypi.org/project/canonicaljson/.
+#
+# To run:
+#   python -m venv env
+#   . env/bin/activate
+#   pip install canonicaljson
+#   ./test.py
+
+import sys
+from typing import Any
+
+import canonicaljson
+import os
+import json
+
+TEST_DATA_DIR: str = os.path.join(os.path.dirname(__file__), "testcases")
+
+
+def encode_canonical_json(data: Any) -> bytes:
+    """This is the function under test. It should encode the given data as Canonical JSON.
+
+    If the data cannot be legally represented as Canonical JSON, it should throw an exception.
+
+    Ideally, we would simply call `canonicaljson.encode_canonical_json`; however,
+    the python canonicaljson encoder doesn't actually confirm to the spec unless
+    you first verify that there aren't any unsupported types, so we have to implement a separate validation step.
+    """
+    validate_canonicaljson(data)
+    return canonicaljson.encode_canonical_json(data)
+
+
+def validate_canonicaljson(value: Any) -> None:
+    """
+    Ensure that the JSON object is valid according to the rules of canonical JSON.
+
+    This rejects JSON that has:
+    * An integer outside the range of [-2 ^ 53 + 1, 2 ^ 53 - 1]
+    * Floats
+    * NaN, Infinity, -Infinity
+
+    From synapse: https://github.com/element-hq/synapse/blob/3622579e7bc9fe70d3682bc20bb4955fbb0c9e82/synapse/events/utils.py#L487-L516
+    """
+    # Max/min size of ints in canonical JSON
+    CANONICALJSON_MAX_INT = (2**53) - 1
+    CANONICALJSON_MIN_INT = -CANONICALJSON_MAX_INT
+
+    if type(value) is int:  # noqa: E721
+        if value < CANONICALJSON_MIN_INT or CANONICALJSON_MAX_INT < value:
+            raise Exception("JSON integer out of range")
+
+    elif isinstance(value, float):
+        # Note that Infinity, -Infinity, and NaN are also considered floats.
+        raise Exception("Bad JSON value: float")
+
+    elif isinstance(value, dict):
+        for v in value.values():
+            validate_canonicaljson(v)
+
+    elif isinstance(value, (list, tuple)):
+        for i in value:
+            validate_canonicaljson(i)
+
+    elif not isinstance(value, (bool, str)) and value is not None:
+        # Other potential JSON values (bool, None, str) are safe.
+        raise Exception("Unknown JSON value")
+
+
+def verify_testcase(filename: str) -> None:
+    # Break the file into sections at the "---" boundary.
+    # The first section is the input; the second half lists acceptable outputs, one per line
+    with open(filename, "rb") as f:
+        content = f.read()
+
+    sections = content.split(b"---\n", 1)
+
+    # In the input, lines beginning '#' are comments and should be removed
+    input_json = b"".join(
+        filter(
+            lambda line: not line.startswith(b"#"),
+            sections[0].splitlines(keepends=True),
+        )
+    )
+
+    acceptable_outputs = sections[1].splitlines()
+
+    parsed = json.loads(input_json)
+    try:
+        canonical_json = encode_canonical_json(parsed)
+    except Exception as e:
+        canonical_json = b"REJECT"
+
+    if canonical_json not in acceptable_outputs:
+        print(
+            f"""\
+Testcase {filename} failed
+--------------------------
+
+Input:
+{input_json.decode(errors="replace")}
+
+Parsed input:
+{parsed}
+
+Canonicalised output:
+{canonical_json.decode()}
+
+Acceptable outputs:
+{"\n".join(map(lambda o: o.decode(), acceptable_outputs))}\
+""",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+for file in os.listdir(TEST_DATA_DIR):
+    verify_testcase(os.path.join(TEST_DATA_DIR, file))
+
+print("OK")

--- a/proposals/data/4458/testcases/00-empty-object
+++ b/proposals/data/4458/testcases/00-empty-object
@@ -1,0 +1,4 @@
+# A simple object. Taken from spec v1.19.
+{}
+---
+{}

--- a/proposals/data/4458/testcases/01-object1
+++ b/proposals/data/4458/testcases/01-object1
@@ -1,0 +1,7 @@
+# A simple object, taken from spec v1.19.
+{
+    "one": 1,
+    "two": "Two"
+}
+---
+{"one":1,"two":"Two"}

--- a/proposals/data/4458/testcases/02-object-key-sorting
+++ b/proposals/data/4458/testcases/02-object-key-sorting
@@ -1,0 +1,7 @@
+# Advanced sorting of object keys: BMP keys sort before non-BMP keys.
+{
+   "😀": "smiley face",
+   "\uFB33": "dalet"
+}
+---
+{"דּ":"dalet","😀":"smiley face"}

--- a/proposals/data/4458/testcases/03-object-duplicate-keys
+++ b/proposals/data/4458/testcases/03-object-duplicate-keys
@@ -1,0 +1,6 @@
+# An object with duplicate keys
+{"a": 1, "a": 2}
+---
+REJECT
+{"a":1}
+{"a":2}

--- a/proposals/data/4458/testcases/10-float1
+++ b/proposals/data/4458/testcases/10-float1
@@ -1,0 +1,5 @@
+# Input with floating point may be truncated or rejected. New for MSC 4458.
+1.5
+---
+REJECT
+1

--- a/proposals/data/4458/testcases/11-exponent
+++ b/proposals/data/4458/testcases/11-exponent
@@ -1,0 +1,12 @@
+# Negative zero and exponents should be resolved.
+# Taken from spec v1.19.
+#
+# However, I think this is incorrect, per https://github.com/matrix-org/matrix-spec/issues/2424, and I have
+# added "REJECT" as an acceptable output.
+{
+    "a": -0,
+    "b": 1e10
+}
+---
+{"a":0,"b":10000000000}
+REJECT

--- a/proposals/data/4458/testcases/12-negative-zero
+++ b/proposals/data/4458/testcases/12-negative-zero
@@ -1,0 +1,6 @@
+# Negative zero should be resolved. The non-broken part of 11-exponent.
+{
+    "a": -0
+}
+---
+{"a":0}

--- a/proposals/data/4458/testcases/20-string-japanese
+++ b/proposals/data/4458/testcases/20-string-japanese
@@ -1,0 +1,6 @@
+# We should be able to support non-latin strings. Taken from spec v1.19.
+{
+    "a": "日本語"
+}
+---
+{"a":"日本語"}

--- a/proposals/data/4458/testcases/21-string-unpaired-surrogate
+++ b/proposals/data/4458/testcases/21-string-unpaired-surrogate
@@ -1,0 +1,4 @@
+# Strings containing unpaired surrogates must be rejected. New for MSC 4458.
+"a \ud83d z"
+---
+REJECT

--- a/proposals/data/4458/testcases/22-string-utf-16
+++ b/proposals/data/4458/testcases/22-string-utf-16
@@ -1,0 +1,4 @@
+# A string with UTF-16 surrogates. New for MSC 4458.
+"a \ud83d\ude00 b"
+---
+"a 😀 b"

--- a/proposals/data/4458/testcases/23-string-invalid-utf-8
+++ b/proposals/data/4458/testcases/23-string-invalid-utf-8
@@ -1,0 +1,7 @@
+# A string containing invalid UTF-8: in particular, an attempt to encode one of the UTF-16 surrogates. New for MSC 4458.
+#
+# D83D is 1101 1000 0011 1101, making its UTF-8 encoding
+# 11101101 10100000 10111101, ie ED A0 BD
+"a �\ude00 b"
+---
+REJECT


### PR DESCRIPTION
[Rendered](https://github.com/matrix-org/matrix-spec-proposals/blob/rav/proposal/json_handling_clarifications/proposals/4458-handling-received-json.md)

Implementation: Synapse already does all this.

---

SCT stuff:

[MSC checklist](https://github.com/matrix-org/matrix-spec-proposals/pull/4458#issuecomment-5040151220)
[FCP tickyboxes](https://github.com/matrix-org/matrix-spec-proposals/pull/4458#issuecomment-5040152537)