### PR TITLE
MSC4512: Delegating parts of the Client-Server and Server-Server API to application services

### DIFF
--- a/proposals/4512-app-service-takeover.md
+++ b/proposals/4512-app-service-takeover.md
@@ -35,9 +35,9 @@ application service and allows the service to trigger S-S requests under its own
 
 ### Proxying client-server requests
 
-For any authenticated C-S request under `/_matrix/client/{proxy}/*`, the server first authorises the
-request as usual. If authorization succeeds, the server proxies the request to
-`{url}/_matrix/client/{proxy}/*` and streams the response back to the requesting client.
+For any authenticated C-S request under `/_matrix/client/(unstable/[^/]+|v[^/]+)/{proxy}/.*`, the
+server first authorises the request as usual. If authorization succeeds, the server proxies the
+request to the same path anchored on `url` and streams the response back to the requesting client.
 
 Any "hop-by-hop" headers as defined by [RFC2616] MUST be stripped both before forwarding the request
 to the service and before streaming the response back to the requesting client.
@@ -50,9 +50,9 @@ server supplies the MXID of the requesting client to the application service in 
 
 The process for proxying server-server requests is analogous.
 
-For any authenticated S-S request under `/_matrix/federation/{proxy}/*`, the server first authorises
-the request as usual. If authorization succeeds, the server proxies the request to
-`{url}/_matrix/federation/{proxy}/*` and streams the response back to the requesting server.
+For any authenticated S-S request under `/_matrix/federation/(unstable/[^/]+|v[^/]+)/{proxy}/.*`, the
+server first authorises the request as usual. If authorization succeeds, the server proxies the
+request to the same path anchored on `url` and streams the response back to the requesting server.
 
 Any "hop-by-hop" headers as defined by [RFC2616] MUST be stripped both before forwarding the request
 to the service and before streaming the response back to the requesting server.
@@ -73,7 +73,7 @@ POST /_matrix/client/v1/appservice/fed_proxy HTTP/1.1
 {
   "destination": "example.org",
   "method": "POST",
-  "path": "/_matrix/federation/{proxy}/foo/bar/",
+  "path": "/_matrix/federation/v1/{proxy}/foo/bar/",
   "query": { ... },
   "body": { ... }
 }

--- a/proposals/4512-app-service-takeover.md
+++ b/proposals/4512-app-service-takeover.md
@@ -35,6 +35,9 @@ proxy_url: "http://127.0.0.1:1234"
 When both `proxy_prefix` and `proxy_url` are set, the server proxies matching C-S and S-S requests
 to the application service and allows the service to trigger S-S requests under its own prefix.
 
+For now, authentication is REQUIRED for any C-S and S-S requests under the `proxy_prefix`. A future
+proposal may introduce a way for application services to define when authentication isn't required.
+
 ### Proxying client-server requests
 
 For any authenticated C-S request under `/_matrix/client/(unstable/[^/]+|v[^/]+)/{proxy_prefix}/.*`,

--- a/proposals/4512-app-service-takeover.md
+++ b/proposals/4512-app-service-takeover.md
@@ -42,7 +42,7 @@ the server first authorises the request as usual. If authorization succeeds, the
 request to the same path anchored on `proxy_url` and streams the response back to the requesting
 client.
 
-Any "hop-by-hop" headers as defined by [RFC2616] MUST be stripped both before forwarding the request
+Any "hop-by-hop" headers as defined by [RFC 2616] MUST be stripped both before forwarding the request
 to the service and before streaming the response back to the requesting client.
 
 Additionally, the `Authorization` header MUST be stripped on the forwarded request. Instead, the

--- a/proposals/4512-app-service-takeover.md
+++ b/proposals/4512-app-service-takeover.md
@@ -46,7 +46,7 @@ Any "hop-by-hop" headers as defined by [RFC 2616] MUST be stripped both before f
 to the service and before streaming the response back to the requesting client.
 
 Additionally, the `Authorization` header MUST be stripped on the forwarded request. Instead, the
-server supplies the MXID of the requesting client to the application service in a new request header
+server supplies the User ID of the requesting client to the application service in a new request header
 `X-Matrix-User-Identifier`.
 
 ### Proxying server-server requests

--- a/proposals/4512-app-service-takeover.md
+++ b/proposals/4512-app-service-takeover.md
@@ -21,7 +21,7 @@ file] for application services. `proxy_prefix` is a string and defines the path 
 service is claiming. `proxy_url` is a string that determines the `url` to send proxied requests to.
 `proxy_prefix` and `proxy_url` are optional but if used, MUST always be specified together.
 
-``` yaml
+```yaml
 id: "My app service"
 url: null
 as_token: "30c05ae90a248a4188e620216fa72e349803310ec83e2a77b34fe90be6081f46"

--- a/proposals/4512-app-service-takeover.md
+++ b/proposals/4512-app-service-takeover.md
@@ -139,9 +139,11 @@ design as no associated use cases are known yet.
 
 ## Alternatives
 
-The existing `url` property could be reused to avoid having to specify a separate `proxy_url`. This
-would disallow using proxying while disabling namespace-related traffic from the server by setting
-`url` to `null`, however.
+The existing `url` property could be reused to avoid having to specify a separate `proxy_url`. However,
+`url` is also used to forward events to the application service as per its `namespaces` setting. An
+application service may not be interested in receiving regular Matrix events though. Instead, it could
+only be using `namespaces` to be able to puppet users on the C-S API. The separate `proxy_url` property
+resolves this conflict and avoids excess traffic between the homeserver and the application service.
 
 ## Security considerations
 

--- a/proposals/4512-app-service-takeover.md
+++ b/proposals/4512-app-service-takeover.md
@@ -167,5 +167,5 @@ None.
   [lk-jwt-service]: https://github.com/element-hq/lk-jwt-service
   [MSC4195]: https://github.com/matrix-org/matrix-spec-proposals/pull/4195
   [registration file]: https://spec.matrix.org/v1.19/application-service-api/#registration
-  [RFC2616]: https://datatracker.ietf.org/doc/html/rfc2616#section-13.5.1
+  [RFC 2616]: https://datatracker.ietf.org/doc/html/rfc2616#section-13.5.1
   [server name]: https://spec.matrix.org/v1.19/appendices/#server-name

--- a/proposals/4512-app-service-takeover.md
+++ b/proposals/4512-app-service-takeover.md
@@ -1,0 +1,164 @@
+# MSC4512: Delegating parts of the C-S and S-S API to application services
+
+With the Matrix spec growing, there is an increased burden on homeserver maintainers to implement
+new functionality[^1]. In some cases, this burden could be reduced by sharing common code as
+libraries among server implementations. Differences between tech stacks can make this difficult,
+however.
+
+Another, less tightly integrated, alternative is to delegate certain parts of the API to a sidecar
+component that runs alongside but separately from the homeserver. An example use case where this
+would be beneficial is [lk-jwt-service], originally introduced in [MSC4195]. Reusing this service
+spares server maintainers having to integrate LiveKit SDKs and converse with the LiveKit SFU.
+Instead they could just run lk-jwt-service as a sidecar and proxy the respective endpoints to it.
+
+This proposal aims to formalise this delegation process in a generic way by enabling app services to
+claim parts of the Client-Server and Server-Server API.
+
+## Proposal
+
+A new optional property `proxy` is added to the top level of the [registration file] for application
+services. `proxy` is a string and defines the path prefix that the service is claiming. If `proxy`
+is specified, a non-null value for `url` is REQUIRED.
+
+``` yaml
+id: "My app service"
+url: "http://127.0.0.1:1234"
+as_token: "30c05ae90a248a4188e620216fa72e349803310ec83e2a77b34fe90be6081f46"
+hs_token: "312df522183efd404ec1cd22d2ffa4bbc76a8c1ccf541dd692eef281356bb74e"
+sender_localpart: "_my_service"
+namespaces:
+proxy: "foo/bar"
+```
+
+When both `proxy` and `url` are set, the server proxies matching C-S and S-S requests to the
+application service and allows the service to trigger S-S requests under its own `proxy` prefix.
+
+### Proxying client-server requests
+
+For any authenticated C-S request under `/_matrix/client/{proxy}/*`, the server first authorises the
+request as usual. If authorization succeeds, the server proxies the request to
+`{url}/_matrix/client/{proxy}/*` and streams the response back to the requesting client.
+
+Any "hop-by-hop" headers as defined by [RFC2616] MUST be stripped both before forwarding the request
+to the service and before streaming the response back to the requesting client.
+
+Additionally, the `Authorization` header MUST be stripped on the forwarded request. Instead, the
+server supplies the MXID of the requesting client to the application service in a new request header
+`X-Matrix-User-Identifier`.
+
+### Proxying server-server requests
+
+The process for proxying server-server requests is analogous.
+
+For any authenticated S-S request under `/_matrix/federation/{proxy}/*`, the server first authorises
+the request as usual. If authorization succeeds, the server proxies the request to
+`{url}/_matrix/federation/{proxy}/*` and streams the response back to the requesting server.
+
+Any "hop-by-hop" headers as defined by [RFC2616] MUST be stripped both before forwarding the request
+to the service and before streaming the response back to the requesting server.
+
+Additionally, the `Authorization` header MUST be stripped on the forwarded request. Instead, the
+server supplies the server name of the requesting server to the application service in a new request
+header `X-Matrix-Origin`.
+
+### Sending server-server requests
+
+Application services that provide both C-S and S-S endpoints may need to call their S-S endpoint(s)
+on a different server when processing C-S requests. To enable this, a new Client-Server endpoint
+`POST /_matrix/client/v1/appservice/fed_proxy` is introduced.
+
+``` http
+POST /_matrix/client/v1/appservice/fed_proxy HTTP/1.1
+
+{
+  "destination": "example.org",
+  "method": "POST",
+  "path": "/_matrix/federation/{proxy}/foo/bar/",
+  "query": { ... },
+  "body": { ... }
+}
+```
+
+- `destination` (required, string): The [server name] of the target server.
+- `method` (required, string): The HTTP method to use for the request. MUST be one of `GET`, `POST`,
+  `PUT`, `DELETE`.
+- `path` (required, string): The request path.
+- `query` {object}: A flat JSON object denoting the query parameter pairs to supply on the request,
+  if any. All values in `query` MUST be strings.
+- `body` {object}: A JSON object defining the request body, if any. MUST NOT be specified when
+  `method` is `GET` or `DELETE`.
+
+This endpoint can only be called by application services. If the requesting client is not an
+application service, the server MUST respond with HTTP 403 / `M_FORBIDDEN`.
+
+If any of the required parameters are missing, the server MUST reject the request with HTTP 400 /
+`M_MISSING_PARAM`. If any of the parameters contain invalid values, the server MUST reject the
+request with HTTP 400 / `M_INVALID_PARAM`.
+
+If `destination` points to a remote server that the server generally denies federating with or if
+`destination` is the server's own server name, the server MUST reject the request with HTTP 403 /
+`M_FEDPROXY_DESTINATION_DENIED`.
+
+If `path` does not have a prefix of `/_matrix/federation/{proxy}/` (where `proxy` is the identically
+named property from the application service's registration file), the server MUST reject the request
+with HTTP 403 / `M_FEDPROXY_PATH_NOT_ALLOWED`. The same MUST happen if `path` contains any segments
+of `.` or `..`.
+
+Otherwise, the server signs and sends the respective federation request.
+
+If the server is unable to deliver the request to the destination, it MUST fail with HTTP 502 /
+`M_FEDPROXY_CONNECTION_FAILED`. If the server can deliver the request, it relays the response status
+code and body back to the application service.
+
+``` http
+HTTP 200 OK
+
+{
+  "status": 200,
+  "content": { ... }
+}
+```
+
+- `status` (required, number): The HTTP status of the federation response.
+- `content` (object): A JSON object representing the body of the federation response.
+
+## Potential issues
+
+Running sidecar services reduces implementation work but complicates deployment of the homeserver.
+This is a tradeoff that server maintainers need to consider on a case by case basis.
+
+This proposal doesn't permit application services to proxy unauthenticated endpoints. This is by
+design as no associated use cases are known yet.
+
+## Alternatives
+
+None apparent.
+
+## Security considerations
+
+External services triggering federation requests on behalf of the server could be used abusively.
+The impact is limited though because requests are limited to the service's proxy prefix which the
+homeserver needs to explicitly allow-list.
+
+## Unstable prefix
+
+| Stable identifier | Purpose | Unstable identifier |
+|----|----|----|
+| `proxy` | Registration file property | `io.element.msc4512.proxy` |
+| `/_matrix/client/v1/appservice/fed_proxy` | Endpoint | `/_matrix/client/unstable/io.element.msc4512/appservice/fed_proxy` |
+| `M_FEDPROXY_DESTINATION_DENIED` | Error code | `IO.ELEMENT.MSC4512.M_FEDPROXY_DESTINATION_DENIED` |
+| `M_FEDPROXY_PATH_NOT_ALLOWED` | Error code | `IO.ELEMENT.MSC4512.M_FEDPROXY_PATH_NOT_ALLOWED` |
+| `M_FEDPROXY_CONNECTION_FAILED` | Error code | `IO.ELEMENT.MSC4512.M_FEDPROXY_CONNECTION_FAILED` |
+
+## Dependencies
+
+None.
+
+[^1]: Some statistics on what spec versions homeservers support and how long it took them to declare
+    support may be found on <https://patrick.cloke.us/homeserver-spec-versions/>.
+
+  [lk-jwt-service]: https://github.com/element-hq/lk-jwt-service
+  [MSC4195]: https://github.com/matrix-org/matrix-spec-proposals/pull/4195
+  [registration file]: https://spec.matrix.org/v1.19/application-service-api/#registration
+  [RFC2616]: https://datatracker.ietf.org/doc/html/rfc2616#section-13.5.1
+  [server name]: https://spec.matrix.org/v1.19/appendices/#server-name

--- a/proposals/4512-app-service-takeover.md
+++ b/proposals/4512-app-service-takeover.md
@@ -16,28 +16,31 @@ claim parts of the Client-Server and Server-Server API.
 
 ## Proposal
 
-A new optional property `proxy` is added to the top level of the [registration file] for application
-services. `proxy` is a string and defines the path prefix that the service is claiming. If `proxy`
-is specified, a non-null value for `url` is REQUIRED.
+Two new properties `proxy_prefix` and `proxy_url` are added to the top level of the [registration
+file] for application services. `proxy_prefix` is a string and defines the path prefix that the
+service is claiming. `proxy_url` is a string that determines the `url` to send proxied requests to.
+`proxy_prefix` and `proxy_url` are optional but if used, MUST always be specified together.
 
 ``` yaml
 id: "My app service"
-url: "http://127.0.0.1:1234"
+url: null
 as_token: "30c05ae90a248a4188e620216fa72e349803310ec83e2a77b34fe90be6081f46"
 hs_token: "312df522183efd404ec1cd22d2ffa4bbc76a8c1ccf541dd692eef281356bb74e"
 sender_localpart: "_my_service"
 namespaces:
-proxy: "foo/bar"
+proxy_prefix: "foo/bar"
+proxy_url: "http://127.0.0.1:1234"
 ```
 
-When both `proxy` and `url` are set, the server proxies matching C-S and S-S requests to the
-application service and allows the service to trigger S-S requests under its own `proxy` prefix.
+When both `proxy_prefix` and `proxy_url` are set, the server proxies matching C-S and S-S requests
+to the application service and allows the service to trigger S-S requests under its own prefix.
 
 ### Proxying client-server requests
 
-For any authenticated C-S request under `/_matrix/client/(unstable/[^/]+|v[^/]+)/{proxy}/.*`, the
-server first authorises the request as usual. If authorization succeeds, the server proxies the
-request to the same path anchored on `url` and streams the response back to the requesting client.
+For any authenticated C-S request under `/_matrix/client/(unstable/[^/]+|v[^/]+)/{proxy_prefix}/.*`,
+the server first authorises the request as usual. If authorization succeeds, the server proxies the
+request to the same path anchored on `proxy_url` and streams the response back to the requesting
+client.
 
 Any "hop-by-hop" headers as defined by [RFC2616] MUST be stripped both before forwarding the request
 to the service and before streaming the response back to the requesting client.
@@ -50,9 +53,10 @@ server supplies the MXID of the requesting client to the application service in 
 
 The process for proxying server-server requests is analogous.
 
-For any authenticated S-S request under `/_matrix/federation/(unstable/[^/]+|v[^/]+)/{proxy}/.*`, the
-server first authorises the request as usual. If authorization succeeds, the server proxies the
-request to the same path anchored on `url` and streams the response back to the requesting server.
+For any authenticated S-S request under
+`/_matrix/federation/(unstable/[^/]+|v[^/]+)/{proxy_prefix}/.*`, the server first authorises the
+request as usual. If authorization succeeds, the server proxies the request to the same path
+anchored on `proxy_url` and streams the response back to the requesting server.
 
 Any "hop-by-hop" headers as defined by [RFC2616] MUST be stripped both before forwarding the request
 to the service and before streaming the response back to the requesting server.
@@ -99,10 +103,10 @@ If `destination` points to a remote server that the server generally denies fede
 `destination` is the server's own server name, the server MUST reject the request with HTTP 403 /
 `M_FEDPROXY_DESTINATION_DENIED`.
 
-If `path` does not have a prefix of `/_matrix/federation/{proxy}/` (where `proxy` is the identically
-named property from the application service's registration file), the server MUST reject the request
-with HTTP 403 / `M_FEDPROXY_PATH_NOT_ALLOWED`. The same MUST happen if `path` contains any segments
-of `.` or `..`.
+If `path` does not have a prefix of `/_matrix/federation/{proxy_prefix}/` (where `proxy_prefix` is
+the identically named property from the application service's registration file), the server MUST
+reject the request with HTTP 403 / `M_FEDPROXY_PATH_NOT_ALLOWED`. The same MUST happen if `path`
+contains any segments of `.` or `..`.
 
 Otherwise, the server signs and sends the respective federation request.
 
@@ -132,7 +136,9 @@ design as no associated use cases are known yet.
 
 ## Alternatives
 
-None apparent.
+The existing `url` property could be reused to avoid having to specify a separate `proxy_url`. This
+would disallow using proxying while disabling namespace-related traffic from the server by setting
+`url` to `null`, however.
 
 ## Security considerations
 
@@ -144,7 +150,8 @@ homeserver needs to explicitly allow-list.
 
 | Stable identifier | Purpose | Unstable identifier |
 |----|----|----|
-| `proxy` | Registration file property | `io.element.msc4512.proxy` |
+| `proxy_prefix` | Registration file property | `io.element.msc4512.proxy_prefix` |
+| `proxy_url` | Registration file property | `io.element.msc4512.proxy_url` |
 | `/_matrix/client/v1/appservice/fed_proxy` | Endpoint | `/_matrix/client/unstable/io.element.msc4512/appservice/fed_proxy` |
 | `M_FEDPROXY_DESTINATION_DENIED` | Error code | `IO.ELEMENT.MSC4512.M_FEDPROXY_DESTINATION_DENIED` |
 | `M_FEDPROXY_PATH_NOT_ALLOWED` | Error code | `IO.ELEMENT.MSC4512.M_FEDPROXY_PATH_NOT_ALLOWED` |

--- a/proposals/4512-app-service-takeover.md
+++ b/proposals/4512-app-service-takeover.md
@@ -1,4 +1,4 @@
-# MSC4512: Delegating parts of the C-S and S-S API to application services
+# MSC4512: Delegating parts of the Client-Server and Server-Server API to application services
 
 With the Matrix spec growing, there is an increased burden on homeserver maintainers to implement
 new functionality[^1]. In some cases, this burden could be reduced by sharing common code as
@@ -32,37 +32,39 @@ proxy_prefix: "foo/bar"
 proxy_url: "http://127.0.0.1:1234"
 ```
 
-When both `proxy_prefix` and `proxy_url` are set, the server proxies matching C-S and S-S requests
-to the application service and allows the service to trigger S-S requests under its own prefix.
+When both `proxy_prefix` and `proxy_url` are set, the server proxies matching Client-Server and
+Server-Server requests to the application service and allows the service to trigger Server-Server
+requests under its own prefix.
 
-For now, authentication is REQUIRED for any C-S and S-S requests under the `proxy_prefix`. A future
-proposal may introduce a way for application services to define when authentication isn't required.
+For now, authentication is REQUIRED for any Client-Server and Server-Server requests under the
+`proxy_prefix`. A future proposal may introduce a way for application services to define when
+authentication isn't required.
 
 ### Proxying client-server requests
 
-For any authenticated C-S request under `/_matrix/client/(unstable/[^/]+|v[^/]+)/{proxy_prefix}/.*`,
-the server first authorises the request as usual. If authorization succeeds, the server proxies the
-request to the same path anchored on `proxy_url` and streams the response back to the requesting
-client.
+For any authenticated Client-Server request under
+`/_matrix/client/(unstable/[^/]+|v[^/]+)/{proxy_prefix}/.*`, the server first authorises the request
+as usual. If authorization succeeds, the server proxies the request to the same path anchored on
+`proxy_url` and streams the response back to the requesting client.
 
-Any "hop-by-hop" headers as defined by [RFC 2616] MUST be stripped both before forwarding the request
-to the service and before streaming the response back to the requesting client.
+Any "hop-by-hop" headers as defined by [RFC 2616] MUST be stripped both before forwarding the
+request to the service and before streaming the response back to the requesting client.
 
 Additionally, the `Authorization` header MUST be stripped on the forwarded request. Instead, the
-server supplies the User ID of the requesting client to the application service in a new request header
-`X-Matrix-User-Identifier`.
+server supplies the User ID of the requesting client to the application service in a new request
+header `X-Matrix-User-Identifier`.
 
 ### Proxying server-server requests
 
 The process for proxying server-server requests is analogous.
 
-For any authenticated S-S request under
+For any authenticated Server-Server request under
 `/_matrix/federation/(unstable/[^/]+|v[^/]+)/{proxy_prefix}/.*`, the server first authorises the
 request as usual. If authorization succeeds, the server proxies the request to the same path
 anchored on `proxy_url` and streams the response back to the requesting server.
 
-Any "hop-by-hop" headers as defined by [RFC2616] MUST be stripped both before forwarding the request
-to the service and before streaming the response back to the requesting server.
+Any "hop-by-hop" headers as defined by \[RFC2616\] MUST be stripped both before forwarding the
+request to the service and before streaming the response back to the requesting server.
 
 Additionally, the `Authorization` header MUST be stripped on the forwarded request. Instead, the
 server supplies the server name of the requesting server to the application service in a new request
@@ -70,9 +72,10 @@ header `X-Matrix-Origin`.
 
 ### Sending server-server requests
 
-Application services that provide both C-S and S-S endpoints may need to call their S-S endpoint(s)
-on a different server when processing C-S requests. To enable this, a new Client-Server endpoint
-`POST /_matrix/client/v1/appservice/fed_proxy` is introduced.
+Application services that provide both Client-Server and Server-Server endpoints may need to call
+their Server-Server endpoint(s) on a different server when processing Client-Server requests. To
+enable this, a new Client-Server endpoint `POST /_matrix/client/v1/appservice/fed_proxy` is
+introduced.
 
 ``` http
 POST /_matrix/client/v1/appservice/fed_proxy HTTP/1.1
@@ -139,11 +142,12 @@ design as no associated use cases are known yet.
 
 ## Alternatives
 
-The existing `url` property could be reused to avoid having to specify a separate `proxy_url`. However,
-`url` is also used to forward events to the application service as per its `namespaces` setting. An
-application service may not be interested in receiving regular Matrix events though. Instead, it could
-only be using `namespaces` to be able to puppet users on the C-S API. The separate `proxy_url` property
-resolves this conflict and avoids excess traffic between the homeserver and the application service.
+The existing `url` property could be reused to avoid having to specify a separate `proxy_url`.
+However, `url` is also used to forward events to the application service as per its `namespaces`
+setting. An application service may not be interested in receiving regular Matrix events though.
+Instead, it could only be using `namespaces` to be able to puppet users on the Client-Server API.
+The separate `proxy_url` property resolves this conflict and avoids excess traffic between the
+homeserver and the application service.
 
 ## Security considerations
 

--- a/proposals/4512-app-service-takeover.md
+++ b/proposals/4512-app-service-takeover.md
@@ -50,9 +50,9 @@ as usual. If authorization succeeds, the server proxies the request to the same 
 Any "hop-by-hop" headers as defined by [RFC 2616] MUST be stripped both before forwarding the
 request to the service and before streaming the response back to the requesting client.
 
-Additionally, the `Authorization` header MUST be stripped on the forwarded request. Instead, the
-server supplies the User ID of the requesting client to the application service in a new request
-header `X-Matrix-User-Identifier`.
+Additionally, the `Authorization` header MUST be stripped from the incoming request. Instead, the
+server authenticates the proxied request with the application service's `hs_token` and supplies the
+User ID of the requesting client to the application service in a new request header `X-Matrix-User-Identifier`.
 
 ### Proxying server-server requests
 
@@ -66,9 +66,9 @@ anchored on `proxy_url` and streams the response back to the requesting server.
 Any "hop-by-hop" headers as defined by \[RFC2616\] MUST be stripped both before forwarding the
 request to the service and before streaming the response back to the requesting server.
 
-Additionally, the `Authorization` header MUST be stripped on the forwarded request. Instead, the
-server supplies the server name of the requesting server to the application service in a new request
-header `X-Matrix-Origin`.
+Additionally, the `Authorization` header MUST be stripped from the incoming request. Instead, the
+server authenticates the proxied request with the application service's `hs_token` and supplies the
+server name of the requesting server to the application service in a new request header `X-Matrix-Origin`.
 
 ### Sending server-server requests
 


### PR DESCRIPTION
[Rendered](https://github.com/matrix-org/matrix-spec-proposals/blob/johannes/app-service-takeover/proposals/4512-app-service-takeover.md)

Thanks to @erikjohnston for ideating and brainstorming on this.