### PR TITLE
MSC4515: RTC Transports discovery for widgets

### DIFF
--- a/proposals/4515-rtc-transports-widget-action.md
+++ b/proposals/4515-rtc-transports-widget-action.md
@@ -1,0 +1,121 @@
+# MSC4515: RTC Transports discovery for widgets
+
+Widgets embedded in a room may need to know which real-time communication (RTC) backends the homeserver
+offers, for example to join a call.
+[MSC4143](https://github.com/matrix-org/matrix-spec-proposals/pull/4143) Matrix RTC offers a way for clients
+to discover the available transports through a new authenticated Client-Server endpoint, **GET**
+`/_matrix/client/v1/rtc/transports`.
+
+Given that this new endpoint is authenticated, widgets cannot access it directly: they need a new widget
+action to get the information by delegating to the client.
+
+## Proposal
+
+The widget API is extended with one new interface to access the discovery of rtc transports. The user must
+manually approve the `rtc_transports` capability before the action can be used.
+
+To trigger the action to get the configuration, widgets will use a new fromWidget request with the action
+`get_rtc_transports` which takes the following shape:
+
+```json
+{
+   "api":"fromWidget",
+   "widgetId":"widget-1234",
+   "requestId":"req-abc",
+   "action":"get_rtc_transports",
+   "data":{}
+}
+```
+
+If the widget did not get approved for the `rtc_transports` capability, the client MUST send an error
+response (as required currently by the capabilities system for widgets).
+
+Upon reception of the action, the hosting client should call **GET** `/_matrix/client/v1/rtc/transports`
+and forward the response body verbatim to the widget under the `response` field.
+
+**Success Response**
+```json
+{
+   "api":"fromWidget",
+   "widgetId":"widget-1234",
+   "requestId":"req-abc",
+   "action":"get_rtc_transports",
+   "data":{},
+   "response":{
+      "rtc_transports":[
+         {
+            "type":"livekit",
+            "livekit_service_url":"https://livekit-jwt.example.com"
+         }
+      ]
+   }
+}
+```
+
+The `rtc_transports` field follows the same format as
+[MSC4143](https://github.com/matrix-org/matrix-spec-proposals/pull/4143), that is:
+
+- `rtc_transports` (required, array): Array of objects describing the transports the homeserver supports.
+    - `type`: (required, string): The globally unique transport identifier. MUST follow the Common
+      Namespaced Identifier Grammar but without the namespacing requirements.
+    - Optionally includes further properties specific to the transport type. The concrete properties are
+      defined by the transport's specification.
+
+
+**Error Response**
+```json
+{
+   "api":"fromWidget",
+   "widgetId":"widget-1234",
+   "requestId":"req-abc",
+   "action":"get_rtc_transports",
+   "data":{},
+   "response":{
+      "error": { "message": "Missing capability" }
+   }
+}
+```
+
+The `error` envelope follows the standard widget API error format. Two error cases are possible:
+
+- **Missing capability**: the widget was not approved for the `rtc_transports` capability. The client MUST
+  reject the request without calling the endpoint.
+- **Upstream failure**: the delegated **GET** `/_matrix/client/v1/rtc/transports` call fails (the
+  homeserver returns an error, does not implement the endpoint, or is unreachable). The client SHOULD
+  surface the homeserver's `errcode` and message in the `error` envelope where available, so the widget
+  can distinguish a transient failure from an unsupported homeserver.
+
+## Potential issues
+
+**Staleness**. This is a one-shot fetch with no push/refresh (unlike MSC3846's watch_turn_servers). If
+infrastructure rotates, the widget must re-request. This is intentional: RTC transports are quite stable.
+
+## Alternatives
+
+Instead of adding a new capability, maybe the `get_rtc_transports` could be granted automatically if the
+widget is allowed to send rtc member events. There are no other examples of such mechanism, so we choose
+to keep the "one action ↔ one capability". If needed the client consent policy could merge several
+capability in a single check for users.
+
+Offer a generic `do_authenticated_api_call` action where widget could call any path via the host. This
+would create a more complex consent from the user point of view ("allow widget to make calls to
+`this/path` on your behalf"). Also there are precedents related to VOIP that had more high level APIs,
+like [MSC3846](https://github.com/matrix-org/matrix-spec-proposals/pull/3846) TurnServers.
+
+## Security considerations
+
+- The widget never sees the access token — the client makes the authenticated call and returns only the
+  endpoint body.
+
+## Unstable prefix
+
+While this MSC is not yet included in the spec, implementations should use
+`org.matrix.msc4515.rtc_transports` in place of the `rtc_transports` capability identifier, and
+`org.matrix.msc4515.get_rtc_transports` in place of the `get_rtc_transports` action name. Clients and
+widgets should only call or support these actions if a widget API version of `org.matrix.msc4515` is
+advertised.
+
+## Dependencies
+
+This MSC builds on [MSC4143](https://github.com/matrix-org/matrix-spec-proposals/pull/4143) (which at the
+time of writing have not yet been accepted into the spec).

--- a/proposals/4515-rtc-transports-widget-action.md
+++ b/proposals/4515-rtc-transports-widget-action.md
@@ -11,8 +11,8 @@ action to get the information by delegating to the client.
 
 ## Proposal
 
-The widget API is extended with one new interface to access the discovery of rtc transports. The user must
-manually approve the `rtc_transports` capability before the action can be used.
+The widget API is extended with one new interface to access the discovery of RTC transports. The client must
+approve the `rtc_transports` capability before the action can be used.
 
 To trigger the action to get the configuration, widgets will use a new fromWidget request with the action
 `get_rtc_transports` which takes the following shape:

--- a/proposals/4515-rtc-transports-widget-action.md
+++ b/proposals/4515-rtc-transports-widget-action.md
@@ -1,17 +1,18 @@
 # MSC4515: RTC Transports discovery for widgets
 
 Widgets embedded in a room may need to know which real-time communication (RTC) backends the homeserver
-offers, for example to join a call.
-[MSC4143](https://github.com/matrix-org/matrix-spec-proposals/pull/4143) Matrix RTC offers a way for clients
-to discover the available transports through a new authenticated Client-Server endpoint, **GET**
-`/_matrix/client/v1/rtc/transports`.
+offers in order to join MatrixRTC sessions
+([MSC4143](https://github.com/matrix-org/matrix-spec-proposals/pull/4143)).
+[MSC4519: MatrixRTC Transports Registry](https://github.com/matrix-org/matrix-spec-proposals/pull/4519)
+offers a way for clients to discover the available transports through a new authenticated
+Client-Server endpoint, **GET** `/_matrix/client/v1/rtc/transports`.
 
 Given that this new endpoint is authenticated, widgets cannot access it directly: they need a new widget
 action to get the information by delegating to the client.
 
 ## Proposal
 
-The widget API is extended with one new interface to access the discovery of RTC transports. The client must
+The widget API is extended with one new action to access the discovery of RTC transports. The client must
 approve the `rtc_transports` capability before the action can be used.
 
 To trigger the action to get the configuration, widgets will use a new fromWidget request with the action
@@ -30,7 +31,7 @@ To trigger the action to get the configuration, widgets will use a new fromWidge
 If the widget did not get approved for the `rtc_transports` capability, the client MUST send an error
 response (as required currently by the capabilities system for widgets).
 
-Upon reception of the action, the hosting client should call **GET** `/_matrix/client/v1/rtc/transports`
+Upon receipt of the action, the hosting client should call **GET** `/_matrix/client/v1/rtc/transports`
 and forward the response body verbatim to the widget under the `response` field.
 
 **Success Response**
@@ -53,13 +54,14 @@ and forward the response body verbatim to the widget under the `response` field.
 ```
 
 The `rtc_transports` field follows the same format as
-[MSC4143](https://github.com/matrix-org/matrix-spec-proposals/pull/4143), that is:
+[MSC4519](https://github.com/matrix-org/matrix-spec-proposals/pull/4519), that is:
 
 - `rtc_transports` (required, array): Array of objects describing the transports the homeserver supports.
-    - `type`: (required, string): The globally unique transport identifier. MUST follow the Common
-      Namespaced Identifier Grammar but without the namespacing requirements.
+    - `type`: (required, string): The globally unique transport identifier. MUST be an
+      [Opaque Identifier](https://spec.matrix.org/v1.19/appendices/#opaque-identifiers) registered
+      in the MatrixRTC Transports Registry.
     - Optionally includes further properties specific to the transport type. The concrete properties are
-      defined by the transport's specification.
+      defined by the transport's registered specification.
 
 
 **Error Response**
@@ -87,13 +89,14 @@ The `error` envelope follows the standard widget API error format. At least two 
 
 ## Potential issues
 
-**Staleness**. This is a one-shot fetch with no push/refresh (unlike MSC3846's watch_turn_servers). If
+**Staleness**. This is a one-shot fetch with no push/refresh (unlike
+[MSC3846](https://github.com/matrix-org/matrix-spec-proposals/pull/3846)'s watch_turn_servers). If
 infrastructure rotates, the widget must re-request. This is intentional: RTC transports are quite stable.
 
 ## Alternatives
 
 Instead of adding a new capability, maybe the `get_rtc_transports` could be granted automatically if the
-widget is allowed to send rtc member events. There are no other examples of such mechanism, so we choose
+widget is allowed to send RTC member events. There are no other examples of such mechanism, so we choose
 to keep the "one action ↔ one capability". If needed the client consent policy could merge several
 capability in a single check for users.
 

--- a/proposals/4515-rtc-transports-widget-action.md
+++ b/proposals/4515-rtc-transports-widget-action.md
@@ -76,7 +76,7 @@ The `rtc_transports` field follows the same format as
 }
 ```
 
-The `error` envelope follows the standard widget API error format. Two error cases are possible:
+The `error` envelope follows the standard widget API error format. At least two error cases are possible:
 
 - **Missing capability**: the widget was not approved for the `rtc_transports` capability. The client MUST
   reject the request without calling the endpoint.

--- a/proposals/4515-rtc-transports-widget-action.md
+++ b/proposals/4515-rtc-transports-widget-action.md
@@ -120,5 +120,7 @@ advertised.
 
 ## Dependencies
 
-This MSC builds on [MSC4143](https://github.com/matrix-org/matrix-spec-proposals/pull/4143) (which at the
-time of writing have not yet been accepted into the spec).
+This MSC builds on [MSC4519](https://github.com/matrix-org/matrix-spec-proposals/pull/4519) (which at the
+time of writing has not yet been accepted into the spec).
+
+Also, in practice, widgets should be formally included in the spec before this MSC gets included.


### PR DESCRIPTION
[Rendered](https://github.com/BillCarsonFr/matrix-doc/blob/valere/rtc/widget_action_rtc_transport/proposals/4515-rtc-transports-widget-action.md)

Implementations:
 - Widget API https://github.com/matrix-org/matrix-widget-api/pull/165
 - matrix-js-sdk https://github.com/matrix-org/matrix-js-sdk/pull/5444
 - rust sdk https://github.com/matrix-org/matrix-rust-sdk/pull/6791
 - Clients:
     - EW https://github.com/element-hq/element-web/pull/34393
     - Gomuks https://github.com/gomuks/gomuks/pull/737 (with https://github.com/matrix-org/matrix-widget-api/pull/165)
 - Widget (using):
     - EC https://github.com/element-hq/element-call/pull/4135

