### PR TITLE
MSC4522: Username colors

### DIFF
--- a/proposals/4522-username-colors.md
+++ b/proposals/4522-username-colors.md
@@ -20,13 +20,9 @@ For standardization:
 If a custom color is wished to be set for an ID of a PMP it may be set through a `m.colors` field within the 
 `m.per_message_profile` of the message
 
-  The `m.colors` and `color` fields represent arrays of objects for the color. Each object of the array
-should contain the color that is to be displayed and may contain a `background` that it is meant to 
-represent the ideal background the `color` should be displayed over. The background SHOULD NOT be 
-displayed but should only serve as a way for the client to determine which color best fits the background 
-it is displayed against. 
-  The `m.colors` array and color arrays MUST have at most one object that has no background color that SHOULD
-serve as a fallback.
+  The `m.colors` and `color` fields represent an object that contains the colors that may be choosen depending
+on the active theme of the client. The light_color represents the color that is lighter, and dark_color the color that is darker,
+so a light_color should ideally be used when the user has a dark theme and vice versa.
 
 The field within the extended profile can be for example:
 ```json
@@ -35,12 +31,10 @@ The field within the extended profile can be for example:
   "displayname": "Shea Butter",
   "m.banner_url": "mxc://matrix.org/example_banner",
   "m.tz": "Europe/Troll",
-  "m.colors": [
-    { "color": "#ffd9f5", "background": "#000000" },
-    { "color": "#440000", "background": "#fff" },
-    { "color": "#f0f", "background": "#888" },
-    { "color": "#ff0000" }
-  ]
+  "m.colors": {
+    "light_color": "#ffd9f5",
+    "dark_color": "#440000" 
+  }
 }
 ```
 
@@ -50,9 +44,10 @@ The room state `m.room.member` may be updated to for example:
   "membership": "join",
   "displayname": "User",
   "avatar_url": "mxc://example.com/code",
-  "m.colors": [
-    {"color": "#ff0", "background": "000"}
-  ]
+  "m.colors": {
+    "light_color": "#f00",
+    "dark_color": "#400" 
+  }
 }
 ```
 
@@ -63,17 +58,17 @@ The room state `m.powerlevels_style` represents a potential override, and an arr
     "powerlevels": [
       {
         "powerlevel": 51,
-        "colors": [
-          { "color": "#00f", "background": "#818181" },
-          { "color": "#88f", "background": "#808080" }
-        ]
+        "colors": {
+          "light_color": "#f00",
+          "dark_color": "#400" 
+        }
       },
       {
         "powerlevel": 1,
-        "colors": [
-          { "color": "#000", "background": "#ffffff" },
-          { "color": "#fff", "background": "#000000" }
-        ]
+        "colors": {
+          "light_color": "#f8f",
+          "dark_color": "#404" 
+        }
       }
     ]
   },
@@ -86,10 +81,10 @@ The `m.colors` for PMPs may look for example:
   "displayname": "Nough",
   "avatar_url": "mxc://example.com/example_url",
   "has_fallback": true,
-  "m.colors": [
-    { "color": "#f0f", "background": "#818181" },
-    { "color": "#88f", "background": "#808080" }
-  ]
+  "m.colors": {
+    "light_color": "#82F2A3",
+    "dark_color": "#11403A" 
+  }
 },
 ```
 
@@ -97,26 +92,26 @@ The `m.colors` for PMPs may look for example:
 to the other colors in order to reduce ambiguity between the moderators of a community and its participants,
 but if it is missing clients should consider that as being set to false.
 
-  Every `color` and `background` field must be a hex color for consistency.
+  The color fields must be a hex color for consistency.
 
-  The order of the color values should be: PMP color, per-room color, 
-account profile color, powerlevel color, default fallback that a client SHOULD have. This order may be
-overridden for powerlevels to take precedence above every other color however.
+  The order of the color values should be: PMP color, per-room color, account profile color, 
+powerlevel color, default fallback that a client SHOULD have. This order may be overridden 
+for powerlevels to take precedence above every other color.
 
 ## Potential issues
 
 A user may choose to set their per-room or per account color to match one of a modertator of a room, but this
 may be mitigated by setting `override_other_colors` to true if needed.
 
-A user may choose to set the color and background within one item to the same value but this may be mitigated
-by clients by removing these values from the pool of potential colors to choose from.
+A user may choose to set the color that has poor visibility to the background but that may be mitigated by
+either choosing the color for the opposite theme if it fits better or refusing both and going one step lower
+whenever that is detected (ie so it would ignore the PMP color and use the per-room color)
 
 ## Alternatives
 
-One alternative is setting only one hex value for the color but that was dismissed as that would force clients
-to either fully dismiss the color option of an individual when using a color that clashes with the background it
-is set over or display a color that has poor visibility, and does not offer an alternative color that the user 
-might prefer instead.
+One alternative is setting only one hex value for the color but that was dismissed as it reduces the pool of
+potential colors that a client might have to choose from when there is poor visiblity resulting in a less
+personalized experience.
 
 ## Security considerations
 

--- a/proposals/4522-username-colors.md
+++ b/proposals/4522-username-colors.md
@@ -13,16 +13,15 @@ that could be specific to a room, a powerlevel, or PMP
 Color selection should have a unified cross platform solution in order to best represent every case.
 
 For standardization:
- - per-account colors, profiles may have an optional `m.colors` field object relying on [MSC4133](https://github.com/matrix-org/matrix-spec-proposals/pull/4133).
- - per-room colors may be set through a `m.colors` field within the `m.room.member` state event
- - per-powerlevel colors may be set through a `colors` field within a new `m.powerlevels_style` room state object
+ - per-account colors, profiles may have an optional `m.color` field object relying on [MSC4133](https://github.com/matrix-org/matrix-spec-proposals/pull/4133).
+ - per-room colors may be set through a `m.color` field within the `m.room.member` state event
+ - per-powerlevel colors may be set through a `color` field within a new `m.powerlevels_style` room state object
 
-If a custom color is wished to be set for an ID of a PMP it may be set through a `m.colors` field within the 
+If a custom color is wished to be set for an ID of a PMP it may be set through a `m.color` field within the 
 `m.per_message_profile` of the message
 
-  The `m.colors` and `color` fields represent an object that contains the colors that may be choosen depending
-on the active theme of the client. The light_color represents the color that is lighter, and dark_color the color that is darker,
-so a light_color should ideally be used when the user has a dark theme and vice versa.
+  The `m.color` and `color` fields represent the theme that the color is to be displayed over, 
+the `on_dark` value represents the color that should be used when the client uses a dark theme and `on_light` on light themes.
 
 The field within the extended profile can be for example:
 ```json
@@ -31,9 +30,9 @@ The field within the extended profile can be for example:
   "displayname": "Shea Butter",
   "m.banner_url": "mxc://matrix.org/example_banner",
   "m.tz": "Europe/Troll",
-  "m.colors": {
-    "light_color": "#ffd9f5",
-    "dark_color": "#440000" 
+  "m.color": {
+    "on_dark": "#ffd9f5",
+    "on_light": "#440000" 
   }
 }
 ```
@@ -44,9 +43,9 @@ The room state `m.room.member` may be updated to for example:
   "membership": "join",
   "displayname": "User",
   "avatar_url": "mxc://example.com/code",
-  "m.colors": {
-    "light_color": "#f00",
-    "dark_color": "#400" 
+  "m.color": {
+    "on_dark": "#f00",
+    "on_light": "#400" 
   }
 }
 ```
@@ -58,32 +57,32 @@ The room state `m.powerlevels_style` represents a potential override, and an arr
     "powerlevels": [
       {
         "powerlevel": 51,
-        "colors": {
+        "color": {
           "light_color": "#f00",
           "dark_color": "#400" 
         }
       },
       {
         "powerlevel": 1,
-        "colors": {
-          "light_color": "#f8f",
-          "dark_color": "#404" 
+        "color": {
+          "on_dark": "#f8f",
+          "on_light": "#404" 
         }
       }
     ]
   },
 ```
 
-The `m.colors` for PMPs may look for example:
+The `m.color` for PMPs may look for example:
 ```json
 "m.per_message_profile": {
   "id": "nough",
   "displayname": "Nough",
   "avatar_url": "mxc://example.com/example_url",
   "has_fallback": true,
-  "m.colors": {
-    "light_color": "#82F2A3",
-    "dark_color": "#11403A" 
+  "m.color": {
+    "on_dark": "#82F2A3",
+    "on_light": "#11403A" 
   }
 },
 ```
@@ -121,7 +120,7 @@ There are no new security issues introduced by this proposal
 
 ## Unstable prefix
 
-`eu.she-a.colors` should be used instead of `m.colors`       
+`eu.she-a.color` should be used instead of `m.color`       
 
 `eu.she-a.powerlevels_style` should be used instead of `m.powerlevels_style`
 

--- a/proposals/4522-username-colors.md
+++ b/proposals/4522-username-colors.md
@@ -5,7 +5,7 @@ and with the advent of extensible events clients have started to create unique i
 that are not cross compatible.
 
 There needs to be a way to tell a client that your name should have a specific color, ideally one 
-that could be specific to a room, a role, or PMP
+that could be specific to a room, a powerlevel, or PMP
 
 
 ## Proposal
@@ -14,12 +14,11 @@ Color selection should have a unified cross platform solution in order to best r
 
 For standardization:
  - per-account colors, profiles may have an optional `m.colors` field object relying on [MSC4133](https://github.com/matrix-org/matrix-spec-proposals/pull/4133).
- - per-room colors may be set through a `m.users_colors` room state object
- - per-role colors may be set through a `colors` field within a new `m.roles_style` room state object
+ - per-room colors may be set through a `m.colors` field within the `m.room.member` state event
+ - per-powerlevel colors may be set through a `colors` field within a new `m.powerlevels_style` room state object
 
-If a custom color is wished to be set for an ID of a PMP, that may be done as follows:
- - per-message colors may be set through a `m.colors` field within the `m.per_message_profile` of the message
- - per-room colors may be set through the same means as the account ones, but prefixed with the id (eg. @foo@bar:example.org )
+If a custom color is wished to be set for an ID of a PMP it may be set through a `m.colors` field within the 
+`m.per_message_profile` of the message
 
   The `m.colors` and `color` fields represent arrays of objects for the color. Each object of the array
 should contain the color that is to be displayed and may contain a `background` that it is meant to 
@@ -45,28 +44,19 @@ The field within the extended profile can be for example:
 }
 ```
 
-The room state `m.users_colors` is an array of objects with the name and colors array as for example:
+The room state `m.room.member` may be updated to for example:
 ```json
 {
-    "m.users": [
-      {
-        "userId": "@foo:example.com",
-        "colors": [
-          { "color": "#00f", "background": "#818181" },
-          { "color": "#88f", "background": "#808080" }
-        ]
-      },
-      {
-        "userId": "@bar@foo:example.com",
-        "colors": [
-          { "color": "#f00" }
-        ]
-      }
-    ]
-  },
+  "membership": "join",
+  "displayname": "User",
+  "avatar_url": "mxc://example.com/code",
+  "m.colors": [
+    {"color": "#ff0", "background": "000"}
+  ]
+}
 ```
 
-The room state `m.roles_style` represents an array of objects with powerlevel, an optional override, and a colors array as for example:
+The room state `m.powerlevels_style` represents a potential override, and an array of objects with powerlevels with and a colors array as for example:
 ```json
 {
     "override_other_colors": false,
@@ -91,7 +81,7 @@ The room state `m.roles_style` represents an array of objects with powerlevel, a
 
 The `m.colors` for PMPs may look for example:
 ```json
-"com.beeper.per_message_profile": {
+"m.per_message_profile": {
   "id": "nough",
   "displayname": "Nough",
   "avatar_url": "mxc://example.com/example_url",
@@ -103,21 +93,20 @@ The `m.colors` for PMPs may look for example:
 },
 ```
 
-  The `override_other_colors` key may be set in order to define whether or not the roles of a room should take precedence 
+  The `override_other_colors` key may be set in order to define whether or not the powerlevels of a room should take precedence 
 to the other colors in order to reduce ambiguity between the moderators of a community and its participants,
 but if it is missing clients should consider that as being set to false.
 
   Every `color` and `background` field must be a hex color for consistency.
 
-  The order of the color values should be: PMP room color, PMP message color, account room color, 
-account profile color, role color, default fallback that a client SHOULD have. This order may be
-overridden for roles to take precedence above every other color however.
+  The order of the color values should be: PMP color, per-room color, 
+account profile color, powerlevel color, default fallback that a client SHOULD have. This order may be
+overridden for powerlevels to take precedence above every other color however.
 
 ## Potential issues
 
 A user may choose to set their per-room or per account color to match one of a modertator of a room, but this
-may be mitigated by setting `override_other_colors` to true if needed or by having the `m.user_colors` restricted
-above the user's powerlevel and setting their color to a different one.
+may be mitigated by setting `override_other_colors` to true if needed.
 
 A user may choose to set the color and background within one item to the same value but this may be mitigated
 by clients by removing these values from the pool of potential colors to choose from.
@@ -139,9 +128,7 @@ There are no new security issues introduced by this proposal
 
 `eu.she-a.colors` should be used instead of `m.colors`       
 
-`eu.she-a.users_colors` should be used instead of `m.users_colors`      
-
-`eu.she-a.roles_style` should be used instead of `m.roles_style`
+`eu.she-a.powerlevels_style` should be used instead of `m.powerlevels_style`
 
 
 ## Dependencies

--- a/proposals/4522-username-colors.md
+++ b/proposals/4522-username-colors.md
@@ -16,11 +16,11 @@ For standardization:
  - per-account colors, profiles may have an optional `m.color_preference` field object relying on [MSC4133](https://github.com/matrix-org/matrix-spec-proposals/pull/4133).
  - per-room colors may be set through a `m.color_preference` field within the `m.room.member` state event
 
-If a custom color is wished to be set for an ID of a PMP it may be set through a `m.color_preference` field within the 
+If a custom color is wished to be set for an ID of a Per-Message Profiles (PMP) it may be set through a `m.color_preference` field within the 
 `m.per_message_profile` of the message
 
   The `m.color_preference` object contains 2 fields for the potential colors to be displayed but are named by the theme kind that the name/message is to be displayed over, 
-the `on_dark` value represents the color that should be used when the client uses a dark theme (ie the color itself shoulds be bright) and `on_light` on light themes (ie the color itself should be dark).
+the `on_dark` value represents the color that should be used when the client uses a dark theme (ie the color itself should be bright) and `on_light` on light themes (ie the color itself should be dark).
 
 The field within the extended profile can be for example:
 ```json
@@ -72,11 +72,11 @@ The `m.color_preference` for PMPs may look for example:
 
   The color fields must be a hex color (#RGB or #RRGGBB) for consistency and ease of use for the end-user.
 
-  A client may adjust the final displayed color to accomodate theming, technical and accessibility requirements.
+  A client may adjust the final displayed color to accommodate theming, technical and accessibility requirements.
 However, The client should preserve the hue where possible, and may alter the Saturation/Chroma/Lightness.
   
-  For example a terminal-based client might have a very limited color pallete and might end up compressing 
-all the color options set by the users to a 8-32 selection and that client could still be compliant with the 
+  For example a terminal-based client might have a very limited color palette and might end up compressing 
+all the color options set by the users to an 8-32 selection and that client could still be compliant with the 
 msc as it would be within its limitations.
 
 ## Potential issues
@@ -85,14 +85,17 @@ msc as it would be within its limitations.
 either choosing the color for the opposite theme if it fits better or refusing both and going one step lower
 whenever that is detected (ie so it would ignore the PMP color and use the per-room color)
 
-  A user may choose to mimique the color of a moderator of a room for impersonation reasons, but this may be easily detected as a 
+  A user may choose to mimic the color of a moderator of a room for impersonation reasons, but this may be easily detected as a 
 per room setting and is mitigated by [the name disambiguation algorithm](https://spec.matrix.org/latest/client-server-api/#calculating-the-display-name-for-a-user)
 
 ## Alternatives
 
 One alternative is setting only one hex value for the color but that was dismissed as it reduces the pool of
-potential colors that a client might have to choose from when there is poor visiblity resulting in a less
-personalized experience.
+potential colors that a client might have to choose from when there is poor visibility resulting in a less
+personalized experience, or makes them use colors that are less relevant to the user's taste in coloring, such
+as completely ignoring the lightness for a dark color making it light, which would result in a fully different color
+(i.e. a color that has chosen navy blue because they are using a light theme might have no wish to have a baby blue color for dark theme usecases 
+and a user that has chosen an orange color would not want a brown color when using a light theme).
 
 ## Security considerations
 

--- a/proposals/4522-username-colors.md
+++ b/proposals/4522-username-colors.md
@@ -67,7 +67,7 @@ The `m.color_preference` for PMPs may look for example:
    - PMP color, 
    - per-room color, 
    - account profile color, 
-   - [MSC3949](https://github.com/ajbura/matrix-spec-proposals/blob/power-level-tag/proposals/3949-power-level-tag.md) colors if the client implements this MSC, 
+   - [MSC3949](https://github.com/matrix-org/matrix-spec-proposals/pull/3949) colors if the client implements this MSC, 
    - default fallback that a client SHOULD have
 
   The color fields must be a hex color (#RGB or #RRGGBB) for consistency and ease of use for the end-user.
@@ -96,8 +96,22 @@ personalized experience. Or, makes them use colors that are less relevant to the
 
  For example this could result in completely ignoring the lightness for a dark color making it light, which would result in a fully different color
 
-  (i.e. a user that has chosen navy blue because they are using a light theme might have no wish to have a baby blue color for dark theme usecases 
-and a user that has chosen an orange color would not want a brown color when using a light theme).
+  (i.e. a user that has chosen navy blue because they are using a light theme might have no wish to have a baby blue color for dark theme usecases, a user that has chosen an orange color might not want a brown color when using a light theme, a user selecting a pastel pink name in a dark theme might not want a murky pink in a light theme).
+
+  Another potential change would be the usage of a standard different from 24bit RGB, and while there are substantial benefits to many other standards 
+in their respective usecases, 24bit RGB is the most interoperable color standard, being supported by ANSI for terminal clients, natively by browsers, and by
+most platforms that support other color standards. So, by choosing a color standard other than RGBG (or CYMK but, no, CYMK is not an option for this), many 
+clients would have to devise conversion algorithms for their platform or implement entire color libraries for a very limited scope.            
+  Another alternative in this situation is to not set a color standard but that would result in applications needing to understand dozens of standards only for one
+setting, which would increase the cost unreasonably, requiring either to be able to convert between every existant standard and the client's prefered one or to 
+be able to process directly every color standard
+
+  Lastly, the standard could allow a user to set an arbitrary amount of prefered colors in an array that a client might choose from in the form:
+  ```json
+  m.preferred_colors = ["#ffd9f5", "#440000", "#460333"]
+  ```
+  And while that method would be a very pleasant and elegant way to set colors, it would present an increased cost of implementation, allowing arbitrarily long lists of 
+colors across 3 of the stages of the order of precedence.
 
 ## Security considerations
 
@@ -113,4 +127,4 @@ This MSC builds on:
  - [MSC4133](https://github.com/matrix-org/matrix-spec-proposals/pull/4133) for per-account colors,
  - [MSC4144](https://github.com/matrix-org/matrix-spec-proposals/pull/4144) for the per-message-profile object, 
 
-And wishes that more clients would implement [MSC3949](https://github.com/ajbura/matrix-spec-proposals/blob/power-level-tag/proposals/3949-power-level-tag.md) or some other standard powerlevel specific customization
+And wishes that more clients would implement [MSC3949](https://github.com/matrix-org/matrix-spec-proposals/pull/3949) or some other standard powerlevel specific customization

--- a/proposals/4522-username-colors.md
+++ b/proposals/4522-username-colors.md
@@ -1,0 +1,149 @@
+# MSC4522: Username colors
+
+For a long while users have wanted a way to declare what color their name should be displayed with, 
+and with the advent of extensible events clients have started to create unique implementations for users
+that are not cross compatible.
+
+There needs to be a way to tell a client that your name should have a specific color, ideally one 
+that could be specific to a room, a role, or PMP
+
+
+## Proposal
+
+Color selection should have a unified cross platform solution in order to best represent every case.
+
+For standardization:
+ - per-account colors, profiles may have an optional `m.colors` field object relying on [MSC4133](https://github.com/matrix-org/matrix-spec-proposals/pull/4133).
+ - per-room colors may be set through a `m.users_colors` room state object
+ - per-role colors may be set through a `colors` field within a new `m.roles_style` room state object
+
+If a custom color is wished to be set for an ID of a PMP, that may be done as follows:
+ - per-message colors may be set through a `m.colors` field within the `m.per_message_profile` of the message
+ - per-room colors may be set through the same means as the account ones, but prefixed with the id (eg. @foo@bar:example.org )
+
+  The `m.colors` and `color` fields represent arrays of objects for the color. Each object of the array
+should contain the color that is to be displayed and may contain a `background` that it is meant to 
+represent the ideal background the `color` should be displayed over. The background SHOULD NOT be 
+displayed but should only serve as a way for the client to determine which color best fits the background 
+it is displayed against. 
+  The `m.colors` array and color arrays MUST have at most one object that has no background color that SHOULD
+serve as a fallback.
+
+The field within the extended profile can be for example:
+```json
+{
+  "avatar_url": "mxc://matrix.org/example",
+  "displayname": "Shea Butter",
+  "m.banner_url": "mxc://matrix.org/example_banner",
+  "m.tz": "Europe/Troll",
+  "m.colors": [
+    { "color": "#ffd9f5", "background": "#000000" },
+    { "color": "#440000", "background": "#fff" },
+    { "color": "#f0f", "background": "#888" },
+    { "color": "#ff0000" }
+  ]
+}
+```
+
+The room state `m.users_colors` is an array of objects with the name and colors array as for example:
+```json
+{
+    "m.users": [
+      {
+        "userId": "@foo:example.com",
+        "colors": [
+          { "color": "#00f", "background": "#818181" },
+          { "color": "#88f", "background": "#808080" }
+        ]
+      },
+      {
+        "userId": "@bar@foo:example.com",
+        "colors": [
+          { "color": "#f00" }
+        ]
+      }
+    ]
+  },
+```
+
+The room state `m.roles_style` represents an array of objects with powerlevel, an optional override, and a colors array as for example:
+```json
+{
+    "override_other_colors": false,
+    "powerlevels": [
+      {
+        "powerlevel": 51,
+        "colors": [
+          { "color": "#00f", "background": "#818181" },
+          { "color": "#88f", "background": "#808080" }
+        ]
+      },
+      {
+        "powerlevel": 1,
+        "colors": [
+          { "color": "#000", "background": "#ffffff" },
+          { "color": "#fff", "background": "#000000" }
+        ]
+      }
+    ]
+  },
+```
+
+The room state `m.colors` for PMPs may look for example for example:
+```json
+"com.beeper.per_message_profile": {
+  "id": "nough",
+  "displayname": "Nough",
+  "avatar_url": "mxc://example.com/example_url",
+  "has_fallback": true,
+  "colors": [
+    { "color": "#f0f", "background": "#818181" },
+    { "color": "#88f", "background": "#808080" }
+  ]
+},
+```
+
+  The `override_other_colors` key may be set in order to define whether or not the roles of a room should take precedence 
+to the other colors in order to reduce ambiguity between the moderators of a community and its participants,
+but if it is missing clients should consider that as being set to false.
+
+  Every `color` and `background` field must be a hex color for consistency.
+
+  The order of the color values should be: PMP room color, PMP message color, account room color, 
+account profile color, role color, default fallback that a client SHOULD have. This order may be
+overridden for roles to take precedence above every other color however.
+
+## Potential issues
+
+A user may choose to set their per-room or per account color to match one of a modertator of a room, but this
+may be mitigated by setting `override_other_colors` to true if needed or by having the `m.user_colors` restricted
+above the user's powerlevel and setting their color to a different one.
+
+A user may choose to set the color and background within one item to the same value but this may be mitigated
+by clients easily to remove these values from the pool of potential colors to choose from.
+
+## Alternatives
+
+One alternative is setting only one hex value for the color but that was dismissed as that would force clients
+to either fully dismiss the color option of an individual when using a color that clashes with the background it
+is set over or display a color that has poor visibility, and does not offer an alternative color that the user 
+might prefer instead.
+
+## Security considerations
+
+**All proposals must now have this section, even if it is to say there are no security issues.**
+
+There are no new security issues introduced by this proposal
+
+## Unstable prefix
+
+`eu.she-a.colors` should be used instead of `m.colors`       
+
+`eu.she-a.users_colors` should be used instead of `m.users_colors`      
+
+`eu.she-a.roles_style` should be used instead of `m.roles_style`
+
+
+## Dependencies
+
+This MSC builds on [MSC4133](https://github.com/matrix-org/matrix-spec-proposals/pull/4133) for per-account colors and [MSC4144](https://github.com/matrix-org/matrix-spec-proposals/pull/4144) for the per-message-profile object

--- a/proposals/4522-username-colors.md
+++ b/proposals/4522-username-colors.md
@@ -86,7 +86,7 @@ The `m.colors` for PMPs may look for example:
   "displayname": "Nough",
   "avatar_url": "mxc://example.com/example_url",
   "has_fallback": true,
-  "colors": [
+  "m.colors": [
     { "color": "#f0f", "background": "#818181" },
     { "color": "#88f", "background": "#808080" }
   ]

--- a/proposals/4522-username-colors.md
+++ b/proposals/4522-username-colors.md
@@ -90,11 +90,13 @@ per room setting and is mitigated by [the name disambiguation algorithm](https:/
 
 ## Alternatives
 
-One alternative is setting only one hex value for the color but that was dismissed as it reduces the pool of
-potential colors that a client might have to choose from when there is poor visibility resulting in a less
-personalized experience, or makes them use colors that are less relevant to the user's taste in coloring, such
-as completely ignoring the lightness for a dark color making it light, which would result in a fully different color
-(i.e. a color that has chosen navy blue because they are using a light theme might have no wish to have a baby blue color for dark theme usecases 
+  One alternative is setting only one hex value for the color but that was dismissed as it reduces the pool of
+potential colors, a client might have to choose from when there is poor visibility resulting in a less
+personalized experience. Or, makes them use colors that are less relevant to the user's taste in coloring
+
+ For example this could result in completely ignoring the lightness for a dark color making it light, which would result in a fully different color
+
+  (i.e. a user that has chosen navy blue because they are using a light theme might have no wish to have a baby blue color for dark theme usecases 
 and a user that has chosen an orange color would not want a brown color when using a light theme).
 
 ## Security considerations

--- a/proposals/4522-username-colors.md
+++ b/proposals/4522-username-colors.md
@@ -58,8 +58,8 @@ The room state `m.powerlevels_style` represents a potential override, and an arr
       {
         "powerlevel": 51,
         "color": {
-          "light_color": "#f00",
-          "dark_color": "#400" 
+          "on_dark": "#f00",
+          "on_light": "#400" 
         }
       },
       {

--- a/proposals/4522-username-colors.md
+++ b/proposals/4522-username-colors.md
@@ -1,11 +1,11 @@
 # MSC4522: Username colors
 
-For a long while users have wanted a way to declare what color their name should be displayed with, 
+For a long while users have wanted a way to declare what color their name/message should be displayed with, 
 and with the advent of extensible events clients have started to create unique implementations for users
 that are not cross compatible.
 
-There needs to be a way to tell a client that your name should have a specific color, ideally one 
-that could be specific to a room, a powerlevel, or PMP
+There needs to be a way to tell a client that your name/messages should have a specific color, ideally one 
+that could be specific to a room
 
 
 ## Proposal
@@ -13,15 +13,14 @@ that could be specific to a room, a powerlevel, or PMP
 Color selection should have a unified cross platform solution in order to best represent every case.
 
 For standardization:
- - per-account colors, profiles may have an optional `m.color` field object relying on [MSC4133](https://github.com/matrix-org/matrix-spec-proposals/pull/4133).
- - per-room colors may be set through a `m.color` field within the `m.room.member` state event
- - per-powerlevel colors may be set through a `color` field within a new `m.powerlevels_style` room state object
+ - per-account colors, profiles may have an optional `m.color_preference` field object relying on [MSC4133](https://github.com/matrix-org/matrix-spec-proposals/pull/4133).
+ - per-room colors may be set through a `m.color_preference` field within the `m.room.member` state event
 
-If a custom color is wished to be set for an ID of a PMP it may be set through a `m.color` field within the 
+If a custom color is wished to be set for an ID of a PMP it may be set through a `m.color_preference` field within the 
 `m.per_message_profile` of the message
 
-  The `m.color` and `color` fields represent the theme that the color is to be displayed over, 
-the `on_dark` value represents the color that should be used when the client uses a dark theme and `on_light` on light themes.
+  The `m.color_preference` object contains 2 fields for the potential colors to be displayed but are named by the theme kind that the name/message is to be displayed over, 
+the `on_dark` value represents the color that should be used when the client uses a dark theme (ie the color itself shoulds be bright) and `on_light` on light themes (ie the color itself should be dark).
 
 The field within the extended profile can be for example:
 ```json
@@ -30,7 +29,7 @@ The field within the extended profile can be for example:
   "displayname": "Shea Butter",
   "m.banner_url": "mxc://matrix.org/example_banner",
   "m.tz": "Europe/Troll",
-  "m.color": {
+  "m.color_preference": {
     "on_dark": "#ffd9f5",
     "on_light": "#440000" 
   }
@@ -43,68 +42,51 @@ The room state `m.room.member` may be updated to for example:
   "membership": "join",
   "displayname": "User",
   "avatar_url": "mxc://example.com/code",
-  "m.color": {
+  "m.color_preference": {
     "on_dark": "#f00",
     "on_light": "#400" 
   }
 }
 ```
 
-The room state `m.powerlevels_style` represents a potential override, and an array of objects with powerlevels with and a colors array as for example:
-```json
-{
-    "override_other_colors": false,
-    "powerlevels": [
-      {
-        "powerlevel": 51,
-        "color": {
-          "on_dark": "#f00",
-          "on_light": "#400" 
-        }
-      },
-      {
-        "powerlevel": 1,
-        "color": {
-          "on_dark": "#f8f",
-          "on_light": "#404" 
-        }
-      }
-    ]
-  },
-```
-
-The `m.color` for PMPs may look for example:
+The `m.color_preference` for PMPs may look for example:
 ```json
 "m.per_message_profile": {
   "id": "nough",
   "displayname": "Nough",
   "avatar_url": "mxc://example.com/example_url",
   "has_fallback": true,
-  "m.color": {
+  "m.color_preference": {
     "on_dark": "#82F2A3",
     "on_light": "#11403A" 
   }
 },
 ```
 
-  The `override_other_colors` key may be set in order to define whether or not the powerlevels of a room should take precedence 
-to the other colors in order to reduce ambiguity between the moderators of a community and its participants,
-but if it is missing clients should consider that as being set to false.
+  The order of precedence for the color values must be: 
+   - PMP color, 
+   - per-room color, 
+   - account profile color, 
+   - [MSC3949](https://github.com/ajbura/matrix-spec-proposals/blob/power-level-tag/proposals/3949-power-level-tag.md) colors if the client implements this MSC, 
+   - default fallback that a client SHOULD have
 
-  The color fields must be a hex color for consistency.
+  The color fields must be a hex color (#RGB or #RRGGBB) for consistency and ease of use for the end-user.
 
-  The order of the color values should be: PMP color, per-room color, account profile color, 
-powerlevel color, default fallback that a client SHOULD have. This order may be overridden 
-for powerlevels to take precedence above every other color.
+  A client may adjust the final displayed color to accomodate theming, technical and accessibility requirements.
+However, The client should preserve the hue where possible, and may alter the Saturation/Chroma/Lightness.
+  
+  For example a terminal-based client might have a very limited color pallete and might end up compressing 
+all the color options set by the users to a 8-32 selection and that client could still be compliant with the 
+msc as it would be within its limitations.
 
 ## Potential issues
 
-A user may choose to set their per-room or per account color to match one of a modertator of a room, but this
-may be mitigated by setting `override_other_colors` to true if needed.
-
-A user may choose to set the color that has poor visibility to the background but that may be mitigated by
+  A user may choose to set the color that has poor visibility to the background but that may be mitigated by
 either choosing the color for the opposite theme if it fits better or refusing both and going one step lower
 whenever that is detected (ie so it would ignore the PMP color and use the per-room color)
+
+  A user may choose to mimique the color of a moderator of a room for impersonation reasons, but this may be easily detected as a 
+per room setting and is mitigated by [the name disambiguation algorithm](https://spec.matrix.org/latest/client-server-api/#calculating-the-display-name-for-a-user)
 
 ## Alternatives
 
@@ -114,17 +96,16 @@ personalized experience.
 
 ## Security considerations
 
-**All proposals must now have this section, even if it is to say there are no security issues.**
-
 There are no new security issues introduced by this proposal
 
 ## Unstable prefix
 
-`eu.she-a.color` should be used instead of `m.color`       
-
-`eu.she-a.powerlevels_style` should be used instead of `m.powerlevels_style`
-
+`eu.she-a.color` should be used instead of `m.color_preference`      
 
 ## Dependencies
 
-This MSC builds on [MSC4133](https://github.com/matrix-org/matrix-spec-proposals/pull/4133) for per-account colors and [MSC4144](https://github.com/matrix-org/matrix-spec-proposals/pull/4144) for the per-message-profile object
+This MSC builds on:
+ - [MSC4133](https://github.com/matrix-org/matrix-spec-proposals/pull/4133) for per-account colors,
+ - [MSC4144](https://github.com/matrix-org/matrix-spec-proposals/pull/4144) for the per-message-profile object, 
+
+And wishes that more clients would implement [MSC3949](https://github.com/ajbura/matrix-spec-proposals/blob/power-level-tag/proposals/3949-power-level-tag.md) or some other standard powerlevel specific customization

--- a/proposals/4522-username-colors.md
+++ b/proposals/4522-username-colors.md
@@ -89,7 +89,7 @@ The room state `m.roles_style` represents an array of objects with powerlevel, a
   },
 ```
 
-The room state `m.colors` for PMPs may look for example for example:
+The `m.colors` for PMPs may look for example:
 ```json
 "com.beeper.per_message_profile": {
   "id": "nough",
@@ -120,7 +120,7 @@ may be mitigated by setting `override_other_colors` to true if needed or by havi
 above the user's powerlevel and setting their color to a different one.
 
 A user may choose to set the color and background within one item to the same value but this may be mitigated
-by clients easily to remove these values from the pool of potential colors to choose from.
+by clients by removing these values from the pool of potential colors to choose from.
 
 ## Alternatives
 


### PR DESCRIPTION
[Rendered](https://github.com/matrix-org/matrix-spec-proposals/blob/106542900bf5862ad5f84dcfc78e8e047ff08939/proposals/4522-username-colors.md)

Implementations:
 - Setting:
   - Sable https://github.com/SableClient/Sable/pull/1526
 - Rendering:
   - Sable https://github.com/SableClient/Sable/pull/1526

Signed-off by: Shea <nu@she-a.eu>