### PR TITLE
Bullet-proof the RTC invite validity conditions

### DIFF
--- a/proposals/4075-rtc-notification-event.md
+++ b/proposals/4075-rtc-notification-event.md
@@ -73,7 +73,8 @@ Clients MUST send both `m.rtc.invite` and `m.rtc.decline` as sticky events as pe
 associated delivery guarantee. The sticky durations of `m.rtc.invite` events, `m.rtc.member` events
 which accept an invite, or `m.rtc.decline` events which decline an invite SHOULD NOT be smaller than
 the invite's `lifetime`. Additionally, clients MUST implement the ephemeral map algorithm as per
-[MSC4354] to construct a state-like store of invite events.
+[MSC4354] to construct a state-like store of invite events. Tracking decline events in a map isn't
+necessary because there is no need to update them after being sent.
 
 [mentions]: https://spec.matrix.org/v1.19/client-server-api/#user-and-room-mentions
 [MSC4354]: https://github.com/matrix-org/matrix-spec-proposals/pull/4354

--- a/proposals/4075-rtc-notification-event.md
+++ b/proposals/4075-rtc-notification-event.md
@@ -316,7 +316,7 @@ In this situation, Alice's smartphone would have ignored the invite, since it wa
 the time, while her laptop would display the invite, because it cannot see Alice's previous join
 event due to it expiring halfway through.
 
-This series of events should be exceedingly rare, but as a mitigation, clients MAY choose to resend
+This series of events should be exceedingly rare, but as a mitigation, clients SHOULD resend
 `m.rtc.member` join events as soon as they receive an invite to the same session, when necessary to
 ensure that their membership will remain sticky throughout the entire lifetime of the invite.
 

--- a/proposals/4075-rtc-notification-event.md
+++ b/proposals/4075-rtc-notification-event.md
@@ -316,8 +316,9 @@ the time, while her laptop would display the invite, because it cannot see Alice
 event due to it expiring halfway through.
 
 This series of events should be exceedingly rare, but as a mitigation, clients SHOULD resend
-`m.rtc.member` join events as soon as they receive an invite to the same session, when necessary to
-ensure that their membership will remain sticky throughout the entire lifetime of the invite.
+`m.rtc.member` join events 2 minutes before they would expire (matching the maximum lifetime of an
+`m.rtc.invite` event) at the latest, to rule out any possibility of it expiring during the lifetime
+of an invite.
 
 ## Alternatives
 

--- a/proposals/4075-rtc-notification-event.md
+++ b/proposals/4075-rtc-notification-event.md
@@ -306,7 +306,7 @@ may later reappear, to the user's surprise, on another device:
 
 1. Alice's laptop loses connection to her homeserver
 1. Later, Alice joins a session from her smartphone
-1. Bob joins the same session and sends an invite asking the whole room to join
+1. Bob then joins the same session and sends an invite asking the whole room to join
 1. During the invite's lifetime:
     1. Alice leaves the session from her smartphone
     1. Alice's original join event expires (ceases to be sticky)

--- a/proposals/4075-rtc-notification-event.md
+++ b/proposals/4075-rtc-notification-event.md
@@ -112,7 +112,7 @@ apply:
 - The invite is the current invite entry in the ephemeral sticky events map for the sender
   and slot and not a withdrawal (that is, an invite event whose `content` is empty except
   for `sticky_key`).
-- An `m.rtc.slot` event with `state_key = slot_id` and `status = "open"` exists in the room
+- An `m.rtc.slot` event with `state_key = slot_id` and `status = "open"` exists in the state of the room
   where the invite was received.
 - The `lifetime`, as measured from `sender_ts`, has not elapsed. If `sender_ts` is more than
   20 seconds ahead of `origin_server_ts`, the `lifetime` SHOULD be measured from `origin_server_ts`

--- a/proposals/4075-rtc-notification-event.md
+++ b/proposals/4075-rtc-notification-event.md
@@ -119,7 +119,8 @@ apply:
   instead. This limits the impact of a malicious user faking `sender_ts` to trigger long-lived
   notifications. Regardless of the basis for measuring, the remaining lifetime MUST be capped
   at 2 minutes.
-- `m.mentions`  either has `room` set to `true` or contains the current user in `user_ids`.
+- `m.mentions` either has `room` set to `true` (and the sender had a sufficient power level at the
+  time of sending to trigger a `room` notification) or contains the current user in `user_ids`.
 - The user is not already joined to the same slot via a corresponding `m.rtc.member` event.
 
 If the invite is valid, the receiving client has three options:

--- a/proposals/4075-rtc-notification-event.md
+++ b/proposals/4075-rtc-notification-event.md
@@ -109,6 +109,7 @@ In line with the expected behaviour of sending clients that was outlined in the 
 a receiving client SHOULD only consider an invite valid as long as all of the following conditions
 apply:
 
+- The `sender` is not the same user as the recipient.
 - The invite is the current invite entry in the ephemeral sticky events map for the sender
   and slot, and is not a withdrawal (that is, an invite event whose `content` is empty except
   for `sticky_key`).

--- a/proposals/4075-rtc-notification-event.md
+++ b/proposals/4075-rtc-notification-event.md
@@ -73,8 +73,7 @@ Clients MUST send both `m.rtc.invite` and `m.rtc.decline` as sticky events as pe
 associated delivery guarantee. The sticky durations of `m.rtc.invite` events, `m.rtc.member` events
 which accept an invite, or `m.rtc.decline` events which decline an invite SHOULD NOT be smaller than
 the invite's `lifetime`. Additionally, clients MUST implement the ephemeral map algorithm as per
-[MSC4354] to construct a state-like store of invite events. Tracking decline events in a map isn't
-necessary because there is no need to update them after being sent.
+[MSC4354] to construct a state-like store of invite events and decline events.
 
 [mentions]: https://spec.matrix.org/v1.19/client-server-api/#user-and-room-mentions
 [MSC4354]: https://github.com/matrix-org/matrix-spec-proposals/pull/4354
@@ -123,11 +122,12 @@ apply:
   at 2 minutes.
 - `m.mentions` either has `room` set to `true` (and the sender had a sufficient power level at the
   time of sending to trigger a `room` notification) or contains the current user in `user_ids`.
-- For any currently sticky `m.rtc.member` event with a membership of `join` that the user has for
-  the same slot, there also exists a currently sticky `m.rtc.member` event with a membership of
-  `leave`, such that the leave event comes *after* the join event but *before* the invite event.[^order]
-- The user does not have any currently sticky `m.rtc.decline` events referencing the
-  `m.rtc.invite` event.
+- The user has no `m.rtc.member` event with a membership of `join` for the slot in the ephemeral
+  sticky events map.
+- If the user has an `m.rtc.member` event with a membership of `leave` for the slot in the ephemeral
+  sticky events map, its `origin_server_ts` is less than the `origin_server_ts` of the invite event.
+- The user has no `m.rtc.decline` event referencing the invite event in the ephemeral sticky events
+  map.
 
 In effect, these conditions mean that when an invite comes in, the receiving client has three
 options:
@@ -301,13 +301,13 @@ This might not be true for future MatrixRTC transports, however.
 
 Intuitively, an invite that is considered invalid on one device ought to stay invalid on *all* of a
 user's devices for the remainder of its lifetime. However, there is an edge case in which an invite
-may later reappear, to the user's surprise, on another device:
+could later reappear, to the user's surprise, on another device:
 
 1. Alice's laptop loses connection to her homeserver
 1. Later, Alice joins a session from her smartphone
 1. Bob then joins the same session and sends an invite asking the whole room to join
 1. During the invite's lifetime:
-    1. Alice leaves the session from her smartphone
+    1. Alice's smartphone *also* loses connection to her homeserver
     1. Alice's original join event expires (ceases to be sticky)
     1. Alice's laptop reestablishes its connection and syncs the invite event
 
@@ -315,7 +315,7 @@ In this situation, Alice's smartphone would have ignored the invite, since it wa
 the time, while her laptop would display the invite, because it cannot see Alice's previous join
 event due to it expiring halfway through.
 
-This series of events should be exceedingly rare, but as a mitigation, clients SHOULD resend
+This series of events should already be quite rare, but as a mitigation, clients SHOULD resend
 `m.rtc.member` join events 2 minutes before they would expire (matching the maximum lifetime of an
 `m.rtc.invite` event) at the latest, to rule out any possibility of it expiring during the lifetime
 of an invite.

--- a/proposals/4075-rtc-notification-event.md
+++ b/proposals/4075-rtc-notification-event.md
@@ -123,12 +123,11 @@ apply:
   at 2 minutes.
 - `m.mentions` either has `room` set to `true` (and the sender had a sufficient power level at the
   time of sending to trigger a `room` notification) or contains the current user in `user_ids`.
-- The user does not have *any* currently sticky `m.rtc.member` events with a membership of `join`
-  in the same slot, regardless of whether the ephemeral map algorithm considers them the latest
-  state.
-- The user does not have *any* currently sticky `m.rtc.decline` events referencing the
-  `m.rtc.invite` event, regardless of whether the ephemeral map algorithm considers them the latest
-  state.
+- For any currently sticky `m.rtc.member` event with a membership of `join` that the user has for
+  the same slot, there also exists a currently sticky `m.rtc.member` event with a membership of
+  `leave`, such that the leave event comes *after*[^order] the join event.
+- The user does not have any currently sticky `m.rtc.decline` events referencing the
+  `m.rtc.invite` event.
 
 In effect, these conditions mean that when an invite comes in, the receiving client has three
 options:
@@ -417,3 +416,7 @@ mitigate this by adapting their push rules, [ignoring] the sender or leaving the
 ## Dependencies
 
 This proposal depends on [MSC4143] and [MSC4354].
+
+[^order]: As determined by the sticky event ordering found in the ephemeral map algorithm from
+[MSC4354] (i.e. based on the `origin_server_ts`, sticky durations, and event IDs of the events in
+question).

--- a/proposals/4075-rtc-notification-event.md
+++ b/proposals/4075-rtc-notification-event.md
@@ -73,7 +73,8 @@ Clients MUST send both `m.rtc.invite` and `m.rtc.decline` as sticky events as pe
 associated delivery guarantee. The sticky durations of `m.rtc.invite` events, `m.rtc.member` events
 which accept an invite, or `m.rtc.decline` events which decline an invite SHOULD NOT be smaller than
 the invite's `lifetime`. Additionally, clients MUST implement the ephemeral map algorithm as per
-[MSC4354] to construct a state-like store of invite events and decline events.
+[MSC4354] to construct a state-like store of invite events. Tracking decline events in a map isn't
+necessary because there is no need to update them after being sent.
 
 [mentions]: https://spec.matrix.org/v1.19/client-server-api/#user-and-room-mentions
 [MSC4354]: https://github.com/matrix-org/matrix-spec-proposals/pull/4354
@@ -126,8 +127,7 @@ apply:
   sticky events map.
 - If the user has an `m.rtc.member` event with a membership of `leave` for the slot in the ephemeral
   sticky events map, its `origin_server_ts` is less than the `origin_server_ts` of the invite event.
-- The user has no `m.rtc.decline` event referencing the invite event in the ephemeral sticky events
-  map.
+- The user has no currently sticky `m.rtc.decline` event referencing the invite event.
 
 In effect, these conditions mean that when an invite comes in, the receiving client has three
 options:

--- a/proposals/4075-rtc-notification-event.md
+++ b/proposals/4075-rtc-notification-event.md
@@ -417,7 +417,3 @@ mitigate this by adapting their push rules, [ignoring] the sender or leaving the
 ## Dependencies
 
 This proposal depends on [MSC4143] and [MSC4354].
-
-[^order]: As determined by the sticky event ordering found in the ephemeral map algorithm from
-[MSC4354] (i.e. based on the `origin_server_ts`, sticky durations, and event IDs of the events in
-question).

--- a/proposals/4075-rtc-notification-event.md
+++ b/proposals/4075-rtc-notification-event.md
@@ -122,15 +122,20 @@ apply:
   at 2 minutes.
 - `m.mentions` either has `room` set to `true` (and the sender had a sufficient power level at the
   time of sending to trigger a `room` notification) or contains the current user in `user_ids`.
-- The user is not already joined to the same slot via a corresponding `m.rtc.member` event.
+- The user does not have *any* currently sticky `m.rtc.member` events with a membership of `join`
+  in the same slot, regardless of whether the ephemeral map algorithm considers them the latest
+  state.
+- The user does not have *any* currently sticky `m.rtc.decline` events referencing the
+  `m.rtc.invite` event, regardless of whether the ephemeral map algorithm considers them the latest
+  state.
 
-If the invite is valid, the receiving client has three options:
+In effect, these conditions mean that when an invite comes in, the receiving client has three
+options:
 
 1. It can accept the invite by joining the slot with an appropriate `m.rtc.member` event as
-   per [MSC4143]. Once the event is observed by other devices of the user, it invalidates the
-   invite.
-1. It can decline the invite by sending an `m.rtc.decline` event. Again, once the event is
-   observed by other devices of the user, it invalidates the invite.
+   per [MSC4143]. The client will invalidate the invite due to the presence of a sticky join event.
+1. It can decline the invite by sending an `m.rtc.decline` event. Again, the client will invalidate
+   the invite due to the presence of a sticky decline event.
 1. It can ignore the event by doing nothing. The invite will remain valid until either
    the user accepts or declines the invite on another device or its `lifetime` has elapsed.
 

--- a/proposals/4075-rtc-notification-event.md
+++ b/proposals/4075-rtc-notification-event.md
@@ -297,29 +297,6 @@ This might not be true for future MatrixRTC transports, however.
 [MSC4028]: https://github.com/matrix-org/matrix-spec-proposals/pull/4028
 [MSC4075]: https://github.com/matrix-org/matrix-spec-proposals/pull/4075
 
-### Invites may reappear when membership expires
-
-Intuitively, an invite that is considered invalid on one device ought to stay invalid on *all* of a
-user's devices for the remainder of its lifetime. However, there is an edge case in which an invite
-could later reappear, to the user's surprise, on another device:
-
-1. Alice's laptop loses connection to her homeserver
-1. Later, Alice joins a session from her smartphone
-1. Bob then joins the same session and sends an invite asking the whole room to join
-1. During the invite's lifetime:
-    1. Alice's smartphone *also* loses connection to her homeserver
-    1. Alice's original join event expires (ceases to be sticky)
-    1. Alice's laptop reestablishes its connection and syncs the invite event
-
-In this situation, Alice's smartphone would have ignored the invite, since it was already joined at
-the time, while her laptop would display the invite, because it cannot see Alice's previous join
-event due to it expiring halfway through.
-
-This series of events should already be quite rare, but as a mitigation, clients SHOULD resend
-`m.rtc.member` join events 2 minutes before they would expire (matching the maximum lifetime of an
-`m.rtc.invite` event) at the latest, to rule out any possibility of it expiring during the lifetime
-of an invite.
-
 ## Alternatives
 
 ### Inferring notifications from membership events

--- a/proposals/4075-rtc-notification-event.md
+++ b/proposals/4075-rtc-notification-event.md
@@ -70,10 +70,10 @@ The schema of `m.rtc.decline` is as follows:
 ```
 
 Clients MUST send both `m.rtc.invite` and `m.rtc.decline` as sticky events as per [MSC4354] for the
-associated delivery guarantee. The sticky duration for `m.rtc.invite` events SHOULD NOT be smaller
-than the invite's `lifetime`. The sticky duration for `m.rtc.decline`, in turn, SHOULD NOT be smaller
-than the declined invite's sticky duration. Additionally, clients MUST implement the ephemeral map
-algorithm as per [MSC4354] to construct a state-like store of both invite and decline events.
+associated delivery guarantee. The sticky durations of `m.rtc.invite` events, `m.rtc.member` events
+which accept an invite, or `m.rtc.decline` events which decline an invite SHOULD NOT be smaller than
+the invite's `lifetime`. Additionally, clients MUST implement the ephemeral map algorithm as per
+[MSC4354] to construct a state-like store of invite events.
 
 [mentions]: https://spec.matrix.org/v1.19/client-server-api/#user-and-room-mentions
 [MSC4354]: https://github.com/matrix-org/matrix-spec-proposals/pull/4354
@@ -296,6 +296,28 @@ This might not be true for future MatrixRTC transports, however.
 
 [MSC4028]: https://github.com/matrix-org/matrix-spec-proposals/pull/4028
 [MSC4075]: https://github.com/matrix-org/matrix-spec-proposals/pull/4075
+
+### Invites may reappear when membership expires
+
+Intuitively, an invite that is considered invalid on one device ought to stay invalid on *all* a
+user's devices for the remainder of its lifetime. However, there is an edge case in which an invite
+may later reappear, to the user's surprise, on another device:
+
+1. Alice's laptop loses connection to her homeserver
+1. Later, Alice joins a session from her smartphone
+1. Bob joins the same session and sends an invite asking the whole room to join
+1. During the invite's lifetime:
+    1. Alice leaves the session from her smartphone
+    1. Alice's original join event expires (ceases to be sticky)
+    1. Alice's laptop reestablishes its connection and syncs the invite event
+
+In this situation, Alice's smartphone would have ignored the invite, since it was already joined at
+the time, while her laptop would display the invite, because it cannot see Alice's previous join
+event due to it expiring halfway through.
+
+This series of events should be exceedingly rare, but as a mitigation, clients MAY choose to resend
+`m.rtc.member` join events as soon as they receive an invite to the same session, when necessary to
+ensure that their membership will remain sticky throughout the entire lifetime of the invite.
 
 ## Alternatives
 

--- a/proposals/4075-rtc-notification-event.md
+++ b/proposals/4075-rtc-notification-event.md
@@ -125,7 +125,7 @@ apply:
   time of sending to trigger a `room` notification) or contains the current user in `user_ids`.
 - For any currently sticky `m.rtc.member` event with a membership of `join` that the user has for
   the same slot, there also exists a currently sticky `m.rtc.member` event with a membership of
-  `leave`, such that the leave event comes *after*[^order] the join event.
+  `leave`, such that the leave event comes *after* the join event but *before* the invite event.[^order]
 - The user does not have any currently sticky `m.rtc.decline` events referencing the
   `m.rtc.invite` event.
 

--- a/proposals/4075-rtc-notification-event.md
+++ b/proposals/4075-rtc-notification-event.md
@@ -300,7 +300,7 @@ This might not be true for future MatrixRTC transports, however.
 
 ### Invites may reappear when membership expires
 
-Intuitively, an invite that is considered invalid on one device ought to stay invalid on *all* a
+Intuitively, an invite that is considered invalid on one device ought to stay invalid on *all* of a
 user's devices for the remainder of its lifetime. However, there is an edge case in which an invite
 may later reappear, to the user's surprise, on another device:
 

--- a/proposals/4075-rtc-notification-event.md
+++ b/proposals/4075-rtc-notification-event.md
@@ -110,7 +110,7 @@ a receiving client SHOULD only consider an invite valid as long as all of the fo
 apply:
 
 - The invite is the current invite entry in the ephemeral sticky events map for the sender
-  and slot and not a withdrawal (that is, an invite event whose `content` is empty except
+  and slot, and is not a withdrawal (that is, an invite event whose `content` is empty except
   for `sticky_key`).
 - An `m.rtc.slot` event with `state_key = slot_id` and `status = "open"` exists in the state of the room
   where the invite was received.


### PR DESCRIPTION
These are some revisions to the invite validity conditions in MSC4075, which I think would be valuable to ensure that clients, no matter when they sync and what events they have observed in the past, will determine whether an invite is valid in a consistent manner.

The issue I saw with the existing wording was essentially that it made the validity of an invite depend on past events which a client may or may not have observed, depending on your definition of 'observe'. 5188e0d377d52fdbfb3e1a4e27fd255d8415e588 and 923bb1846a91ddd6dc879df050e49cee300a1bcf are the important changes.